### PR TITLE
Stop using alloca

### DIFF
--- a/src/cunumeric/matrix/dot_omp.cc
+++ b/src/cunumeric/matrix/dot_omp.cc
@@ -16,9 +16,9 @@
 
 #include "cunumeric/matrix/dot.h"
 #include "cunumeric/matrix/dot_template.inl"
+#include "cunumeric/omp_help.h"
 
 #include <omp.h>
-#include <alloca.h>
 
 namespace cunumeric {
 
@@ -39,7 +39,7 @@ struct DotImplBody<VariantKind::OMP, CODE> {
   {
     const auto volume      = rect.volume();
     const auto max_threads = omp_get_max_threads();
-    auto locals            = static_cast<ACC*>(alloca(max_threads * sizeof(ACC)));
+    ThreadLocalStorage<ACC> locals(max_threads);
     for (auto idx = 0; idx < max_threads; ++idx) locals[idx] = SumReduction<ACC>::identity;
 
     if (dense) {

--- a/src/cunumeric/omp_help.h
+++ b/src/cunumeric/omp_help.h
@@ -1,0 +1,43 @@
+/* Copyright 2022 NVIDIA Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#pragma once
+
+#include <vector>
+
+namespace cunumeric {
+
+// Simple STL vector-based thread local storage for OpenMP threads to avoid false sharing
+template <typename VAL>
+struct ThreadLocalStorage {
+ private:
+  static constexpr size_t CACHE_LINE_SIZE = 64;
+
+ public:
+  ThreadLocalStorage(size_t num_threads) : storage_(CACHE_LINE_SIZE * num_threads) {}
+  ~ThreadLocalStorage() {}
+
+ public:
+  VAL& operator[](size_t idx)
+  {
+    return *reinterpret_cast<VAL*>(storage_.data() + CACHE_LINE_SIZE * idx);
+  }
+
+ private:
+  std::vector<int8_t> storage_;
+};
+
+}  // namespace cunumeric

--- a/src/cunumeric/search/nonzero_omp.cc
+++ b/src/cunumeric/search/nonzero_omp.cc
@@ -16,6 +16,7 @@
 
 #include "cunumeric/search/nonzero.h"
 #include "cunumeric/search/nonzero_template.inl"
+#include "cunumeric/omp_help.h"
 
 #include <omp.h>
 
@@ -36,11 +37,11 @@ struct NonzeroImplBody<VariantKind::OMP, CODE, DIM> {
   {
     const auto max_threads = omp_get_max_threads();
 
-    int64_t size     = 0;
-    int64_t* offsets = static_cast<int64_t*>(alloca(max_threads * sizeof(int64_t)));
+    int64_t size = 0;
+    ThreadLocalStorage<int64_t> offsets(max_threads);
 
     {
-      int64_t* sizes = static_cast<int64_t*>(alloca(max_threads * sizeof(int64_t)));
+      ThreadLocalStorage<int64_t> sizes(max_threads);
       for (auto idx = 0; idx < max_threads; ++idx) sizes[idx] = 0;
 #pragma omp parallel
       {

--- a/src/cunumeric/unary/scalar_unary_red_omp.cc
+++ b/src/cunumeric/unary/scalar_unary_red_omp.cc
@@ -16,6 +16,7 @@
 
 #include "cunumeric/unary/scalar_unary_red.h"
 #include "cunumeric/unary/scalar_unary_red_template.inl"
+#include "cunumeric/omp_help.h"
 
 #include <omp.h>
 
@@ -40,7 +41,7 @@ struct ScalarUnaryRedImplBody<VariantKind::OMP, OP_CODE, CODE, DIM> {
     auto result            = LG_OP::identity;
     const size_t volume    = rect.volume();
     const auto max_threads = omp_get_max_threads();
-    auto locals            = static_cast<VAL*>(alloca(max_threads * sizeof(VAL)));
+    ThreadLocalStorage<VAL> locals(max_threads);
     for (auto idx = 0; idx < max_threads; ++idx) locals[idx] = LG_OP::identity;
     if (dense) {
       auto inptr = in.ptr(rect);
@@ -83,7 +84,7 @@ struct ScalarUnaryRedImplBody<VariantKind::OMP, UnaryRedCode::CONTAINS, CODE, DI
     const auto to_find     = to_find_scalar.scalar<VAL>();
     const size_t volume    = rect.volume();
     const auto max_threads = omp_get_max_threads();
-    auto locals            = static_cast<bool*>(alloca(max_threads * sizeof(VAL)));
+    ThreadLocalStorage<bool> locals(max_threads);
     for (auto idx = 0; idx < max_threads; ++idx) locals[idx] = false;
     if (dense) {
       auto inptr = in.ptr(rect);
@@ -121,7 +122,7 @@ void logical_operator_omp(AccessorRO<VAL, DIM> in,
 {
   const size_t volume    = rect.volume();
   const auto max_threads = omp_get_max_threads();
-  auto locals            = static_cast<bool*>(alloca(max_threads * sizeof(bool)));
+  ThreadLocalStorage<bool> locals(max_threads);
   for (auto idx = 0; idx < max_threads; ++idx) locals[idx] = LG_OP::identity;
   if (dense) {
     auto inptr = in.ptr(rect);
@@ -198,7 +199,7 @@ struct ScalarUnaryRedImplBody<VariantKind::OMP, UnaryRedCode::COUNT_NONZERO, COD
     auto result            = LG_OP::identity;
     const size_t volume    = rect.volume();
     const auto max_threads = omp_get_max_threads();
-    auto locals            = static_cast<uint64_t*>(alloca(max_threads * sizeof(VAL)));
+    ThreadLocalStorage<uint64_t> locals(max_threads);
     for (auto idx = 0; idx < max_threads; ++idx) locals[idx] = 0;
     if (dense) {
       auto inptr = in.ptr(rect);


### PR DESCRIPTION
This PR replaces all uses of `alloca` in OpenMP tasks with a custom thread local storage implementation that avoids false sharing.