### PR TITLE
excluding 2 documentation files from pre-commit config file

### DIFF
--- a/docs/cunumeric/source/comparison/_comparison_generator.py
+++ b/docs/cunumeric/source/comparison/_comparison_generator.py
@@ -36,7 +36,7 @@ def _filter(obj, n):
             and n[0].islower()  # starts with lower char
             and not n.startswith("__")  # not special methods
         )
-    except ValueError:
+    except:  # noqa: E722
         return False
 
 

--- a/docs/cunumeric/source/conf.py
+++ b/docs/cunumeric/source/conf.py
@@ -29,10 +29,10 @@
 import os
 import sys
 
-import _comparison_generator
-
 sys.path.insert(0, os.path.abspath("comparison"))
 sys.path.insert(0, os.path.abspath("../../../"))
+
+import _comparison_generator  # noqa: E402
 
 # Generate comparison table.
 with open("comparison/comparison_table.rst.inc", "w") as f:


### PR DESCRIPTION
We need to exclude config.py and _comparison* script files from pre-commit configuration. 
Pre-commit complains on the order of "import"  in config.py, but the order has to be the way it is for generating correct comparison table
 