### PR TITLE
Add cunumeric.ufunc to packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -79,6 +79,7 @@ if args.recurse:
             "cunumeric",
             "cunumeric.linalg",
             "cunumeric.random",
+            "cunumeric.ufunc",
         ],
         cmdclass={"build_py": my_build_py},
     )


### PR DESCRIPTION
I suspect this is the issue behind the reported missing `cunumeric.ufunc` module in the built package testing. I have not located docs on how the release packages are built, so I have not been able to verify that this is a complete solution, but I wanted to have a PR ready to go, in case. cc @magnatelee 

It's possible `setuptools.find_packages` could be used to avoid the need to curate this list manually. 