### PR TITLE
Add a switch to not call tril on Cholesky outputs

### DIFF
--- a/cunumeric/array.py
+++ b/cunumeric/array.py
@@ -1040,7 +1040,7 @@ class ndarray(object):
         else:
             return out_arr
 
-    def cholesky(self, stacklevel=1):
+    def cholesky(self, no_tril=False, stacklevel=1):
         input = self
         if input.dtype.kind not in ("f", "c"):
             input = input.astype("float64")
@@ -1050,7 +1050,9 @@ class ndarray(object):
             stacklevel=stacklevel + 1,
             inputs=(input,),
         )
-        output._thunk.cholesky(input._thunk, stacklevel=(stacklevel + 1))
+        output._thunk.cholesky(
+            input._thunk, no_tril=no_tril, stacklevel=(stacklevel + 1)
+        )
         return output
 
     def clip(self, min=None, max=None, out=None):

--- a/cunumeric/deferred.py
+++ b/cunumeric/deferred.py
@@ -1782,6 +1782,9 @@ class DeferredArray(NumPyThunk):
     @profile
     @auto_convert([1])
     @shadow_debug("cholesky", [1])
-    def cholesky(self, src, stacklevel=0, callsite=None):
+    def cholesky(self, src, no_tril=False, stacklevel=0, callsite=None):
         cholesky(self, src, stacklevel=stacklevel + 1, callsite=callsite)
-        self.trilu(self, 0, True, stacklevel=stacklevel + 1, callsite=callsite)
+        if not no_tril:
+            self.trilu(
+                self, 0, True, stacklevel=stacklevel + 1, callsite=callsite
+            )

--- a/cunumeric/eager.py
+++ b/cunumeric/eager.py
@@ -1125,7 +1125,7 @@ class EagerArray(NumPyThunk):
                 self.array[:] = np.triu(rhs.array, k)
             self.runtime.profile_callsite(stacklevel + 1, False)
 
-    def cholesky(self, src, stacklevel):
+    def cholesky(self, src, no_tril, stacklevel):
         if self.shadow:
             src = self.runtime.to_eager_array(src, stacklevel=(stacklevel + 1))
         elif self.deferred is None:

--- a/examples/cholesky.py
+++ b/examples/cholesky.py
@@ -1,0 +1,52 @@
+# Copyright 2021 NVIDIA Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import argparse
+
+from legate.timing import time
+
+import cunumeric as np
+
+
+def cholesky(n, dtype):
+    input = np.eye(n, dtype=dtype)
+
+    start = time()
+    input.cholesky(no_tril=True)
+    stop = time()
+    flops = (n ** 3) / 3 + 2 * n / 3
+    print(f"{(stop - start) * 1e-3} ms, {flops / (stop - start) * 1e-3} GOP/s")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-n",
+        "--num",
+        type=int,
+        default=10,
+        dest="n",
+        help="number of rows in the matrix",
+    )
+    parser.add_argument(
+        "-t",
+        "--type",
+        default="float64",
+        choices=["float32", "float64", "complex64", "complex128"],
+        dest="dtype",
+        help="data type",
+    )
+    args, unknown = parser.parse_known_args()
+    cholesky(args.n, args.dtype)


### PR DESCRIPTION
This PR add an internal switch to `ndarray.cholesky` to bypass the `tril` call on Cholesky outputs. This allows the Cholesky benchmark to measure performance of the implemented Cholesky factorization more easily.