### PR TITLE
[DNM] Fix offset calculation in view partitions

### DIFF
--- a/legate/numpy/runtime.py
+++ b/legate/numpy/runtime.py
@@ -387,10 +387,9 @@ def _find_or_create_partition(
     lo = (0,) * len(tile_shape)
     # Legion is inclusive so map down
     hi = tuple(map(lambda x: (x - 1), tile_shape))
-    if offset is not None:
-        assert len(offset) == len(tile_shape)
-        lo = tuple(map(lambda x, y: (x + y), lo, offset))
-        hi = tuple(map(lambda x, y: (x + y), hi, offset))
+    assert len(offset) == len(tile_shape)
+    lo = tuple(map(lambda x, y: (x + y), lo, offset))
+    hi = tuple(map(lambda x, y: (x + y), hi, offset))
     # Construct the transform to use based on the color space
     tile_transform = Transform(len(tile_shape), len(tile_shape))
     for idx, tile in enumerate(tile_shape):
@@ -690,7 +689,7 @@ class RegionField(object):
             )
             # Check to see if they are all one, if so then we don't even need
             # to bother with making the partition
-            volume = reduce(lambda x, y: x * y, color_shape)
+            volume = calculate_volume(color_shape)
             assert volume > 0
             if volume == 1:
                 self.launch_space = ()
@@ -1697,7 +1696,7 @@ class Runtime(object):
                     parent.region,
                     color_space_bounds,
                     tile_shape,
-                    None,
+                    (0,) * len(color_space_bounds),
                     parent.transform,
                 )
                 # Then we can build the actual child region that we want and

--- a/legate/numpy/utils.py
+++ b/legate/numpy/utils.py
@@ -100,3 +100,13 @@ def calculate_volume(shape):
     if shape == ():
         return 0
     return reduce(lambda x, y: x * y, shape)
+
+
+def is_permutation_matrix(x):
+    return (
+        x.ndim == 2
+        and x.shape[0] == x.shape[1]
+        and (x.sum(axis=0) == 1).all()
+        and (x.sum(axis=1) == 1).all()
+        and ((x == 1) | (x == 0)).all()
+    )


### PR DESCRIPTION
Do not merge this PR, read below.

### Summary

The view partitioning code in legate.numpy is supposed to shift tile boundaries so that view tiles align with tiles of the underlying root array. This is currently not working as prescribed, see example below.

With this PR the tiles are computed correctly. However this partitioning scheme is not compatible with the projection functors in NumPy, that don't just dereference the appropriate sub-region on their partition, but instead expect the application code to compute their boundaries and pass it to them through the task argument. This logic expects the origin tile to start at `(0,0)` (see `NumPyProjectionFunctor::unpack_shape`), so e.g. in the example below the origin tile of the output array is `<0,0>..<1,2>`, but the projection functor wants to access `<0,0>..<2,3>`.

The projection functors in the upcoming legate.core will not follow this logic, therefore I'm not going to spend time updating the projection functors in current NumPy, and instead wait for the refactoring to land.

CCing @lightsighter that originally wrote this code, to confirm my logic, and @magnatelee to port these changes to the refactoring branch.

### Example

Command line: `NUMPY_TEST=1 legate parttest.py -lg:numpy:test --cpus 8`

<details>
<summary>Input program (parttest.py)</summary>

```
import legate.numpy as lg
a = lg.zeros((2*3,4*4))
b = a[1:-1, 5:13]
b * 2
```
</details>

<details>
<summary>Patch for debugging output</summary>

```
diff --git a/legate/numpy/runtime.py b/legate/numpy/runtime.py
index 05aa4f5..ecbc7a4 100644
--- a/legate/numpy/runtime.py
+++ b/legate/numpy/runtime.py
@@ -383,6 +383,7 @@ class FieldManager(object):
 def _find_or_create_partition(
     runtime, region, color_shape, tile_shape, offset, transform, complete=True
 ):
+    print(f'_find_or_create_partition: index_space={region.index_space.get_bounds()} color_shape={color_shape} tile_shape={tile_shape} offset={offset} transform={transform}', flush=True)
     # Compute the extent and transform for this partition operation
     lo = (0,) * len(tile_shape)
     # Legion is inclusive so map down
@@ -429,8 +430,10 @@ def _find_or_create_partition(
                 result.color_shape = color_shape
                 result.tile_shape = tile_shape
                 result.tile_offset = offset
+            print(f'  hit cache', flush=True)
             return result
     color_space = runtime.find_or_create_index_space(color_shape)
+    print(f'  making: tile_transform={tile_transform} extent={extent}', flush=True)
     functor = PartitionByRestriction(tile_transform, extent)
     index_partition = IndexPartition(
         runtime.context,
@@ -443,6 +446,8 @@ def _find_or_create_partition(
         else legion.LEGION_DISJOINT_INCOMPLETE_KIND,
         keep=True,  # export this partition functor to other libraries
     )
+    for idx in np.ndindex(color_shape):
+        print(f'  {idx} -> {index_partition.get_child(Point(idx)).get_bounds()}', flush=True)
     partition = region.get_child(index_partition)
     partition.color_shape = color_shape
     partition.tile_shape = tile_shape
```
</details>

