### PR TITLE
Build OpenBLAS with CROSS option to prevent tests at compile time

### DIFF
--- a/install.py
+++ b/install.py
@@ -167,6 +167,7 @@ def install_openblas(openblas_dir, thread_count, verbose):
             "make",
             "-j",
             str(thread_count),
+            "CROSS=1",
             "USE_THREAD=1",
             "NO_STATIC=1",
             "USE_CUDA=0",


### PR DESCRIPTION
This change would prevent OpenBLAS from running tests during compilation. This is needed when building on machines or in conditions (e.g., using docker) that cause some of the OpenBLAS tests to fail. The potential downside of this is that we would want to run with OpenBLAS checks by default when users are building in the same environment in which they will run. If we want to run OpenBLAS tests by default, we could add an option to prevent testing at build time.