### PR TITLE
Expand coverage reporting to ndarray methods

### DIFF
--- a/cunumeric/__init__.py
+++ b/cunumeric/__init__.py
@@ -23,21 +23,15 @@ with GPU acceleration.
 :meta private:
 """
 
-import sys as _sys
-
 import numpy as _np
+
 from cunumeric import linalg, random
 from cunumeric.array import ndarray
 from cunumeric.module import *
 from cunumeric.ufunc import *
-from cunumeric.coverage import (
-    add_missing_attributes as _add_missing_attributes,
-)
+from cunumeric.coverage import clone_module
 
-_thismodule = _sys.modules[__name__]
+clone_module(_np, globals())
 
-# map any undefined attributes to numpy
-_add_missing_attributes(_np, _thismodule)
-
-# Remote this method from the scope
-del _add_missing_attributes
+del clone_module
+del _np

--- a/cunumeric/array.py
+++ b/cunumeric/array.py
@@ -24,6 +24,7 @@ import pyarrow
 from legate.core import Array
 
 from .config import BinaryOpCode, UnaryOpCode, UnaryRedCode
+from .coverage import clone_class
 from .runtime import runtime
 from .utils import dot_modes
 
@@ -166,7 +167,8 @@ def convert_to_predicate_ndarray(obj):
     )
 
 
-class ndarray(object):
+@clone_class(np.ndarray)
+class ndarray:
     def __init__(
         self,
         shape,

--- a/cunumeric/coverage.py
+++ b/cunumeric/coverage.py
@@ -12,91 +12,123 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from __future__ import annotations
 
-import inspect
 import warnings
+from functools import wraps
+from types import FunctionType, ModuleType
+from typing import Any, Container, Optional
 
 from .runtime import runtime
 from .utils import find_last_user_frames, find_last_user_stacklevel
 
+__all__ = ("clone_module",)
 
-# Get the list of attributes defined in a namespace
-def getPredefinedAttributes(namespace):
-    preDefined = {}
-    for attr in dir(namespace):
-        preDefined[attr] = getattr(namespace, attr)
-    return preDefined
+FALLBACK_WARNING = (
+    "cuNumeric has not implemented {name} "
+    + "and is falling back to canonical numpy. "
+    + "You may notice significantly decreased performance "
+    + "for this function call."
+)
+
+MOD_INTERNAL = {"__dir__", "__getattr__"}
 
 
-def unimplemented(func):
-    def wrapper(*args, **kwargs):
-        """Unimplemented"""
-        stacklevel = find_last_user_stacklevel()
+def filter_namespace(
+    ns: dict[str, Any],
+    *,
+    omit_names: Optional[Container[str]] = None,
+    omit_types: tuple[type, ...] = (),
+) -> dict[str, Any]:
+    omit_names = omit_names or set()
+    return {
+        attr: value
+        for attr, value in ns.items()
+        if attr not in omit_names and not isinstance(value, omit_types)
+    }
 
-        warnings.warn(
-            "cuNumeric has not implemented "
-            + func.__name__
-            + " and is falling back to canonical numpy. "
-            + "You may notice significantly decreased performance "
-            + "for this function call.",
-            stacklevel=stacklevel,
-            category=RuntimeWarning,
-        )
+
+# todo: (bev) use callback protocol type starting with 3.8
+def implemented(func: Any, prefix: str) -> Any:
+    name = f"{prefix}.{func.__name__}"
+
+    @wraps(func)
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        location = find_last_user_frames(not runtime.report_dump_callstack)
+        runtime.record_api_call(name=name, location=location, implemented=True)
         return func(*args, **kwargs)
 
     return wrapper
 
 
-def unimplemented_with_reporting(func_name, func):
-    def wrapper(*args, **kwargs):
-        loc = find_last_user_frames(not runtime.report_dump_callstack)
-        runtime.record_api_call(func_name, loc, False)
-        return func(*args, **kwargs)
+# todo: (bev) use callback protocol type starting with 3.8
+def unimplemented(func: Any, prefix: str, *, reporting: bool = True) -> Any:
+    name = f"{prefix}.{func.__name__}"
+    if reporting:
+
+        @wraps(func)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            location = find_last_user_frames(not runtime.report_dump_callstack)
+            runtime.record_api_call(
+                name=name, location=location, implemented=False
+            )
+            return func(*args, **kwargs)
+
+    else:
+
+        @wraps(func)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            stacklevel = find_last_user_stacklevel()
+            warnings.warn(
+                FALLBACK_WARNING.format(name=name),
+                stacklevel=stacklevel,
+                category=RuntimeWarning,
+            )
+            return func(*args, **kwargs)
 
     return wrapper
 
 
-def implemented(func_name, func):
-    def wrapper(*args, **kwargs):
-        loc = find_last_user_frames(not runtime.report_dump_callstack)
-        runtime.record_api_call(func_name, loc, True)
-        return func(*args, **kwargs)
+def clone_module(
+    origin_module: ModuleType, new_globals: dict[str, Any]
+) -> None:
+    """Copy attributes from one module to another, excluding submodules
 
