### PR TITLE
Remove old-style casts

### DIFF
--- a/src/cunumeric/arg.inl
+++ b/src/cunumeric/arg.inl
@@ -84,7 +84,7 @@ __CUDA_HD__ inline void Argval<T>::apply(const Argval<T>& rhs)
     // Spin until no one else is doing their comparison
     // We use -1 as a guard to indicate we're doing our
     // comparison since we know all indexes should be >= 0
-    volatile long long* ptr = (volatile long long*)&arg;
+    volatile long long* ptr = reinterpret_cast<volatile long long*>(&arg);
     long long next          = *ptr;
     long long current;
     do {

--- a/src/cunumeric/divmod.h
+++ b/src/cunumeric/divmod.h
@@ -289,7 +289,7 @@ struct FastDivmod {
     // Use IMUL.HI if div != 1, else simply copy the source.
     quo = (div != 1) ? __umulhi(src, mul) >> shr : src;
 #else
-    quo = int((div != 1) ? int(((int64_t)src * mul) >> 32) >> shr : src);
+    quo = (div != 1) ? static_cast<int>((int64_t{src} * mul) >> 32) >> shr : src;
 #endif
     // The remainder.
     rem = src - (quo * div);

--- a/src/cunumeric/random/philox.h
+++ b/src/cunumeric/random/philox.h
@@ -49,7 +49,7 @@ class Philox_2x32 {
       prod_hi = __umulhi(ctr_lo, PHILOX_M2x32_0x);
       prod_lo = ctr_lo * PHILOX_M2x32_0x;
 #else
-      u64 prod = ((u64)ctr_lo) * PHILOX_M2x32_0x;
+      u64 prod = u64{ctr_lo} * PHILOX_M2x32_0x;
       prod_hi  = prod >> 32;
       prod_lo  = prod;
 #endif
@@ -57,7 +57,7 @@ class Philox_2x32 {
       ctr_hi = prod_lo;
       key += PHILOX_W32_0x;
     }
-    return (((u64)ctr_hi) << 32) + ctr_lo;
+    return (u64{ctr_hi} << 32) + ctr_lo;
   }
 
   // Helper function for CPU hi 64-bit multiplication
@@ -90,7 +90,7 @@ class Philox_2x32 {
 #ifdef __NVCC__
     return __umulhi(bits, n);
 #else
-    return (((u64)bits) * ((u64)bits)) >> 32;
+    return (u64{bits} * u64{bits}) >> 32;
 #endif
   }
 

--- a/src/cunumeric/random/rand_util.h
+++ b/src/cunumeric/random/rand_util.h
@@ -19,8 +19,8 @@
 #include "cunumeric/cunumeric.h"
 #include "cunumeric/random/philox.h"
 
-#define HI_BITS(x) ((unsigned)((x) >> 32))
-#define LO_BITS(x) ((unsigned)((x)&0x00000000FFFFFFFF))
+#define HI_BITS(x) (static_cast<unsigned>((x) >> 32))
+#define LO_BITS(x) (static_cast<unsigned>((x)&0x00000000FFFFFFFF))
 
 namespace cunumeric {
 


### PR DESCRIPTION
Found using -Wold-style-cast

Following Google C++ Style Guide, arithmetic upcasting replaced with
`type{val}`, arithmetic downcasting replaced with `static_cast<type>(val)`