### PR TITLE
Managing CUDA library contexts directly in cuNumeric

### DIFF
--- a/src/cunumeric.mk
+++ b/src/cunumeric.mk
@@ -40,10 +40,7 @@ GEN_CPU_SRC += cunumeric/ternary/where.cc               \
 							 cunumeric/convolution/convolve.cc        \
 							 cunumeric/transform/flip.cc              \
 							 cunumeric/arg.cc                         \
-							 cunumeric/mapper.cc                      \
-							 cunumeric/cunumeric.cc # This must always be the last file!
-                                      # It guarantees we do our registration callback
-                                      # only after all task variants are recorded
+							 cunumeric/mapper.cc
 
 ifeq ($(strip $(USE_OPENMP)),1)
 GEN_CPU_SRC += cunumeric/ternary/where_omp.cc          \
@@ -69,6 +66,14 @@ GEN_CPU_SRC += cunumeric/ternary/where_omp.cc          \
 							 cunumeric/convolution/convolve_omp.cc   \
 							 cunumeric/transform/flip_omp.cc
 endif
+
+ifeq ($(strip $(USE_CUDA)),1)
+GEN_CPU_SRC += cunumeric/cudalibs.cc
+endif
+
+GEN_CPU_SRC += cunumeric/cunumeric.cc # This must always be the last file!
+                                      # It guarantees we do our registration callback
+                                      # only after all task variants are recorded
 
 GEN_GPU_SRC += cunumeric/ternary/where.cu               \
 							 cunumeric/binary/binary_op.cu            \

--- a/src/cunumeric/cuda_help.h
+++ b/src/cunumeric/cuda_help.h
@@ -52,7 +52,13 @@
 #define MIN(x, y) (((x) < (y)) ? (x) : (y))
 #endif
 
