### PR TITLE
Fix docs breakage

### DIFF
--- a/cunumeric/module.py
+++ b/cunumeric/module.py
@@ -1918,7 +1918,7 @@ def repeat(a, repeats, axis=None):
     ----------
     a : array_like
         Input array.
-    repeats : int or array of ints
+    repeats : int or ndarray[int]
         The number of repetitions for each element. repeats is
         broadcasted to fit the shape of the given axis.
     axis : int, optional
@@ -3738,15 +3738,15 @@ def argsort(a, axis=-1, kind="quicksort", order=None):
     axis : int or None, optional
         Axis to sort. By default, the index -1 (the last axis) is used. If
         None, the flattened array is used.
-    kind : {'quicksort', 'mergesort', 'heapsort', 'stable'}, optional
+    kind : ``{'quicksort', 'mergesort', 'heapsort', 'stable'}``, optional
         Default is 'quicksort'. The underlying sort algorithm might vary.
         The code basically supports 'stable' or *not* 'stable'.
-    order : str or list of str, optional
+    order : str or list[str], optional
         Currently not supported
 
     Returns
     -------
-    index_array : ndarray of ints
+    index_array : ndarray[int]
         Array of indices that sort a along the specified axis. It has the
         same shape as `a.shape` or is flattened in case of `axis` is None.
 
@@ -3815,10 +3815,10 @@ def sort(a, axis=-1, kind="quicksort", order=None):
     axis : int or None, optional
         Axis to sort. By default, the index -1 (the last axis) is used. If
         None, the flattened array is used.
-    kind : {'quicksort', 'mergesort', 'heapsort', 'stable'}, optional
+    kind : ``{'quicksort', 'mergesort', 'heapsort', 'stable'}``, optional
         Default is 'quicksort'. The underlying sort algorithm might vary.
         The code basically supports 'stable' or *not* 'stable'.
-    order : str or list of str, optional
+    order : str or list[str], optional
         Currently not supported
 
     Returns

--- a/docs/cunumeric/source/api/_ndarray.rst
+++ b/docs/cunumeric/source/api/_ndarray.rst
@@ -1,0 +1,75 @@
+cunumeric.ndarray
+=================
+
+.. currentmodule:: cunumeric
+
+.. autoclass:: ndarray
+
+   .. automethod:: __init__
+
+   .. rubric:: Methods
+
+   .. autosummary::
+
+      ~ndarray.__init__
+      ~ndarray.all
+      ~ndarray.any
+      ~ndarray.argmax
+      ~ndarray.argmin
+      ~ndarray.astype
+      ~ndarray.choose
+      ~ndarray.clip
+      ~ndarray.conj
+      ~ndarray.conjugate
+      ~ndarray.copy
+      ~ndarray.diagonal
+      ~ndarray.dot
+      ~ndarray.dump
+      ~ndarray.dumps
+      ~ndarray.fill
+      ~ndarray.find_common_type
+      ~ndarray.flatten
+      ~ndarray.flip
+      ~ndarray.getfield
+      ~ndarray.item
+      ~ndarray.itemset
+      ~ndarray.max
+      ~ndarray.mean
+      ~ndarray.min
+      ~ndarray.nonzero
+      ~ndarray.prod
+      ~ndarray.ravel
+      ~ndarray.reshape
+      ~ndarray.setfield
+      ~ndarray.setflags
+      ~ndarray.squeeze
+      ~ndarray.sum
+      ~ndarray.swapaxes
+      ~ndarray.tobytes
+      ~ndarray.tofile
+      ~ndarray.tolist
+      ~ndarray.tostring
+      ~ndarray.transpose
+      ~ndarray.unique
+      ~ndarray.view
+
+
+   .. rubric:: Attributes
+
+   .. autosummary::
+
+      ~ndarray.T
+      ~ndarray.base
+      ~ndarray.ctypes
+      ~ndarray.data
+      ~ndarray.dtype
+      ~ndarray.flags
+      ~ndarray.flat
+      ~ndarray.imag
+      ~ndarray.itemsize
+      ~ndarray.nbytes
+      ~ndarray.ndim
+      ~ndarray.real
+      ~ndarray.shape
+      ~ndarray.size
+      ~ndarray.strides

