### PR TITLE
Use built-in reduction op

### DIFF
--- a/src/cunumeric/stat/bincount.cu
+++ b/src/cunumeric/stat/bincount.cu
@@ -43,7 +43,7 @@ static __device__ inline void _bincount(int32_t* bins,
     const auto x   = origin[0] + offset;
     const auto bin = rhs[x];
     assert(bin < num_bins);
-    atomicAdd(bins + bin, 1);
+    SumReduction<int32_t>::fold<false>(bins[bin], 1);
     // Now get the next offset
     offset += stride;
   }
@@ -72,7 +72,7 @@ static __device__ inline void _weighted_bincount(double* bins,
     const auto x   = origin[0] + offset;
     const auto bin = rhs[x];
     assert(bin < num_bins);
-    atomicAdd(bins + bin, weights[x]);
+    SumReduction<double>::fold<false>(bins[bin], weights[x]);
     // Now get the next offset
     offset += stride;
   }


### PR DESCRIPTION
This PR replaces `atomicAdd` used in the bincount kernel with Legion's built-in sum reduction op that supports old architectures.