### PR TITLE
Optimize np.tril used in Cholesky

### DIFF
--- a/cunumeric/deferred.py
+++ b/cunumeric/deferred.py
@@ -1518,9 +1518,7 @@ class DeferredArray(NumPyThunk):
 
     @auto_convert([1])
     def cholesky(self, src, no_tril=False):
-        cholesky(self, src)
-        if not no_tril:
-            self.trilu(self, 0, True)
+        cholesky(self, src, no_tril)
 
     def unique(self):
         result = self.runtime.create_unbound_thunk(self.dtype)

--- a/src/cunumeric/mapper.cc
+++ b/src/cunumeric/mapper.cc
@@ -115,6 +115,17 @@ std::vector<StoreMapping> CuNumericMapper::store_mappings(
       }
       return std::move(mappings);
     }
+    case CUNUMERIC_TRILU: {
+      if (task.scalars().size() == 2) return {};
+      // If we're here, this task was the post-processing for Cholesky.
+      // So we will request fortran ordering
+      std::vector<StoreMapping> mappings;
+      auto& input = task.inputs().front();
+      mappings.push_back(StoreMapping::default_mapping(input, options.front()));
+      mappings.back().policy.ordering.fortran_order();
+      mappings.back().policy.exact = true;
+      return std::move(mappings);
+    }
     default: {
       return {};
     }

--- a/src/cunumeric/matrix/trilu.cc
+++ b/src/cunumeric/matrix/trilu.cc
@@ -26,9 +26,10 @@ template <LegateTypeCode CODE, int32_t DIM, bool LOWER>
 struct TriluImplBody<VariantKind::CPU, CODE, DIM, LOWER> {
   using VAL = legate_type_of<CODE>;
 
+  template <bool C_ORDER>
   void operator()(const AccessorWO<VAL, DIM>& out,
                   const AccessorRO<VAL, DIM>& in,
-                  const Pitches<DIM - 1>& pitches,
+                  const Pitches<DIM - 1, C_ORDER>& pitches,
                   const Point<DIM>& lo,
                   size_t volume,
                   int32_t k) const

--- a/src/cunumeric/matrix/trilu_omp.cc
+++ b/src/cunumeric/matrix/trilu_omp.cc
@@ -26,9 +26,10 @@ template <LegateTypeCode CODE, int32_t DIM, bool LOWER>
 struct TriluImplBody<VariantKind::OMP, CODE, DIM, LOWER> {
   using VAL = legate_type_of<CODE>;
 
+  template <bool C_ORDER>
   void operator()(const AccessorWO<VAL, DIM>& out,
                   const AccessorRO<VAL, DIM>& in,
-                  const Pitches<DIM - 1>& pitches,
+                  const Pitches<DIM - 1, C_ORDER>& pitches,
                   const Point<DIM>& lo,
                   size_t volume,
                   int32_t k) const


### PR DESCRIPTION
This PR contains changes to optimize the `np.tril` operation done as the post-processing in Cholesky. The `Pitches` template now supports a mode where points are visited in Fortran order, which is useful when the instance has fortran layout (the case with Cholesky).