### PR TITLE
General cuFFT plan cache

### DIFF
--- a/cunumeric/module.py
+++ b/cunumeric/module.py
@@ -5262,9 +5262,6 @@ def convolve(a, v, mode="full"):
     if mode != "same":
         raise NotImplementedError("Need to implement other convolution modes")
 
-    if a.size < v.size:
-        v, a = a, v
-
     return a.convolve(v, mode)
 
 

--- a/src/cunumeric/cuda_help.h
+++ b/src/cunumeric/cuda_help.h
@@ -29,34 +29,34 @@
 #define COOPERATIVE_THREADS 256
 #define COOPERATIVE_CTAS_PER_SM 4
 
-#define CHECK_CUDA(expr)                    \
-  do {                                      \
-    cudaError_t result = (expr);            \
-    check_cuda(result, __FILE__, __LINE__); \
-  } while (false)
-
-#define CHECK_CUBLAS(expr)                    \
-  do {                                        \
-    cublasStatus_t result = (expr);           \
-    check_cublas(result, __FILE__, __LINE__); \
-  } while (false)
-
-#define CHECK_CUFFT(expr)                    \
-  do {                                       \
-    cufftResult result = (expr);             \
-    check_cufft(result, __FILE__, __LINE__); \
-  } while (false)
-
-#define CHECK_CUSOLVER(expr)                    \
+#define CHECK_CUDA(expr)                        \
   do {                                          \
-    cusolverStatus_t result = (expr);           \
-    check_cusolver(result, __FILE__, __LINE__); \
+    cudaError_t __result__ = (expr);            \
+    check_cuda(__result__, __FILE__, __LINE__); \
   } while (false)
 
