### PR TITLE
np.append & ndarray.flatten

### DIFF
--- a/cunumeric/array.py
+++ b/cunumeric/array.py
@@ -1256,6 +1256,10 @@ class ndarray(object):
         val = np.array(value, dtype=self.dtype)
         self._thunk.fill(val)
 
+    def flatten(self, order="C"):
+        # Same as 'ravel' because cuNumeric creates a new array by 'reshape'
+        return self.reshape(-1, order=order)
+
     def getfield(self, dtype, offset=0):
         raise NotImplementedError(
             "cuNumeric does not currently support type reinterpretation "

--- a/cunumeric/module.py
+++ b/cunumeric/module.py
@@ -1289,6 +1289,11 @@ def _concatenate(
     return out_array
 
 
+def append(arr, values, axis=None):
+    # Check to see if we can build a new tuple of cuNumeric arrays
+    return concatenate([arr, values], axis)
+
+
 def concatenate(inputs, axis=0, out=None, dtype=None, casting="same_kind"):
     """
 

--- a/cunumeric/module.py
+++ b/cunumeric/module.py
@@ -1285,15 +1285,19 @@ def _concatenate(
         idx_arr.append(slice(out_shape[i]))
 
     for inp in inputs:
-        idx_arr[axis] = slice(offset, offset + inp.shape[axis])
-        out_array[tuple(idx_arr)] = inp
-        offset += inp.shape[axis]
+        if inp.size > 0:
+            idx_arr[axis] = slice(offset, offset + inp.shape[axis])
+            out_array[tuple(idx_arr)] = inp
+            offset += inp.shape[axis]
     return out_array
 
 
 def append(arr, values, axis=None):
     # Check to see if we can build a new tuple of cuNumeric arrays
-    return concatenate([arr, values], axis)
+    inputs = list(
+        ndarray.convert_to_cunumeric_ndarray(inp) for inp in [arr, values]
+    )
+    return concatenate(inputs, axis)
 
 
 def concatenate(inputs, axis=0, out=None, dtype=None, casting="same_kind"):

--- a/tests/append.py
+++ b/tests/append.py
@@ -1,4 +1,4 @@
-# Copyright 2021 NVIDIA Corporation
+# Copyright 2022 NVIDIA Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -30,9 +30,8 @@ def run_test(arr, values, test_args):
             err_arr = [b, c]
         else:
             for each in zip(b, c):
-                sub_set = list(each)
-                if not np.array_equal(sub_set[0], sub_set[1]):
-                    err_arr = sub_set
+                if not np.array_equal(*each):
+                    err_arr = each
                     is_equal = False
                     break
         print_msg = (
@@ -53,7 +52,7 @@ def run_test(arr, values, test_args):
 
 def test(dim):
     print("test append")
-    # test np.concatenate & *stack w/ 1D, 2D and 3D arrays
+    # test append w/ 1D, 2D and 3D arrays
     input_arr = [
         (0,),
         (0, 10),
@@ -67,15 +66,14 @@ def test(dim):
     for input_size in input_arr:
         a = np.random.randint(low=0, high=100, size=(input_size))
 
-        test_args = [axis for axis in range(a.ndim)]
+        test_args = list(range(a.ndim))
         test_args.append(None)
-        # test the exception for 1D array on vstack and dstack
+        # test the exception for 1D array on append
         run_test(a, a, test_args)
         if a.ndim > 1:
             # 1D array
             b = np.random.randint(low=0, high=100, size=(dim,))
-            test_args = [None]
-            run_test(a, b, test_args)
+            run_test(a, b, [None])
     return
 
 

--- a/tests/append.py
+++ b/tests/append.py
@@ -1,0 +1,83 @@
+# Copyright 2021 NVIDIA Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import numpy as np
+
+import cunumeric as num
+
+
+def run_test(arr, values, test_args):
+    for axis in test_args:
+        b = np.append(arr, values, axis)
+        c = num.append(arr, values, axis)
+        is_equal = True
+        err_arr = [b, c]
+
+        if len(b) != len(c):
+            is_equal = False
+            err_arr = [b, c]
+        else:
+            for each in zip(b, c):
+                sub_set = list(each)
+                if not np.array_equal(sub_set[0], sub_set[1]):
+                    err_arr = sub_set
+                    is_equal = False
+                    break
+        print_msg = (
+            f"np.append(array({arr.shape}), array({values.shape}), {axis})"
+        )
+        assert is_equal, (
+            f"Failed, {print_msg}\n"
+            f"numpy result: {err_arr[0]}, {b.shape}\n"
+            f"cunumeric_result: {err_arr[1]}, {c.shape}\n"
+            f"cunumeric and numpy shows"
+            f" different result\n"
+        )
+        print(
+            f"Passed, {print_msg}, np: ({b.shape}, {b.dtype})"
+            f", cunumeric: ({c.shape}, {c.dtype}"
+        )
+
+
+def test(dim):
+    print("test append")
+    # test np.concatenate & *stack w/ 1D, 2D and 3D arrays
+    input_arr = [
+        (0,),
+        (0, 10),
+        (1,),
+        (1, 1),
+        (1, 1, 1),
+        (1, dim),
+        (dim, dim),
+        (dim, dim, dim),
+    ]
+    for input_size in input_arr:
+        a = np.random.randint(low=0, high=100, size=(input_size))
+
+        test_args = [axis for axis in range(a.ndim)]
+        test_args.append(None)
+        # test the exception for 1D array on vstack and dstack
+        run_test(a, a, test_args)
+        if a.ndim > 1:
+            # 1D array
+            b = np.random.randint(low=0, high=100, size=(dim,))
+            test_args = [None]
+            run_test(a, b, test_args)
+    return
+
+
+if __name__ == "__main__":
+    test(10)

--- a/tests/concatenate_stack.py
+++ b/tests/concatenate_stack.py
@@ -43,9 +43,8 @@ def run_test(arr, routine, input_size):
             err_arr = [b, c]
         else:
             for each in zip(b, c):
-                sub_set = list(each)
-                if not np.array_equal(sub_set[0], sub_set[1]):
-                    err_arr = sub_set
+                if not np.array_equal(*each):
+                    err_arr = each
                     is_equal = False
                     break
         shape_list = list(inp.shape for inp in arr)
@@ -101,4 +100,4 @@ def test(dim):
 
 
 if __name__ == "__main__":
-    test(10)
+    test(1000)

--- a/tests/concatenate_stack.py
+++ b/tests/concatenate_stack.py
@@ -100,4 +100,4 @@ def test(dim):
 
 
 if __name__ == "__main__":
-    test(1000)
+    test(10)

--- a/tests/flatten.py
+++ b/tests/flatten.py
@@ -1,0 +1,76 @@
+# Copyright 2021 NVIDIA Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import numpy as np
+
+import cunumeric as num
+
+
+def run_test(np_arr, num_arr):
+    # We don't support 'K' yet, which will be supported later
+    test_orders = ["C", "F", "A"]
+    for order in test_orders:
+        b = np_arr.flatten(order)
+        c = num_arr.flatten(order)
+        is_equal = True
+        err_arr = [b, c]
+
+        if len(b) != len(c):
+            is_equal = False
+            err_arr = [b, c]
+        else:
+            for each in zip(b, c):
+                sub_set = list(each)
+                if not np.array_equal(sub_set[0], sub_set[1]):
+                    err_arr = sub_set
+                    is_equal = False
+                    break
+        print_msg = f"np & cunumeric.ndarray({np_arr.shape}).flatten({order}))"
+        assert is_equal, (
+            f"Failed, {print_msg}\n"
+            f"numpy result: {err_arr[0]}, {b.shape}\n"
+            f"cunumeric_result: {err_arr[1]}, {c.shape}\n"
+            f"cunumeric and numpy shows"
+            f" different result\n"
+        )
+        print(
+            f"Passed, {print_msg}, np: ({b.shape}, {b.dtype})"
+            f", cunumeric: ({c.shape}, {c.dtype}"
+        )
+
+
+def test(dim):
+    print("test flatten")
+    # test np.concatenate & *stack w/ 1D, 2D and 3D arrays
+    input_arr = [
+        (0,),
+        (0, 10),
+        (1,),
+        (1, 1),
+        (1, 1, 1),
+        (1, dim),
+        (1, dim, 1),
+        (dim, dim),
+        (dim, dim, dim),
+    ]
+    for input_size in input_arr:
+        a = np.random.randint(low=0, high=100, size=(input_size))
+        b = num.ndarray.convert_to_cunumeric_ndarray(a)
+        run_test(a, b)
+    return
+
+
+if __name__ == "__main__":
+    test(10)

--- a/tests/flatten.py
+++ b/tests/flatten.py
@@ -1,4 +1,4 @@
-# Copyright 2021 NVIDIA Corporation
+# Copyright 2022 NVIDIA Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -32,9 +32,8 @@ def run_test(np_arr, num_arr):
             err_arr = [b, c]
         else:
             for each in zip(b, c):
-                sub_set = list(each)
-                if not np.array_equal(sub_set[0], sub_set[1]):
-                    err_arr = sub_set
+                if not np.array_equal(*each):
+                    err_arr = each
                     is_equal = False
                     break
         print_msg = f"np & cunumeric.ndarray({np_arr.shape}).flatten({order}))"
@@ -53,7 +52,7 @@ def run_test(np_arr, num_arr):
 
 def test(dim):
     print("test flatten")
-    # test np.concatenate & *stack w/ 1D, 2D and 3D arrays
+    # test ndarray.flatten w/ 1D, 2D and 3D arrays
     input_arr = [
         (0,),
         (0, 10),


### PR DESCRIPTION
Append is easily able to be mapped to `concatenate`
In cunumeric, `flatten` is the same as `ravel`

Added tests for each routine. Refined `concatenate` in the previous PR for append.

Currently, we don't support `order = K` in `flatten` and `ravel`, which should be a separate PR for relevent routines (copy, ravel, flatten, etc)