--- a/docs/cunumeric/source/api/creation.rst
+++ b/docs/cunumeric/source/api/creation.rst
@@ -30,6 +30,7 @@ From existing data
    array
    asarray
    copy
+   repeat
 
 
 Numerical ranges

--- a/docs/cunumeric/source/api/ndarray.rst
+++ b/docs/cunumeric/source/api/ndarray.rst
@@ -9,11 +9,14 @@ Constructing arrays
 New arrays can be constructed using the routines detailed in Array creation
 routines, and also by using the low-level ndarray constructor:
 
-.. autosummary::
-   :toctree: generated/
+.. toctree::
+   :maxdepth: 2
+   :hidden:
 
-   ndarray
+   _ndarray
 
+
+:meth:`ndarray`
 
 Calculation
 -----------
@@ -124,8 +127,8 @@ Item selection and manipulation
    .. ndarray.put
    .. ndarray.repeat
    ndarray.choose
-   .. ndarray.sort
-   .. ndarray.argsort
+   ndarray.sort
+   ndarray.argsort
    .. ndarray.partition
    .. ndarray.argpartition
    .. ndarray.searchsorted
@@ -146,6 +149,9 @@ Calculation
    .. ndarray.ptp
    ndarray.clip
    ndarray.conj
+   ndarray.conjugate
+   ndarray.dot
+   ndarray.flip
    .. ndarray.round
    .. ndarray.trace
    ndarray.sum
@@ -158,21 +164,6 @@ Calculation
    ndarray.all
    ndarray.any
    ndarray.unique
-
-
-EXTRA
------
-
-Calculation
-~~~~~~~~~~~
-
-.. autosummary::
-   :toctree: generated/
-
-   ndarray.conjugate
-   ndarray.dot
-   ndarray.flip
-
 
 Arithmetic, matrix multiplication, and comparison operations
 ------------------------------------------------------------

--- a/docs/cunumeric/source/api/sorting.rst
+++ b/docs/cunumeric/source/api/sorting.rst
@@ -3,6 +3,17 @@ Sorting, searching, and counting
 
 .. currentmodule:: cunumeric
 
+Sorting
+-------
+
+.. autosummary::
+   :toctree: generated/
+
+   argsort
+   msort
+   sort
+   sort_complex
+
 Searching
 ---------
 

--- a/docs/cunumeric/source/comparison/_comparison_generator.py
+++ b/docs/cunumeric/source/comparison/_comparison_generator.py
@@ -73,7 +73,7 @@ def _section(header, mod_ext, other_lib, klass=None, exclude_mod=None):
     lg_funcs = []
     for f in _get_functions(lg_obj):
         obj = getattr(lg_obj, f)
-        if obj.__doc__ is None or "Unimplemented" not in obj.__doc__:
+        if getattr(obj, "_cunumeric_implemented", False):
             lg_funcs.append(f)
     lg_funcs = set(lg_funcs)
 


### PR DESCRIPTION
This PR fixes the docs breakage that was uncovered by the fix in #230 

TLDR; The #230 bug caused all the *unimplemented* functions to be erroneously cloned as a tuple `(func,)` instead of `func`. This in turn caused the `autosummary` directive for `ndarray` to ignore them. Howevever *after* #230, the `autosummary` directive for `ndarray` picked the up, and wanted to generate references for them in the class TOC. These are *broken* references, because we do not document *unimplemented* (i.e. numpy-only) functions in our docs. 

This PR removes the `autosummary` directive for `ndarray` and replaces it with a hand-curated TOC. I suppose we could dispense with the class TOC altogether, but Numpy does have a class TOC ([ref](https://numpy.org/doc/1.22/reference/generated/numpy.ndarray.html#numpy.ndarr)), and I do think they are handy. 

cc @magnatelee @ipdemes 