-    return wrapper
+    Function types are wrapped with a decorator to report API calls. All
+    other values are copied as-is.
 
+    Parameters
+    ----------
+    origin_module : ModuleTpe
+        Existing module to clone attributes from
 
-# Copy attributes from one module to another.
-# Works only on modules and doesnt add submodules
-def add_missing_attributes(baseModule, definedModule):
-    module_name = baseModule.__name__
-    internal_attrs = set(["__dir__", "__getattr__"])
-    preDefined = getPredefinedAttributes(definedModule)
-    attrList = {}
-    for attr in dir(baseModule):
-        if attr in preDefined:
-            pass
-        elif not inspect.ismodule(getattr(baseModule, attr)):
-            attrList[attr] = getattr(baseModule, attr)
+    new_globals : dict
+        a globals() dict for the new module to clone into
+
+    Returns
+    -------
+    None
+
+    """
+    module_name = origin_module.__name__
+
+    missing = filter_namespace(
+        origin_module.__dict__,
+        omit_names=set(new_globals).union(MOD_INTERNAL),
+        omit_types=(ModuleType,),
+    )
 
     if runtime.report_coverage:
-        for key, value in preDefined.items():
-            if callable(value):
-                wrapped = implemented(f"{module_name}.{key}", value)
-                setattr(definedModule, key, wrapped)
+        for attr, value in new_globals.items():
+            if isinstance(value, FunctionType):
+                new_globals[attr] = implemented(value, module_name)
 
-    # add the attributes
-    for key, value in attrList.items():
-        if (
-            callable(value)
-            and not isinstance(value, type)
-            and key not in internal_attrs
-        ):
-            if runtime.report_coverage:
-                wrapped = unimplemented_with_reporting(
-                    f"{module_name}.{key}", value
-                )
-                setattr(definedModule, key, wrapped)
-            else:
-                setattr(definedModule, key, unimplemented(value))
+    for attr, value in missing.items():
+        if isinstance(value, FunctionType):
+            new_globals[attr] = (
+                unimplemented(
+                    value, module_name, reporting=runtime.report_coverage
+                ),
+            )
         else:
-            setattr(definedModule, key, value)
+            new_globals[attr] = value

--- a/cunumeric/linalg/__init__.py
+++ b/cunumeric/linalg/__init__.py
@@ -13,17 +13,13 @@
 # limitations under the License.
 #
 
-import sys as _sys
 
 import numpy.linalg as _nplinalg
+
 from cunumeric.linalg.linalg import *
-from cunumeric.coverage import (
-    add_missing_attributes as _add_missing_attributes,
-)
+from cunumeric.coverage import clone_module
 
-_thismodule = _sys.modules[__name__]
+clone_module(_nplinalg, globals())
 
-# map any undefined attributes to numpy
-_add_missing_attributes(_nplinalg, _thismodule)
-
-del _add_missing_attributes
+del clone_module
+del _nplinalg

--- a/cunumeric/random/__init__.py
+++ b/cunumeric/random/__init__.py
@@ -13,17 +13,11 @@
 # limitations under the License.
 #
 
-import sys as _sys
-
 import numpy.random as _nprandom
 from cunumeric.random.random import *
-from cunumeric.coverage import (
-    add_missing_attributes as _add_missing_attributes,
-)
+from cunumeric.coverage import clone_module
 
-_thismodule = _sys.modules[__name__]
+clone_module(_nprandom, globals())
 
-# map any undefined attributes to numpy
-_add_missing_attributes(_nprandom, _thismodule)
-
-del _add_missing_attributes
+del clone_module
+del _nprandom

--- a/cunumeric/runtime.py
+++ b/cunumeric/runtime.py
@@ -156,9 +156,9 @@ class Runtime(object):
         except ValueError:
             self.report_dump_csv = None
 
-    def record_api_call(self, func_name, location, implemented):
+    def record_api_call(self, name, location, implemented):
         assert self.report_coverage
-        self.api_calls.append((func_name, location, implemented))
+        self.api_calls.append((name, location, implemented))
 
     def _load_cudalibs(self):
         task = self.legate_context.create_task(
@@ -196,10 +196,13 @@ class Runtime(object):
         total = len(self.api_calls)
         implemented = sum(int(impl) for (_, _, impl) in self.api_calls)
 
-        print(
-            f"cuNumeric API coverage: {implemented}/{total} "
-            f"({implemented / total * 100}%)"
-        )
+        if total == 0:
+            print("cuNumeric API coverage: 0/0")
+        else:
+            print(
+                f"cuNumeric API coverage: {implemented}/{total} "
+                f"({implemented / total * 100}%)"
+            )
         if self.report_dump_csv is not None:
             with open(self.report_dump_csv, "w") as f:
                 print("function_name,location,implemented", file=f)

--- a/cunumeric/utils.py
+++ b/cunumeric/utils.py
@@ -37,6 +37,8 @@ def find_last_user_frames(top_only=True):
     last = None
     for (frame, _) in traceback.walk_stack(None):
         last = frame
+        if "__name__" not in frame.f_globals:
+            continue
         if not frame.f_globals["__name__"].startswith("cunumeric"):
             break
 


### PR DESCRIPTION
This PR cleans up and generalizes the existing code for reporting implemented vs unimplemented Numpy API. The updated reporting code is extended to also cover `cunumeric.ndarray`.  

### Example output

For the invocation
```
 LEGATE_TEST=1 legate tests/dot.py --gpus 2 -cunumeric:test -cunumeric:report:coverage  -cunumeric:report:dump-csv /tmp/dot.csv
``` 
The coverage summary is
```
cuNumeric API coverage: 26/26 (100.0%)
```
with CSV:
```
numpy.array,tests/dot.py:27,True
numpy.ndarray.__init__,tests/dot.py:27,True
numpy.array,tests/dot.py:28,True
numpy.ndarray.__init__,tests/dot.py:28,True
numpy.ndarray.dot,tests/dot.py:31,True
numpy.ndarray.__init__,tests/dot.py:31,True
numpy.allclose,tests/dot.py:33,True
numpy.ndarray.__init__,tests/dot.py:33,True
numpy.ndarray._maybe_convert,tests/dot.py:33,True
numpy.ndarray._maybe_convert,tests/dot.py:33,True
numpy.ndarray.__init__,tests/dot.py:33,True
numpy.ndarray.__bool__,tests/dot.py:33,True
numpy.ndarray.__array__,tests/dot.py:33,True
numpy.array,tests/dot.py:27,True
numpy.ndarray.__init__,tests/dot.py:27,True
numpy.array,tests/dot.py:28,True
numpy.ndarray.__init__,tests/dot.py:28,True
numpy.ndarray.dot,tests/dot.py:31,True
numpy.ndarray.__init__,tests/dot.py:31,True
numpy.allclose,tests/dot.py:33,True
numpy.ndarray.__init__,tests/dot.py:33,True
numpy.ndarray._maybe_convert,tests/dot.py:33,True
numpy.ndarray._maybe_convert,tests/dot.py:33,True
numpy.ndarray.__init__,tests/dot.py:33,True
numpy.ndarray.__bool__,tests/dot.py:33,True
numpy.ndarray.__array__,tests/dot.py:33,True

```
