### PR TITLE
Add basic cunumeric.patch module

### DIFF
--- a/cunumeric/patch.py
+++ b/cunumeric/patch.py
@@ -1,0 +1,32 @@
+# Copyright 2021-2022 NVIDIA Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+""" This module may be imported in order to globably replace NumPy with
+CuNumeric.
+
+In order to function properly, this module must be imported early (ideally
+at the very start of a script).  The ``numpy`` module in ``sys.modules``
+will be replaced with ``cunumeric`` so that any subsequent use of the
+``numpy`` module will use ``cunumeric`` instead.
+
+This module is primarily intended for quick demonstrations or proofs of
+concept.
+
+"""
+
+import sys
+
+import cunumeric
+
+sys.modules["numpy"] = cunumeric


### PR DESCRIPTION
This PR adds a *very* basic `cunumeric.patch` module that can be imported early in a script to "automatically" replace NumPy with cuNumeric. With the following example script:
```python
import cunumeric.patch

import numpy as np

a = np.random.randn(4, 5)

np.argmin(a, axis=0)
np.argmin(a, axis=1)

np.argmax(a, axis=0)
np.argmax(a, axis=1)
```
 The desired coverage results are generated:
```sh
~/work/cunumeric branch-22.03*
legate37 ❯ legate /tmp/foo.py  -cunumeric:report:coverage 
cuNumeric API coverage: 5/5 (100.0%)
```

## Notes

* This is not yet quite "zero-change", but is a necessary start, and can be utilized immediately, with one line of code added. Assuming a `-m` option is implemented in legion in the future, the it should become possible to utilized this via the command line:
    ```
    legate -m cunumeric.patch foo.py
    ```
    without making any source changes at all. 

* True "zero-change" would require changes to `legate` but there would be questions to answer about having to make `legate` know about `cunumeric`. 

* The patching is *very* simple-minded, and may have edge-cases or shortcomings. E.g. I had hoped to be able to warn loudly in case numpy was already imported, but cunumeric itself imports numpy, so that is not feasible. We cannot rely on the presence or absence of `numpy` in `sys.modules` to condition a warning. I would recommend not widely promoting this module, and keeping it intended as a tool for experienced dev-rel for this reason. 