### PR TITLE
Minor fix for typo

### DIFF
--- a/src/cunumeric/cudalibs.cc
+++ b/src/cunumeric/cudalibs.cc
@@ -70,7 +70,7 @@ cublasContext* CUDALibraries::get_cublas()
               status);
       abort();
     }
-    const char* disable_tensor_cores = getenv("LEGATE_DISABLE_TENSOR_CORES");
+    const char* disable_tensor_cores = getenv("CUNUMERIC_DISABLE_TENSOR_CORES");
     if (nullptr == disable_tensor_cores) {
       // No request to disable tensor cores so turn them on
       status = cublasSetMathMode(cublas_, CUBLAS_TENSOR_OP_MATH);


### PR DESCRIPTION
The environment variable name should have been prefixed with `CUNUMERIC` and not `LEGATE`.