<details>
<summary>Original output</summary>

```
_find_or_create_partition: index_space=<0,0>..<5,15> color_shape=(2, 4) tile_shape=(3, 4) offset=(0, 0) transform=None
  making: tile_transform=array([[3,0],[0,4]]) extent=<0,0>..<2,3>
  (0, 0) -> <0,0>..<2,3>
  (0, 1) -> <0,4>..<2,7>
  (0, 2) -> <0,8>..<2,11>
  (0, 3) -> <0,12>..<2,15>
  (1, 0) -> <3,0>..<5,3>
  (1, 1) -> <3,4>..<5,7>
  (1, 2) -> <3,8>..<5,11>
  (1, 3) -> <3,12>..<5,15>
_find_or_create_partition: index_space=<0,0>..<5,15> color_shape=(1, 1) tile_shape=(4, 8) offset=(1, 5) transform=None
  making: tile_transform=array([[4,0],[0,8]]) extent=<1,5>..<4,12>
  (0, 0) -> <1,5>..<4,12>
_find_or_create_partition: index_space=<1,5>..<4,12> color_shape=(2, 3) tile_shape=(3, 4) offset=(0, 0) transform=array([[1,0,1],[0,1,5],[0,0,1]])
  making: tile_transform=array([[3,0],[0,4]]) extent=<1,5>..<3,8>
  (0, 0) -> <1,5>..<3,8>
  (0, 1) -> <1,9>..<3,12>
  (0, 2) -> <1,13>..<3,12>
  (1, 0) -> <4,5>..<4,8>
  (1, 1) -> <4,9>..<4,12>
  (1, 2) -> <4,13>..<4,12>
_find_or_create_partition: index_space=<0,0>..<3,7> color_shape=(2, 3) tile_shape=(3, 4) offset=(0, 0) transform=None
  making: tile_transform=array([[3,0],[0,4]]) extent=<0,0>..<2,3>
  (0, 0) -> <0,0>..<2,3>
  (0, 1) -> <0,4>..<2,7>
  (0, 2) -> <0,8>..<2,7>
  (1, 0) -> <3,0>..<3,3>
  (1, 1) -> <3,4>..<3,7>
  (1, 2) -> <3,8>..<3,7>
```
</details>

<details>
<summary>Output after changes</summary>

```
_find_or_create_partition: index_space=<0,0>..<5,15> color_shape=(2, 4) tile_shape=(3, 4) offset=(0, 0) transform=None
  making: tile_transform=array([[3,0],[0,4]]) extent=<0,0>..<2,3>
  (0, 0) -> <0,0>..<2,3>
  (0, 1) -> <0,4>..<2,7>
  (0, 2) -> <0,8>..<2,11>
  (0, 3) -> <0,12>..<2,15>
  (1, 0) -> <3,0>..<5,3>
  (1, 1) -> <3,4>..<5,7>
  (1, 2) -> <3,8>..<5,11>
  (1, 3) -> <3,12>..<5,15>
_find_or_create_partition: index_space=<0,0>..<5,15> color_shape=(1, 1) tile_shape=(4, 8) offset=(1, 5) transform=None
  making: tile_transform=array([[4,0],[0,8]]) extent=<1,5>..<4,12>
  (0, 0) -> <1,5>..<4,12>
_find_or_create_partition: index_space=<1,5>..<4,12> color_shape=(2, 3) tile_shape=(3, 4) offset=(-1, -1) transform=array([[1,0,1],[0,1,5],[0,0,1]])
  making: tile_transform=array([[3,0],[0,4]]) extent=<0,4>..<2,7>
  (0, 0) -> <1,5>..<2,7>
  (0, 1) -> <1,8>..<2,11>
  (0, 2) -> <1,12>..<2,12>
  (1, 0) -> <3,5>..<4,7>
  (1, 1) -> <3,8>..<4,11>
  (1, 2) -> <3,12>..<4,12>
_find_or_create_partition: index_space=<0,0>..<3,7> color_shape=(2, 3) tile_shape=(3, 4) offset=(-1, -1) transform=None
  making: tile_transform=array([[3,0],[0,4]]) extent=<-1,-1>..<1,2>
  (0, 0) -> <0,0>..<1,2>
  (0, 1) -> <0,3>..<1,6>
  (0, 2) -> <0,7>..<1,7>
  (1, 0) -> <2,0>..<3,2>
  (1, 1) -> <2,3>..<3,6>
  (1, 2) -> <2,7>..<3,7>
```
</details>

Visualization of partitioning output (before & after): [parttest.pdf](https://github.com/nv-legate/legate.numpy/files/6659543/parttest.pdf)