+struct cublasContext;
+
 namespace cunumeric {
+
+// Defined in cunumeric.cu
+
+cublasContext* get_cublas();
 
 __host__ inline void check_cuda(cudaError_t error, const char* file, int line)
 {

--- a/src/cunumeric/cudalibs.cc
+++ b/src/cunumeric/cudalibs.cc
@@ -1,0 +1,66 @@
+/* Copyright 2021 NVIDIA Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include <stdio.h>
+
+#include <cublas_v2.h>
+
+#include "cudalibs.h"
+
+namespace cunumeric {
+
+CUDALibraries::CUDALibraries() : cublas_(nullptr) {}
+
+CUDALibraries::~CUDALibraries() { finalize(); }
+
+void CUDALibraries::finalize()
+{
+  if (cublas_ != nullptr) {
+    cublasStatus_t status = cublasDestroy(cublas_);
+    if (status != CUBLAS_STATUS_SUCCESS) {
+      fprintf(stderr,
+              "Internal Legate CUBLAS destruction failure "
+              "with error code %d\n",
+              status);
+      abort();
+    }
+    cublas_ = nullptr;
+  }
+}
+
+cublasContext* CUDALibraries::get_cublas()
+{
+  if (nullptr == cublas_) {
+    cublasStatus_t status = cublasCreate(&cublas_);
+    if (status != CUBLAS_STATUS_SUCCESS) {
+      fprintf(stderr,
+              "Internal Legate CUBLAS initialization failure "
+              "with error code %d\n",
+              status);
+      abort();
+    }
+    const char* disable_tensor_cores = getenv("LEGATE_DISABLE_TENSOR_CORES");
+    if (nullptr == disable_tensor_cores) {
+      // No request to disable tensor cores so turn them on
+      status = cublasSetMathMode(cublas_, CUBLAS_TENSOR_OP_MATH);
+      if (status != CUBLAS_STATUS_SUCCESS)
+        fprintf(stderr, "WARNING: CUBLAS does not support Tensor cores!");
+    }
+  }
+  return cublas_;
+}
+
+}  // namespace cunumeric

--- a/src/cunumeric/cudalibs.h
+++ b/src/cunumeric/cudalibs.h
@@ -1,0 +1,41 @@
+/* Copyright 2021 NVIDIA Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#pragma once
+
+struct cublasContext;
+
+namespace cunumeric {
+
+struct CUDALibraries {
+ public:
+  CUDALibraries();
+  ~CUDALibraries();
+
+ private:
+  // Prevent copying and overwriting
+  CUDALibraries(const CUDALibraries& rhs) = delete;
+  CUDALibraries& operator=(const CUDALibraries& rhs) = delete;
+
+ public:
+  void finalize();
+  cublasContext* get_cublas();
+
+ private:
+  cublasContext* cublas_;
+};
+
+}  // namespace cunumeric

--- a/src/cunumeric/cunumeric.cu
+++ b/src/cunumeric/cunumeric.cu
@@ -16,6 +16,7 @@
 
 #include "cunumeric.h"
 #include "arg.h"
+#include "cudalibs.h"
 
 namespace cunumeric {
 
@@ -68,6 +69,27 @@ void register_gpu_reduction_operators(legate::LibraryContext& context)
 {
   REGISTER_REDOPS(ArgmaxReduction);
   REGISTER_REDOPS(ArgminReduction);
+}
+
+static CUDALibraries& get_cuda_libraries(Processor proc)
+{
+  if (proc.kind() != Processor::TOC_PROC) {
+    fprintf(stderr, "Illegal request for CUDA libraries for non-GPU processor");
+    LEGATE_ABORT
+  }
+  static std::map<Processor, CUDALibraries> cuda_libraries;
+  auto finder = cuda_libraries.find(proc);
+  if (finder != cuda_libraries.end())
+    return finder->second;
+  else
+    return cuda_libraries[proc];
+}
+
+cublasContext* get_cublas()
+{
+  const auto proc = Processor::get_executing_processor();
+  auto& lib       = get_cuda_libraries(proc);
+  return lib.get_cublas();
 }
 
 }  // namespace cunumeric

--- a/src/cunumeric/matrix/matmul.cu
+++ b/src/cunumeric/matrix/matmul.cu
@@ -37,7 +37,7 @@ struct MatMulImplBody<VariantKind::GPU, LegateTypeCode::FLOAT_LT> {
                   bool rhs1_transposed,
                   bool rhs2_transposed)
   {
-    cublasHandle_t cublas_handle = Core::get_cublas();
+    cublasHandle_t cublas_handle = get_cublas();
     // Update the stream because the CUDA hijack can't see inside cuBLAS
     cudaStream_t task_stream;
     cudaStreamCreate(&task_stream);
@@ -87,7 +87,7 @@ struct MatMulImplBody<VariantKind::GPU, LegateTypeCode::DOUBLE_LT> {
                   bool rhs1_transposed,
                   bool rhs2_transposed)
   {
-    cublasHandle_t cublas_handle = Core::get_cublas();
+    cublasHandle_t cublas_handle = get_cublas();
     // Update the stream because the CUDA hijack can't see inside cuBLAS
     cudaStream_t task_stream;
     cudaStreamCreate(&task_stream);
@@ -132,7 +132,7 @@ struct MatMulImplBody<VariantKind::GPU, LegateTypeCode::HALF_LT> {
                   bool rhs1_transposed,
                   bool rhs2_transposed)
   {
-    cublasHandle_t cublas_handle = Core::get_cublas();
+    cublasHandle_t cublas_handle = get_cublas();
     // Update the stream because the CUDA hijack can't see inside cuBLAS
     cudaStream_t task_stream;
     cudaStreamCreate(&task_stream);

--- a/src/cunumeric/matrix/matvecmul.cu
+++ b/src/cunumeric/matrix/matvecmul.cu
@@ -33,7 +33,7 @@ struct MatVecMulImplBody<VariantKind::GPU, LegateTypeCode::FLOAT_LT> {
                   size_t mat_stride,
                   bool transpose_mat)
   {
-    cublasHandle_t cublas_handle = Core::get_cublas();
+    cublasHandle_t cublas_handle = get_cublas();
     // Update the stream because the CUDA hijack can't see inside cuBLAS
     cudaStream_t task_stream;
     cudaStreamCreate(&task_stream);
@@ -60,7 +60,7 @@ struct MatVecMulImplBody<VariantKind::GPU, LegateTypeCode::DOUBLE_LT> {
                   size_t mat_stride,
                   bool transpose_mat)
   {
-    cublasHandle_t cublas_handle = Core::get_cublas();
+    cublasHandle_t cublas_handle = get_cublas();
     // Update the stream because the CUDA hijack can't see inside cuBLAS
     cudaStream_t task_stream;
     cudaStreamCreate(&task_stream);
@@ -87,7 +87,7 @@ struct MatVecMulImplBody<VariantKind::GPU, LegateTypeCode::HALF_LT> {
                   size_t mat_stride,
                   bool transpose_mat)
   {
-    cublasHandle_t cublas_handle = Core::get_cublas();
+    cublasHandle_t cublas_handle = get_cublas();
     // Update the stream because the CUDA hijack can't see inside cuBLAS
     cudaStream_t task_stream;
     cudaStreamCreate(&task_stream);


### PR DESCRIPTION
This PR is to start managing CUDA library contexts within cuNumeric. The code that manages cuFFT plans isn't refactored yet, but will later be incorporated in this mechanism once we start working on the fft submodule.