### PR TITLE
Fix some docs breakage

### DIFF
--- a/cunumeric/array.py
+++ b/cunumeric/array.py
@@ -3020,6 +3020,21 @@ class ndarray(object):
         return ndarray(shape=self.shape, dtype=self.dtype, thunk=self._thunk)
 
     def unique(self):
+        """a.unique()
+
+        Find the unique elements of an array.
+
+        Refer to :func:`cunumeric.unique` for full documentation.
+
+        See Also
+        --------
+        cunumeric.unique : equivalent function
+
+        Availability
+        --------
+        Multiple GPUs, Multiple CPUs
+
+        """
         thunk = self._thunk.unique()
         return ndarray(shape=thunk.shape, thunk=thunk)
 

--- a/docs/cunumeric/source/api/math.rst
+++ b/docs/cunumeric/source/api/math.rst
@@ -114,3 +114,6 @@ Miscellaneous
    absolute
    fabs
    sign
+   inner
+   outer
+   vdot

--- a/docs/cunumeric/source/api/ndarray.rst
+++ b/docs/cunumeric/source/api/ndarray.rst
@@ -114,8 +114,8 @@ Shape manipulation
    ndarray.ravel
    ndarray.squeeze
 
-Item selectiona and manipulation
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Item selection and manipulation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. autosummary::
    :toctree: generated/
@@ -157,6 +157,7 @@ Calculation
    .. ndarray.cumprod
    ndarray.all
    ndarray.any
+   ndarray.unique
 
 
 EXTRA

--- a/docs/cunumeric/source/comparison/_comparison_generator.py
+++ b/docs/cunumeric/source/comparison/_comparison_generator.py
@@ -30,7 +30,11 @@ def _filter(obj, n):
                 "set_numeric_ops",
                 "size",
                 "sometrue",
-            ]  # not in blacklist
+                "loads",
+                "mafromtxt",
+                "matmul",
+                "ndfromtxt",
+            ]  # not in blocklist
             and callable(getattr(obj, n))  # callable
             and not isinstance(getattr(obj, n), type)  # not class
             and n[0].islower()  # starts with lower char


### PR DESCRIPTION
Some functions were added without docstrings and/or added without adding to the relevant Sphinx ReST file. Additionally there are a few numpy methods that are not present in our API (see comment below). Finally, there is still a placeholder section in the array methods page for things that don't seem to have a counterpart in the numpy array docs page. We just need to decide where they go:

![image](https://user-images.githubusercontent.com/1078448/159177433-3cd68aca-661d-42fc-a8e7-2e2b4915241e.png)

cc @magnatelee 