-#define CHECK_CUTENSOR(expr)                    \
-  do {                                          \
-    cutensorStatus_t result = (expr);           \
-    check_cutensor(result, __FILE__, __LINE__); \
+#define CHECK_CUBLAS(expr)                        \
+  do {                                            \
+    cublasStatus_t __result__ = (expr);           \
+    check_cublas(__result__, __FILE__, __LINE__); \
+  } while (false)
+
+#define CHECK_CUFFT(expr)                        \
+  do {                                           \
+    cufftResult __result__ = (expr);             \
+    check_cufft(__result__, __FILE__, __LINE__); \
+  } while (false)
+
+#define CHECK_CUSOLVER(expr)                        \
+  do {                                              \
+    cusolverStatus_t __result__ = (expr);           \
+    check_cusolver(__result__, __FILE__, __LINE__); \
+  } while (false)
+
+#define CHECK_CUTENSOR(expr)                        \
+  do {                                              \
+    cutensorStatus_t __result__ = (expr);           \
+    check_cutensor(__result__, __FILE__, __LINE__); \
   } while (false)
 
 #ifndef MAX
@@ -68,6 +68,11 @@
 
 namespace cunumeric {
 
+struct cufftPlan {
+  cufftHandle handle;
+  size_t workarea_size;
+};
+
 // Defined in cudalibs.cu
 
 // Return a cached stream for the current GPU
@@ -75,6 +80,7 @@ cudaStream_t get_cached_stream();
 cublasHandle_t get_cublas();
 cusolverDnHandle_t get_cusolver();
 cutensorHandle_t* get_cutensor();
+cufftPlan* get_cufft_plan(cufftType type, const Legion::DomainPoint& size);
 
 __host__ inline void check_cuda(cudaError_t error, const char* file, int line)
 {

--- a/src/cunumeric/cudalibs.cu
+++ b/src/cunumeric/cudalibs.cu
@@ -17,7 +17,6 @@
 #include "cunumeric.h"
 
 #include "cudalibs.h"
-#include "cuda_help.h"
 
 #include <mutex>
 #include <stdio.h>
@@ -26,8 +25,120 @@ namespace cunumeric {
 
 using namespace Legion;
 
+static Logger log_cudalibs("cunumeric.cudalibs");
+
+struct cufftPlanCache {
+ private:
+  // Maximum number of plans to keep per dimension
+  static constexpr int32_t MAX_PLANS = 4;
+
+ private:
+  struct LRUEntry {
+    std::unique_ptr<cufftPlan> plan{nullptr};
+    DomainPoint fftshape{};
+    uint32_t lru_index{0};
+  };
+
+ public:
+  cufftPlanCache(cufftType type);
+  ~cufftPlanCache();
+
+ public:
+  cufftPlan* get_cufft_plan(const DomainPoint& size);
+
+ private:
+  using Cache = std::array<LRUEntry, MAX_PLANS>;
+  std::array<Cache, LEGION_MAX_DIM + 1> cache_{};
+  cufftType type_;
+};
+
+cufftPlanCache::cufftPlanCache(cufftType type) : type_(type)
+{
+  for (auto& cache : cache_)
+    for (auto& entry : cache) assert(0 == entry.fftshape.dim);
+}
+
+cufftPlanCache::~cufftPlanCache()
+{
+  for (auto& cache : cache_)
+    for (auto& entry : cache)
+      if (entry.plan != nullptr) CHECK_CUFFT(cufftDestroy(entry.plan->handle));
+}
+
+cufftPlan* cufftPlanCache::get_cufft_plan(const DomainPoint& size)
+{
+  int32_t match = -1;
+  auto& cache   = cache_[size.dim];
+  for (int32_t idx = 0; idx < MAX_PLANS; ++idx)
+    if (cache[idx].fftshape == size) {
+      match = idx;
+      break;
+    }
+
+  cufftPlan* result{nullptr};
+  // If there's no match, we create a new plan
+  if (-1 == match) {
+    log_cudalibs.debug() << "[cufftPlanCache] no match found for " << size << " (type: " << type_
+                         << ")";
+    int32_t plan_index = -1;
+    for (int32_t idx = 0; idx < MAX_PLANS; ++idx) {
+      auto& entry = cache[idx];
+      if (nullptr == entry.plan) {
+        log_cudalibs.debug() << "[cufftPlanCache] found empty entry " << idx << " (type: " << type_
+                             << ")";
+        entry.plan      = std::make_unique<cufftPlan>();
+        entry.lru_index = idx;
+        plan_index      = idx;
+        break;
+      } else if (entry.lru_index == MAX_PLANS - 1) {
+        log_cudalibs.debug() << "[cufftPlanCache] evict entry " << idx << " for " << entry.fftshape
+                             << " (type: " << type_ << ")";
+        CHECK_CUFFT(cufftDestroy(entry.plan->handle));
+        plan_index = idx;
+        break;
+      }
+    }
+    assert(plan_index != -1);
+    auto& entry    = cache[plan_index];
+    entry.fftshape = size;
+    result         = entry.plan.get();
+
+    CHECK_CUFFT(cufftCreate(&result->handle));
+    CHECK_CUFFT(cufftSetAutoAllocation(result->handle, 0 /*we'll do the allocation*/));
+
+    std::vector<int32_t> n(size.dim);
+    for (int32_t dim = 0; dim < size.dim; ++dim) n[dim] = size[dim];
+    CHECK_CUFFT(cufftMakePlanMany(result->handle,
+                                  size.dim,
+                                  n.data(),
+                                  nullptr,
+                                  1,
+                                  1,
+                                  nullptr,
+                                  1,
+                                  1,
+                                  type_,
+                                  1 /*batch*/,
+                                  &result->workarea_size));
+  }
+  // Otherwise, we return the cached plan and adjust the LRU count
+  else {
+    log_cudalibs.debug() << "[cufftPlanCache] found match for " << size << " (type: " << type_
+                         << ")";
+    auto& entry = cache[match];
+    result      = entry.plan.get();
+
+    for (int32_t idx = 0; idx < MAX_PLANS; ++idx) {
+      auto& other = cache[idx];
+      if (other.lru_index < entry.lru_index) ++other.lru_index;
+    }
+    entry.lru_index = 0;
+  }
+  return result;
+}
+
 CUDALibraries::CUDALibraries()
-  : finalized_(false), cublas_(nullptr), cusolver_(nullptr), cutensor_(nullptr)
+  : finalized_(false), cublas_(nullptr), cusolver_(nullptr), cutensor_(nullptr), plan_caches_()
 {
   CHECK_CUDA(cudaStreamCreateWithFlags(&stream_, cudaStreamNonBlocking));
 }
@@ -40,6 +151,7 @@ void CUDALibraries::finalize()
   if (cublas_ != nullptr) finalize_cublas();
   if (cusolver_ != nullptr) finalize_cusolver();
   if (cutensor_ != nullptr) finalize_cutensor();
+  for (auto& pair : plan_caches_) delete pair.second;
   cudaStreamDestroy(stream_);
   finalized_ = true;
 }
@@ -94,6 +206,19 @@ cutensorHandle_t* CUDALibraries::get_cutensor()
   return cutensor_;
 }
 
+cufftPlan* CUDALibraries::get_cufft_plan(cufftType type, const DomainPoint& size)
+{
+  auto finder = plan_caches_.find(type);
+  cufftPlanCache* cache{nullptr};
+
+  if (plan_caches_.end() == finder) {
+    cache              = new cufftPlanCache(type);
+    plan_caches_[type] = cache;
+  } else
+    cache = finder->second;
+  return cache->get_cufft_plan(size);
+}
+
 static CUDALibraries& get_cuda_libraries(Processor proc)
 {
   if (proc.kind() != Processor::TOC_PROC) {
@@ -138,6 +263,13 @@ cutensorHandle_t* get_cutensor()
   const auto proc = Processor::get_executing_processor();
   auto& lib       = get_cuda_libraries(proc);
   return lib.get_cutensor();
+}
+
+cufftPlan* get_cufft_plan(cufftType type, const Legion::DomainPoint& size)
+{
+  const auto proc = Processor::get_executing_processor();
+  auto& lib       = get_cuda_libraries(proc);
+  return lib.get_cufft_plan(type, size);
 }
 
 class LoadCUDALibsTask : public CuNumericTask<LoadCUDALibsTask> {

--- a/src/cunumeric/cudalibs.h
+++ b/src/cunumeric/cudalibs.h
@@ -16,11 +16,11 @@
 
 #pragma once
 
-#include <cublas_v2.h>
-#include <cusolverDn.h>
-#include <cutensor.h>
+#include "cuda_help.h"
 
 namespace cunumeric {
+
+struct cufftPlanCache;
 
 struct CUDALibraries {
  public:
@@ -38,6 +38,7 @@ struct CUDALibraries {
   cublasHandle_t get_cublas();
   cusolverDnHandle_t get_cusolver();
   cutensorHandle_t* get_cutensor();
+  cufftPlan* get_cufft_plan(cufftType type, const Legion::DomainPoint& size);
 
  private:
   void finalize_cublas();
@@ -50,6 +51,7 @@ struct CUDALibraries {
   cublasContext* cublas_;
   cusolverDnContext* cusolver_;
   cutensorHandle_t* cutensor_;
+  std::map<cufftType, cufftPlanCache*> plan_caches_;
 };
 
 }  // namespace cunumeric

--- a/tests/convolve.py
+++ b/tests/convolve.py
@@ -37,6 +37,7 @@ def test_double():
         v = num.random.rand(*filter_shape)
 
         test_convolve(a, v)
+        test_convolve(v, a)
 
 
 def test_int():

--- a/tests/convolve.py
+++ b/tests/convolve.py
@@ -13,31 +13,15 @@
 # limitations under the License.
 #
 
-import numpy as np
 import scipy.signal as sig
 
 import cunumeric as num
 
-
-def test_1d():
-    a = num.random.rand(100)
-    v = num.random.rand(5)
-
-    anp = a.__array__()
-    vnp = v.__array__()
-
-    out = num.convolve(a, v, mode="same")
-    out_np = np.convolve(anp, vnp, mode="same")
-    # print(out)
-    # print(out_np)
-
-    assert num.allclose(out, out_np)
+shapes = ((100,), (10, 10), (10, 10, 10))
+filter_shapes = ((5,), (3, 5), (3, 5, 3))
 
 
-def test_2d():
-    a = num.random.rand(10, 10)
-    v = num.random.rand(3, 5)
-
+def test_convolve(a, v):
     anp = a.__array__()
     vnp = v.__array__()
 
@@ -47,20 +31,22 @@ def test_2d():
     assert num.allclose(out, out_np)
 
 
-def test_3d():
-    a = num.random.rand(10, 10, 10)
-    v = num.random.rand(3, 5, 3)
+def test_double():
+    for shape, filter_shape in zip(shapes, filter_shapes):
+        a = num.random.rand(*shape)
+        v = num.random.rand(*filter_shape)
 
-    anp = a.__array__()
-    vnp = v.__array__()
+        test_convolve(a, v)
 
-    out = num.convolve(a, v, mode="same")
-    out_np = sig.convolve(anp, vnp, mode="same")
 
-    assert num.allclose(out, out_np)
+def test_int():
+    for shape, filter_shape in zip(shapes, filter_shapes):
+        a = num.random.randint(0, 5, shape)
+        v = num.random.randint(0, 5, filter_shape)
+
+        test_convolve(a, v)
 
 
 if __name__ == "__main__":
-    test_1d()
-    test_2d()
-    test_3d()
+    test_double()
+    test_int()


### PR DESCRIPTION
This PR is to add a library-wide cache for cuFFT plans and use it in the convolution implementation. This also contains some minor refactoring changes.