### PR TITLE
Use cufft callbacks for better performance on fft-based convolutions

### DIFF
--- a/src/cunumeric/cuda_help.h
+++ b/src/cunumeric/cuda_help.h
@@ -20,6 +20,7 @@
 #include <cublas_v2.h>
 #include <cuda_runtime.h>
 #include <cufft.h>
+#include <cufftXt.h>
 
 #define THREADS_PER_BLOCK 128
 #define MIN_CTAS_PER_SM 4
@@ -87,6 +88,7 @@ __host__ inline void check_cufft(cufftResult result, const char* file, int line)
             result,
             file,
             line);
+    assert(false);
     exit(result);
   }
 }


### PR DESCRIPTION
This branch adds support for using device function callbacks in cufft to improve performance and reduce memory usage in the convolve function. Incorporating these changes will require modifications to the Legate Core build system to support device-side linking with the cufft library. DO NOT MERGE until these changes have been made.