### PR TITLE
Use .cu for CUDA library management

### DIFF
--- a/src/cunumeric.mk
+++ b/src/cunumeric.mk
@@ -69,10 +69,6 @@ GEN_CPU_SRC += cunumeric/ternary/where_omp.cc          \
 							 cunumeric/transform/flip_omp.cc
 endif
 
-ifeq ($(strip $(USE_CUDA)),1)
-GEN_CPU_SRC += cunumeric/cudalibs.cc
-endif
-
 GEN_CPU_SRC += cunumeric/cunumeric.cc # This must always be the last file!
                                       # It guarantees we do our registration callback
                                       # only after all task variants are recorded
@@ -101,4 +97,5 @@ GEN_GPU_SRC += cunumeric/ternary/where.cu               \
 							 cunumeric/stat/bincount.cu               \
 							 cunumeric/convolution/convolve.cu	      \
 							 cunumeric/transform/flip.cu              \
+							 cunumeric/cudalibs.cu                    \
 							 cunumeric/cunumeric.cu

--- a/src/cunumeric/cuda_help.h
+++ b/src/cunumeric/cuda_help.h
@@ -18,6 +18,7 @@
 
 #include "legate.h"
 #include <cublas_v2.h>
+#include <cusolverDn.h>
 #include <cuda_runtime.h>
 #include <cufft.h>
 
@@ -52,15 +53,12 @@
 #define MIN(x, y) (((x) < (y)) ? (x) : (y))
 #endif
 
-struct cublasContext;
-struct cusolverDnContext;
-
 namespace cunumeric {
 
-// Defined in cunumeric.cu
+// Defined in cudalibs.cu
 
-cublasContext* get_cublas();
-cusolverDnContext* get_cusolver();
+cublasHandle_t get_cublas();
+cusolverDnHandle_t get_cusolver();
 
 __host__ inline void check_cuda(cudaError_t error, const char* file, int line)
 {

--- a/src/cunumeric/cudalibs.h
+++ b/src/cunumeric/cudalibs.h
@@ -16,8 +16,8 @@
 
 #pragma once
 
-struct cublasContext;
-struct cusolverDnContext;
+#include <cublas_v2.h>
+#include <cusolverDn.h>
 
 namespace cunumeric {
 
@@ -33,8 +33,8 @@ struct CUDALibraries {
 
  public:
   void finalize();
-  cublasContext* get_cublas();
-  cusolverDnContext* get_cusolver();
+  cublasHandle_t get_cublas();
+  cusolverDnHandle_t get_cusolver();
 
  private:
   void finalize_cublas();

--- a/src/cunumeric/cunumeric.cu
+++ b/src/cunumeric/cunumeric.cu
@@ -16,9 +16,6 @@
 
 #include "cunumeric.h"
 #include "arg.h"
-#include "cudalibs.h"
-
-#include <mutex>
 
 namespace cunumeric {
 
@@ -71,38 +68,6 @@ void register_gpu_reduction_operators(legate::LibraryContext& context)
 {
   REGISTER_REDOPS(ArgmaxReduction);
   REGISTER_REDOPS(ArgminReduction);
-}
-
-static CUDALibraries& get_cuda_libraries(Processor proc)
-{
-  if (proc.kind() != Processor::TOC_PROC) {
-    fprintf(stderr, "Illegal request for CUDA libraries for non-GPU processor");
-    LEGATE_ABORT
-  }
-  static std::mutex mut_cuda_libraries;
-  static std::map<Processor, CUDALibraries> cuda_libraries;
-
-  std::lock_guard<std::mutex> guard(mut_cuda_libraries);
-
-  auto finder = cuda_libraries.find(proc);
-  if (finder != cuda_libraries.end())
-    return finder->second;
-  else
-    return cuda_libraries[proc];
-}
-
-cublasContext* get_cublas()
-{
-  const auto proc = Processor::get_executing_processor();
-  auto& lib       = get_cuda_libraries(proc);
-  return lib.get_cublas();
-}
-
-cusolverDnContext* get_cusolver()
-{
-  const auto proc = Processor::get_executing_processor();
-  auto& lib       = get_cuda_libraries(proc);
-  return lib.get_cusolver();
 }
 
 }  // namespace cunumeric


### PR DESCRIPTION
This PR is to put the CUDA library management code in a .cu file instead of a .cc file. We've been going headerless for CUDA library handles to avoid duplicate definitions of the half float type in a .cc file, but this trick won't work for cuTENSOR whose handle is a struct with a fixed size array instead of just a pointer. So, we use .cu instead so that we can include CUDA library headers in this code.