### PR TITLE
Fix slot calculation in reduction kernel

### DIFF
--- a/src/cunumeric/unary/unary_red.cu
+++ b/src/cunumeric/unary/unary_red.cu
@@ -235,7 +235,7 @@ static __device__ __forceinline__ Point<DIM> local_reduce(CTOR ctor,
     // up doing the full atomic
     coord_t bucket = 0;
     for (int32_t dim = DIM - 2; dim >= 0; --dim)
-      bucket = bucket * (domain.hi[dim + 1] - domain.lo[dim + 1] + 1) + point[dim];
+      bucket = bucket * (domain.hi[dim] - domain.lo[dim] + 1) + point[dim] - domain.lo[dim];
 
     const uint32_t same_mask = __match_any_sync(0xffffffff, bucket);
     int32_t laneid;

--- a/tests/reduction_axis.py
+++ b/tests/reduction_axis.py
@@ -13,24 +13,25 @@
 # limitations under the License.
 #
 
+from itertools import permutations
+
 import numpy as np
 
-import cunumeric as num
+import cunumeric as cn
+
+
+def gen_result(lib):
+    # Try various non-square shapes, to nudge the core towards trying many
+    # different partitionings.
+    for shape in permutations((3, 4, 5)):
+        x = lib.ones(shape)
+        for axis in range(len(shape)):
+            yield x.sum(axis=axis)
 
 
 def test():
-    pythonX = np.reshape(np.linspace(0, 10001, 10000, dtype=int), (100, 100))
-    x = num.array(pythonX)
-
-    pythonY = np.sum(pythonX, axis=0)
-    y = num.sum(x, axis=0)
-    assert np.array_equal(pythonY, y)
-
-    pythonY = np.sum(pythonX, axis=1)
-    y = num.sum(x, axis=1)
-    assert np.array_equal(pythonY, y)
-
-    return
+    for (np_res, cn_res) in zip(gen_result(np), gen_result(cn)):
+        assert np.array_equal(np_res, cn_res)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The linearization logic was wrong, causing threads to sometimes reduce into the wrong output index, in the case where the reduction collapsed the last axis.

The problematic case was not exercised in the old test because the shape of the input array would never get partitioned in a way that would trigger the issue (at least when running on 2 processors).