### PR TITLE
Updates for using the new unbound store API

### DIFF
--- a/cunumeric/deferred.py
+++ b/cunumeric/deferred.py
@@ -1243,7 +1243,7 @@ class DeferredArray(NumPyThunk):
             raise NotImplementedError(
                 "repeat operation is supported only for 1D"
             )
-        out = self.runtime.create_unbound_thunk(self.dtype)
+        out = self.runtime.create_unbound_thunk(self.dtype, ndim=self.ndim)
         task = self.context.create_task(CuNumericOpCode.REPEAT)
         task.add_input(self.base)
         task.add_output(out.base)
@@ -1253,7 +1253,6 @@ class DeferredArray(NumPyThunk):
         if scalar_repeats:
             task.add_scalar_arg(repeats, ty.int64)
         else:
-            repeats = self.runtime.to_deferred_array(repeats)
             task.add_input(repeats.base)
             task.add_alignment(self.base, repeats.base)
         task.execute()

--- a/cunumeric/deferred.py
+++ b/cunumeric/deferred.py
@@ -1235,14 +1235,6 @@ class DeferredArray(NumPyThunk):
 
     # Repeat elements of an array.
     def repeat(self, repeats, axis, scalar_repeats):
-        # FIXME current implementation supports only 1D, waiting on
-        # issue 242 to be addressed to support ND arrays
-        # for ND I would need to promore `repeats` to allign with A
-        # and  constrain the tiling
-        if self.ndim > 1:
-            raise NotImplementedError(
-                "repeat operation is supported only for 1D"
-            )
         out = self.runtime.create_unbound_thunk(self.dtype, ndim=self.ndim)
         task = self.context.create_task(CuNumericOpCode.REPEAT)
         task.add_input(self.base)
@@ -1253,8 +1245,14 @@ class DeferredArray(NumPyThunk):
         if scalar_repeats:
             task.add_scalar_arg(repeats, ty.int64)
         else:
-            task.add_input(repeats.base)
-            task.add_alignment(self.base, repeats.base)
+            shape = self.shape
+            repeats = self.runtime.to_deferred_array(repeats).base
+            for dim, extent in enumerate(shape):
+                if dim == axis:
+                    continue
+                repeats = repeats.promote(dim, extent)
+            task.add_input(repeats)
+            task.add_alignment(self.base, repeats)
         task.execute()
         return out
 

--- a/cunumeric/runtime.py
+++ b/cunumeric/runtime.py
@@ -427,8 +427,8 @@ class Runtime(object):
         else:
             return EagerArray(self, np.empty(shape, dtype=dtype))
 
-    def create_unbound_thunk(self, dtype):
-        store = self.legate_context.create_store(dtype)
+    def create_unbound_thunk(self, dtype, ndim=1):
+        store = self.legate_context.create_store(dtype, ndim=ndim)
         return DeferredArray(self, store, dtype=dtype)
 
     def is_eager_shape(self, shape):

--- a/src/cunumeric/index/repeat.cc
+++ b/src/cunumeric/index/repeat.cc
@@ -26,58 +26,93 @@ template <LegateTypeCode CODE, int DIM>
 struct RepeatImplBody<VariantKind::CPU, CODE, DIM> {
   using VAL = legate_type_of<CODE>;
 
-  size_t operator()(Buffer<VAL>& out,
-                    const AccessorRO<VAL, DIM>& in,
-                    const int64_t repeats,
-                    const int32_t axis,
-                    const Pitches<DIM - 1>& pitches,
-                    const Rect<DIM>& rect) const
+  void operator()(Array& out_array,
+                  const AccessorRO<VAL, DIM>& in,
+                  const int64_t repeats,
+                  const int32_t axis,
+                  const Rect<DIM>& in_rect) const
   {
-    const size_t volume = rect.volume();
-    size_t size         = volume * repeats;
-    out                 = create_buffer<VAL>(size, Memory::Kind::SYSTEM_MEM);
+    Point<DIM> extents = in_rect.hi - in_rect.lo + Point<DIM>::ONES();
+    extents[axis] *= repeats;
 
-    int64_t out_idx = 0;
-    for (size_t idx = 0; idx < volume; ++idx) {
-      auto p = pitches.unflatten(idx, rect.lo);
-      for (size_t r = 0; r < repeats; r++) {
-        out[out_idx] = in[p];
-        ++out_idx;
-      }
+    auto out = out_array.create_output_buffer<VAL, DIM>(extents, true);
+
+    Rect<DIM> out_rect(Point<DIM>::ZEROES(), extents - Point<DIM>::ONES());
+    Pitches<DIM - 1> pitches;
+
+    auto out_volume = pitches.flatten(out_rect);
+    for (size_t idx = 0; idx < out_volume; ++idx) {
+      auto out_p = pitches.unflatten(idx, out_rect.lo);
+      auto in_p  = out_p;
+      in_p[axis] /= repeats;
+      in_p += in_rect.lo;
+      out[out_p] = in[in_p];
     }
-#ifdef CUNUMERIC_DEBUG
-    assert(size == out_idx);
-#endif
-    return size;
   }
 
-  size_t operator()(Buffer<VAL>& out,
-                    const AccessorRO<VAL, DIM>& in,
-                    const AccessorRO<int64_t, DIM>& repeats,
-                    const int32_t axis,
-                    const Pitches<DIM - 1>& pitches,
-                    const Rect<DIM>& rect) const
+  void operator()(Array& out_array,
+                  const AccessorRO<VAL, 1>& in,
+                  const AccessorRO<int64_t, 1>& repeats,
+                  const int32_t axis,
+                  const Rect<1>& in_rect) const
   {
-    const size_t volume = rect.volume();
-    size_t size         = 0;
+    Pitches<0> in_pitches;
+    auto volume = in_pitches.flatten(in_rect);
+    Point<1> extents(0);
     for (size_t idx = 0; idx < volume; ++idx) {
-      auto point = pitches.unflatten(idx, rect.lo);
-      size += repeats[point];
+      auto point = in_pitches.unflatten(idx, in_rect.lo);
+      extents[0] += repeats[point];
     }
-    out = create_buffer<VAL>(size, Memory::Kind::SYSTEM_MEM);
+
+    auto out = out_array.create_output_buffer<VAL, 1>(extents, true);
 
     int64_t out_idx = 0;
-    for (size_t idx = 0; idx < volume; ++idx) {
-      auto p = pitches.unflatten(idx, rect.lo);
-      for (size_t r = 0; r < repeats[p]; r++) {
-        out[out_idx] = in[p];
-        ++out_idx;
+    for (size_t in_idx = 0; in_idx < volume; ++in_idx) {
+      auto p = in_pitches.unflatten(in_idx, in_rect.lo);
+      for (size_t r = 0; r < repeats[p]; r++) out[out_idx++] = in[p];
+    }
+  }
+
+  template <int32_t _DIM = DIM, std::enable_if_t<(_DIM > 1)>* = nullptr>
+  void operator()(Array& out_array,
+                  const AccessorRO<VAL, _DIM>& in,
+                  const AccessorRO<int64_t, _DIM>& repeats,
+                  const int32_t axis,
+                  const Rect<_DIM>& in_rect) const
+  {
+    int64_t sum  = 0;
+    auto p       = in_rect.lo;
+    auto offsets = create_buffer<int64_t>(in_rect.hi[axis] - in_rect.lo[axis] + 1);
+
+    int64_t off_idx = 0;
+    for (int64_t idx = in_rect.lo[axis]; idx <= in_rect.hi[axis]; ++idx) {
+      p[axis]            = idx;
+      offsets[off_idx++] = sum;
+      sum += repeats[p];
+    }
+
+    Point<DIM> extents = in_rect.hi - in_rect.lo + Point<DIM>::ONES();
+    extents[axis]      = sum;
+
+    auto out = out_array.create_output_buffer<VAL, DIM>(extents, true);
+
+    Pitches<DIM - 1> in_pitches;
+    auto in_volume = in_pitches.flatten(in_rect);
+
+    int64_t axis_base = in_rect.lo[axis];
+    for (size_t idx = 0; idx < in_volume; ++idx) {
+      auto in_p  = in_pitches.unflatten(idx, in_rect.lo);
+      auto out_p = in_p - in_rect.lo;
+
+      int64_t off_start = offsets[in_p[axis] - axis_base];
+      int64_t off_end   = off_start + repeats[in_p];
+
+      auto in_v = in[in_p];
+      for (int64_t out_idx = off_start; out_idx < off_end; ++out_idx) {
+        out_p[axis] = out_idx;
+        out[out_p]  = in_v;
       }
     }
-#ifdef CUNUMERIC_DEBUG
-    assert(size == out_idx);
-#endif
-    return size;
   }
 };
 

--- a/src/cunumeric/index/repeat.cu
+++ b/src/cunumeric/index/repeat.cu
@@ -27,63 +27,71 @@ using namespace Legion;
 
 template <typename Output, int DIM>
 static __global__ void __launch_bounds__(THREADS_PER_BLOCK, MIN_CTAS_PER_SM)
-  count_repeat_kernel(const size_t volume,
-                      Output out,
+  count_repeat_kernel(const int64_t extent,
+                      Output sum,
                       const AccessorRO<int64_t, DIM> repeats,
-                      const Pitches<DIM - 1> pitches,
                       const Point<DIM> origin,
+                      const int32_t axis,
                       const size_t iters,
                       Buffer<int64_t> offsets)
 {
   int64_t value = 0;
   for (size_t idx = 0; idx < iters; idx++) {
-    const size_t offset = (idx * gridDim.x + blockIdx.x) * blockDim.x + threadIdx.x;
-    if (offset < volume) {
-      auto point      = pitches.unflatten(offset, origin);
-      auto val        = repeats[point];
+    const int64_t offset = (idx * gridDim.x + blockIdx.x) * blockDim.x + threadIdx.x;
+    if (offset < extent) {
+      auto p = origin;
+      p[axis] += offset;
+      auto val        = repeats[p];
       offsets[offset] = val;
       SumReduction<int64_t>::fold<true>(value, val);
     }
   }
   // Every thread in the thread block must participate in the exchange to get correct results
-  reduce_output(out, value);
+  reduce_output(sum, value);
 }
 
 template <typename VAL, int DIM>
 __global__ static void __launch_bounds__(THREADS_PER_BLOCK, MIN_CTAS_PER_SM)
-  repeat_kernel(Buffer<VAL> out,
+  repeat_kernel(Buffer<VAL, DIM> out,
                 const AccessorRO<VAL, DIM> in,
                 int64_t repeats,
                 const int32_t axis,
-                const Rect<DIM> rect,
+                const Point<DIM> in_lo,
                 const Pitches<DIM - 1> pitches,
-                const int volume)
+                const size_t volume)
 {
   const size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
   if (idx >= volume) return;
-  int64_t i = idx / repeats;
-  auto p    = pitches.unflatten(i, rect.lo);
-  out[idx]  = in[p];
+  auto out_p = pitches.unflatten(idx, Point<DIM>::ZEROES());
+  auto in_p  = out_p;
+  in_p[axis] /= repeats;
+  in_p += in_lo;
+  out[out_p] = in[in_p];
 }
 
 template <typename VAL, int DIM>
 __global__ static void __launch_bounds__(THREADS_PER_BLOCK, MIN_CTAS_PER_SM)
-  repeat_kernel(Buffer<VAL> out,
+  repeat_kernel(Buffer<VAL, DIM> out,
                 const AccessorRO<VAL, DIM> in,
                 const AccessorRO<int64_t, DIM> repeats,
                 Buffer<int64_t> offsets,
                 const int32_t axis,
-                const Rect<DIM> rect,
+                const Point<DIM> in_lo,
                 const Pitches<DIM - 1> pitches,
                 const int volume)
 {
   const size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
   if (idx >= volume) return;
-  auto p         = pitches.unflatten(idx, rect.lo);
-  size_t out_idx = offsets[idx];
-  for (size_t r = 0; r < repeats[p]; r++) {
-    out[out_idx] = in[p];
-    ++out_idx;
+  auto in_p  = pitches.unflatten(idx, in_lo);
+  auto out_p = in_p - in_lo;
+
+  int64_t off_start = offsets[in_p[axis] - in_lo[axis]];
+  int64_t off_end   = off_start + repeats[in_p];
+
+  auto in_v = in[in_p];
+  for (int64_t out_idx = off_start; out_idx < off_end; ++out_idx) {
+    out_p[axis] = out_idx;
+    out[out_p]  = in_v;
   }
 }
 
@@ -91,68 +99,68 @@ template <LegateTypeCode CODE, int DIM>
 struct RepeatImplBody<VariantKind::GPU, CODE, DIM> {
   using VAL = legate_type_of<CODE>;
 
-  size_t operator()(Buffer<VAL>& out,
-                    const AccessorRO<VAL, DIM>& in,
-                    const int64_t repeats,
-                    const int32_t axis,
-                    const Pitches<DIM - 1>& pitches,
-                    const Rect<DIM>& rect) const
+  void operator()(Array& out_array,
+                  const AccessorRO<VAL, DIM>& in,
+                  const int64_t repeats,
+                  const int32_t axis,
+                  const Rect<DIM>& in_rect) const
   {
-    const size_t volume = rect.volume();
-    size_t size         = volume * repeats;
-    const size_t blocks = (size + THREADS_PER_BLOCK - 1) / THREADS_PER_BLOCK;
+    Point<DIM> extents = in_rect.hi - in_rect.lo + Point<DIM>::ONES();
+    extents[axis] *= repeats;
 
-    out = create_buffer<VAL>(size, Memory::Kind::GPU_FB_MEM);
+    auto out = out_array.create_output_buffer<VAL, DIM>(extents, true);
+
+    Rect<DIM> out_rect(Point<DIM>::ZEROES(), extents - Point<DIM>::ONES());
+    Pitches<DIM - 1> pitches;
+
+    auto out_volume   = pitches.flatten(out_rect);
+    const auto blocks = (out_volume + THREADS_PER_BLOCK - 1) / THREADS_PER_BLOCK;
 
     repeat_kernel<VAL, DIM>
-      <<<blocks, THREADS_PER_BLOCK>>>(out, in, repeats, axis, rect, pitches, size);
-    return size;
+      <<<blocks, THREADS_PER_BLOCK>>>(out, in, repeats, axis, in_rect.lo, pitches, out_volume);
   }
 
-  size_t operator()(Buffer<VAL>& out,
-                    const AccessorRO<VAL, DIM>& in,
-                    const AccessorRO<int64_t, DIM>& repeats,
-                    const int32_t axis,
-                    const Pitches<DIM - 1>& pitches,
-                    const Rect<DIM>& rect) const
+  void operator()(Array& out_array,
+                  const AccessorRO<VAL, DIM>& in,
+                  const AccessorRO<int64_t, DIM>& repeats,
+                  const int32_t axis,
+                  const Rect<DIM>& in_rect) const
   {
-    const size_t volume = rect.volume();
-
     auto stream = get_cached_stream();
 
-    // compute offsets
-    Buffer<int64_t> offsets = create_buffer<int64_t>(volume, Memory::Kind::GPU_FB_MEM);
-    DeferredReduction<SumReduction<int64_t>> size;
-    const size_t blocks = (volume + THREADS_PER_BLOCK - 1) / THREADS_PER_BLOCK;
-    size_t shmem_size   = THREADS_PER_BLOCK / 32 * sizeof(int64_t);
+    Pitches<DIM - 1> pitches;
+    const auto volume = pitches.flatten(in_rect);
 
-    if (blocks > MAX_REDUCTION_CTAS) {
-      const size_t iters = (blocks + MAX_REDUCTION_CTAS - 1) / MAX_REDUCTION_CTAS;
+    // Compute offsets
+    int64_t extent = in_rect.hi[axis] - in_rect.lo[axis] + 1;
+    auto offsets   = create_buffer<int64_t>(Point<1>(extent), Memory::Kind::Z_COPY_MEM);
+
+    DeferredReduction<SumReduction<int64_t>> sum;
+    const size_t blocks_count = (extent + THREADS_PER_BLOCK - 1) / THREADS_PER_BLOCK;
+    const size_t shmem_size   = THREADS_PER_BLOCK / 32 * sizeof(int64_t);
+
+    if (blocks_count > MAX_REDUCTION_CTAS) {
+      const size_t iters = (blocks_count + MAX_REDUCTION_CTAS - 1) / MAX_REDUCTION_CTAS;
       count_repeat_kernel<<<MAX_REDUCTION_CTAS, THREADS_PER_BLOCK, shmem_size, stream>>>(
-        volume, size, repeats, pitches, rect.lo, iters, offsets);
+        extent, sum, repeats, in_rect.lo, axis, iters, offsets);
     } else {
-      count_repeat_kernel<<<blocks, THREADS_PER_BLOCK, shmem_size, stream>>>(
-        volume, size, repeats, pitches, rect.lo, 1, offsets);
+      count_repeat_kernel<<<blocks_count, THREADS_PER_BLOCK, shmem_size, stream>>>(
+        extent, sum, repeats, in_rect.lo, axis, 1, offsets);
     }
 
     cudaStreamSynchronize(stream);
 
+    Point<DIM> out_extents = in_rect.hi - in_rect.lo + Point<DIM>::ONES();
+    out_extents[axis]      = sum.read();
+
+    auto out = out_array.create_output_buffer<VAL, DIM>(out_extents, true);
+
     auto p_offsets = offsets.ptr(0);
+    thrust::exclusive_scan(thrust::cuda::par.on(stream), p_offsets, p_offsets + extent, p_offsets);
 
-    exclusive_sum(p_offsets, volume, stream);
-
-    auto out_size = size.read();
-
-    out = create_buffer<VAL>(out_size, Memory::Kind::GPU_FB_MEM);
-
+    const size_t blocks = (volume + THREADS_PER_BLOCK - 1) / THREADS_PER_BLOCK;
     repeat_kernel<VAL, DIM><<<blocks, THREADS_PER_BLOCK, 0, stream>>>(
-      out, in, repeats, offsets, axis, rect, pitches, volume);
-    return out_size;
-  }
-
-  static void exclusive_sum(int64_t* offsets, size_t volume, cudaStream_t stream)
-  {
-    thrust::exclusive_scan(thrust::cuda::par.on(stream), offsets, offsets + volume, offsets);
+      out, in, repeats, offsets, axis, in_rect.lo, pitches, volume);
   }
 };
 

--- a/src/cunumeric/index/repeat_omp.cc
+++ b/src/cunumeric/index/repeat_omp.cc
@@ -16,7 +16,11 @@
 
 #include "cunumeric/index/repeat.h"
 #include "cunumeric/index/repeat_template.inl"
+#include "cunumeric/omp_help.h"
+
 #include <omp.h>
+#include <thrust/scan.h>
+#include <thrust/execution_policy.h>
 
 namespace cunumeric {
 
@@ -27,63 +31,88 @@ template <LegateTypeCode CODE, int DIM>
 struct RepeatImplBody<VariantKind::OMP, CODE, DIM> {
   using VAL = legate_type_of<CODE>;
 
-  size_t operator()(Buffer<VAL>& out,
-                    const AccessorRO<VAL, DIM>& in,
-                    const int64_t repeats,
-                    const int32_t axis,
-                    const Pitches<DIM - 1>& pitches,
-                    const Rect<DIM>& rect) const
+  void operator()(Array& out_array,
+                  const AccessorRO<VAL, DIM>& in,
+                  const int64_t repeats,
+                  const int32_t axis,
+                  const Rect<DIM>& in_rect) const
   {
-    const size_t volume = rect.volume();
-    size_t size         = volume * repeats;
-    Memory::Kind kind =
-      CuNumeric::has_numamem ? Memory::Kind::SOCKET_MEM : Memory::Kind::SYSTEM_MEM;
-    out = create_buffer<VAL>(size, kind);
+    Point<DIM> extents = in_rect.hi - in_rect.lo + Point<DIM>::ONES();
+    extents[axis] *= repeats;
+
+    auto out = out_array.create_output_buffer<VAL, DIM>(extents, true);
+
+    Rect<DIM> out_rect(Point<DIM>::ZEROES(), extents - Point<DIM>::ONES());
+    Pitches<DIM - 1> pitches;
+
+    auto out_volume = pitches.flatten(out_rect);
 #pragma omp parallel for schedule(static)
-    for (size_t idx = 0; idx < size; ++idx) {
-      size_t p_idx = idx / repeats;
-      auto p       = pitches.unflatten(p_idx, rect.lo);
-      out[idx]     = in[p];
+    for (size_t idx = 0; idx < out_volume; ++idx) {
+      auto out_p = pitches.unflatten(idx, out_rect.lo);
+      auto in_p  = out_p;
+      in_p[axis] /= repeats;
+      in_p += in_rect.lo;
+      out[out_p] = in[in_p];
     }
-    return size;
   }
 
-  size_t operator()(Buffer<VAL>& out,
-                    const AccessorRO<VAL, DIM>& in,
-                    const AccessorRO<int64_t, DIM>& repeats,
-                    const int32_t axis,
-                    const Pitches<DIM - 1>& pitches,
-                    const Rect<DIM>& rect) const
+  void operator()(Array& out_array,
+                  const AccessorRO<VAL, DIM>& in,
+                  const AccessorRO<int64_t, DIM>& repeats,
+                  const int32_t axis,
+                  const Rect<DIM>& in_rect) const
   {
-    const size_t volume = rect.volume();
-    int64_t size        = 0;
-    Memory::Kind kind =
-      CuNumeric::has_numamem ? Memory::Kind::SOCKET_MEM : Memory::Kind::SYSTEM_MEM;
-    DeferredBuffer<int64_t, 1> offsets(kind, Rect<1>(0, volume - 1));
+    auto kind = CuNumeric::has_numamem ? Memory::Kind::SOCKET_MEM : Memory::Kind::SYSTEM_MEM;
+    int64_t axis_extent = in_rect.hi[axis] - in_rect.lo[axis] + 1;
+    auto offsets        = create_buffer<int64_t>(axis_extent, kind);
 
+    const auto max_threads = omp_get_max_threads();
+    ThreadLocalStorage<int64_t> local_sums(max_threads);
+    for (auto idx = 0; idx < max_threads; ++idx) local_sums[idx] = 0;
+
+#pragma omp parallel
     {
-      DeferredBuffer<int64_t, 1> sizes(kind, Rect<1>(0, volume - 1));
-#pragma omp parallel for schedule(static)
-      for (size_t idx = 0; idx < volume; ++idx) {
-        auto point = pitches.unflatten(idx, rect.lo);
-        sizes[idx] = repeats[point];
+      const auto tid  = omp_get_thread_num();
+      auto p          = in_rect.lo;
+      int64_t axis_lo = p[axis];
+#pragma omp for schedule(static) private(p)
+      for (int64_t idx = 0; idx < axis_extent; ++idx) {
+        p[axis]      = axis_lo + idx;
+        auto val     = repeats[p];
+        offsets[idx] = val;
+        local_sums[tid] += val;
       }
-
-      for (auto idx = 0; idx < volume; ++idx) size += sizes[idx];
-
-      offsets[0] = 0;
-      for (auto idx = 1; idx < volume; ++idx) offsets[idx] = offsets[idx - 1] + sizes[idx - 1];
-    }  // end section
-
-    out = create_buffer<VAL>(size, kind);
-
-#pragma omp parallel for schedule(static)
-    for (size_t idx = 0; idx < volume; ++idx) {
-      auto p          = pitches.unflatten(idx, rect.lo);
-      int64_t out_idx = offsets[idx];
-      for (size_t r = 0; r < repeats[p]; r++) { out[out_idx + r] = in[p]; }
     }
-    return size;
+
+    auto p_offsets = offsets.ptr(0);
+    thrust::exclusive_scan(thrust::omp::par, p_offsets, p_offsets + axis_extent, p_offsets);
+
+    int64_t sum = 0;
+    for (auto idx = 0; idx < max_threads; ++idx) sum += local_sums[idx];
+
+    Point<DIM> extents = in_rect.hi - in_rect.lo + Point<DIM>::ONES();
+    extents[axis]      = sum;
+
+    auto out = out_array.create_output_buffer<VAL, DIM>(extents, true);
+
+    Pitches<DIM - 1> in_pitches;
+    auto in_volume = in_pitches.flatten(in_rect);
+
+    int64_t axis_base = in_rect.lo[axis];
+#pragma omp parallel for schedule(static)
+    for (size_t idx = 0; idx < in_volume; ++idx) {
+      auto in_p  = in_pitches.unflatten(idx, in_rect.lo);
+      auto out_p = in_p - in_rect.lo;
+
+      int64_t off_start = offsets[in_p[axis] - in_rect.lo[axis]];
+      int64_t off_end   = off_start + repeats[in_p];
+
+      auto in_v = in[in_p];
+      for (int64_t out_idx = off_start; out_idx < off_end; ++out_idx) {
+        out_p[axis] = out_idx;
+        out[out_p]  = in_v;
+      }
+    }
   }
 };
 

--- a/src/cunumeric/index/repeat_template.inl
+++ b/src/cunumeric/index/repeat_template.inl
@@ -32,30 +32,20 @@ struct RepeatImpl {
     using VAL       = legate_type_of<CODE>;
     auto input_rect = args.input.shape<DIM>();
     auto input_arr  = args.input.read_accessor<VAL, DIM>(input_rect);
-    Pitches<DIM - 1> input_pitches;
-    Buffer<VAL> output_arr;
-    size_t volume = input_pitches.flatten(input_rect);
-    if (volume == 0) {
-      auto empty = create_buffer<VAL>(0);
-      args.output.return_data(empty, 0);
+
+    if (input_rect.empty()) {
+      auto extents = Point<DIM>::ZEROES();
+      auto buffer  = create_buffer<VAL, DIM>(extents);
+      args.output.return_data(buffer, extents);
       return;
     }
 
-    if (args.scalar_repeats) {
-      auto size = RepeatImplBody<KIND, CODE, DIM>{}(
-        output_arr, input_arr, args.repeats, args.axis, input_pitches, input_rect);
-      args.output.return_data(output_arr, size);
-
-    } else {
-      auto r_rect      = args.repeats_arr.shape<DIM>();
-      auto repeats_arr = args.repeats_arr.read_accessor<int64_t, DIM>(r_rect);
-#ifdef CUNUMERIC_DEBUG
-      // repeats should have the same shape and partitioning as an input array
-      assert(r_rect == input_rect);
-#endif
-      auto size = RepeatImplBody<KIND, CODE, DIM>{}(
-        output_arr, input_arr, repeats_arr, args.axis, input_pitches, input_rect);
-      args.output.return_data(output_arr, size);
+    if (args.scalar_repeats)
+      RepeatImplBody<KIND, CODE, DIM>{}(
+        args.output, input_arr, args.repeats, args.axis, input_rect);
+    else {
+      auto repeats_arr = args.repeats_arr.read_accessor<int64_t, DIM>(input_rect);
+      RepeatImplBody<KIND, CODE, DIM>{}(args.output, input_arr, repeats_arr, args.axis, input_rect);
     }
   }
 };

--- a/src/cunumeric/search/nonzero_template.inl
+++ b/src/cunumeric/search/nonzero_template.inl
@@ -38,7 +38,7 @@ struct NonzeroImpl {
 
     if (volume == 0) {
       auto empty = create_buffer<VAL>(0);
-      for (auto& store : args.results) store.return_data(empty, 0);
+      for (auto& store : args.results) store.return_data(empty, Point<1>(0));
       return;
     }
 
@@ -46,7 +46,8 @@ struct NonzeroImpl {
     std::vector<Buffer<int64_t>> results(DIM);
     auto size = NonzeroImplBody<KIND, CODE, DIM>()(in, pitches, rect, volume, results);
 
-    for (int32_t idx = 0; idx < DIM; ++idx) args.results[idx].return_data(results[idx], size);
+    for (int32_t idx = 0; idx < DIM; ++idx)
+      args.results[idx].return_data(results[idx], Point<1>(size));
   }
 };
 

--- a/src/cunumeric/set/unique_reduce_template.inl
+++ b/src/cunumeric/set/unique_reduce_template.inl
@@ -43,7 +43,7 @@ struct UniqueReduceImpl {
     Buffer<VAL> result;
     std::tie(result, size) = UniqueReduceImplBody<KIND, CODE>()(inputs);
 
-    output.return_data(result, size);
+    output.return_data(result, Point<1>(size));
   }
 };
 

--- a/src/cunumeric/set/unique_template.inl
+++ b/src/cunumeric/set/unique_template.inl
@@ -45,7 +45,7 @@ struct UniqueImpl {
     std::tie(result, size) =
       UniqueImplBody<KIND, CODE, DIM>()(in, pitches, rect, volume, comms, point, launch_domain);
 
-    output.return_data(result, size);
+    output.return_data(result, Point<1>(size));
   }
 };
 

--- a/src/cunumeric/sort/sort.cu
+++ b/src/cunumeric/sort/sort.cu
@@ -775,10 +775,10 @@ struct SortImplBody<VariantKind::GPU, CODE, DIM> {
           : local_sorted;
       if (argsort) {
         output_array.return_data(local_sorted_repartitioned.indices,
-                                 local_sorted_repartitioned.size);
+                                 Point<1>(local_sorted_repartitioned.size));
       } else {
         output_array.return_data(local_sorted_repartitioned.values,
-                                 local_sorted_repartitioned.size);
+                                 Point<1>(local_sorted_repartitioned.size));
       }
     } else if (argsort) {
       // cleanup

--- a/tests/index_routines.py
+++ b/tests/index_routines.py
@@ -191,51 +191,6 @@ def test():
         f = num.diag(e, k=k)
         fn = np.diag(en, k=k)
         assert np.array_equal(f, fn)
-    # --------------------------------------------------------------
-    # REPEAT
-    # --------------------------------------------------------------
-
-    assert np.array_equal(num.repeat(3, 4), np.repeat(3, 4))
-    print("res_num", num.repeat([3, 1], 4))
-    print("res_np", np.repeat([3, 1], 4))
-    assert np.array_equal(num.repeat([3, 1], 4), np.repeat([3, 1], 4))
-    anp = np.array([1, 2, 3, 4, 5])
-    a = num.array(anp)
-    repnp = np.array([1, 2, 1, 2, 1])
-    rep = num.array(repnp)
-    print(num.repeat(a, rep, axis=0))
-    print(np.repeat(anp, repnp, axis=0))
-    assert np.array_equal(
-        num.repeat(a, rep, axis=0), np.repeat(anp, repnp, axis=0)
-    )
-    # xnp = np.array([[1, 2], [3, 4]])
-    # x = num.array([[1, 2], [3, 4]])
-    # assert np.array_equal(
-    #    num.repeat(x, [1, 2], axis=0), np.repeat(xnp, [1, 2], axis=0)
-    # )
-    # assert np.array_equal(
-    #  num.repeat(x, 0, axis=0), np.repeat(xnp, 0, axis=0))
-
-    # for ndim in range(1, LEGATE_MAX_DIM + 1):
-    #     a_shape = tuple(random.randint(1, 9) for i in range(ndim))
-    #     np_array = mk_seq_array(np, a_shape)
-    #     num_array = mk_seq_array(num, a_shape)
-    #     repeats = random.randint(0, 15)
-    #     res_num = num.repeat(num_array, repeats)
-    #     res_np = np.repeat(np_array, repeats)
-    #     assert np.array_equal(res_num, res_np)
-    #     for axis in range(0, ndim):
-    #         res_num2 = num.repeat(num_array, repeats, axis)
-    #         res_np2 = np.repeat(np_array, repeats, axis)
-    #         assert np.array_equal(res_num2, res_np2)
-    #         rep_shape = (a_shape[axis],)
-    #         rep_arr_np = mk_seq_array(np, rep_shape)
-    #         rep_arr_num = mk_seq_array(num, rep_shape)
-    #         res_num3 = num.repeat(num_array, rep_arr_num, axis)
-    #         res_np3 = np.repeat(np_array, rep_arr_np, axis)
-    #         assert np.array_equal(res_num3, res_np3)
-
-    return
 
 
 if __name__ == "__main__":

--- a/tests/repeat.py
+++ b/tests/repeat.py
@@ -1,0 +1,70 @@
+# Copyright 2021-2022 NVIDIA Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import numpy as np
+from test_tools.generators import mk_seq_array
+
+import cunumeric as num
+from legate.core import LEGATE_MAX_DIM
+
+
+def test():
+    # --------------------------------------------------------------
+    # REPEAT
+    # --------------------------------------------------------------
+
+    assert np.array_equal(num.repeat(3, 4), np.repeat(3, 4))
+    print("res_num", num.repeat([3, 1], 4))
+    print("res_np", np.repeat([3, 1], 4))
+    assert np.array_equal(num.repeat([3, 1], 4), np.repeat([3, 1], 4))
+    anp = np.array([1, 2, 3, 4, 5])
+    a = num.array(anp)
+    repnp = np.array([1, 2, 1, 2, 1])
+    rep = num.array(repnp)
+    print(num.repeat(a, rep, axis=0))
+    print(np.repeat(anp, repnp, axis=0))
+    assert np.array_equal(
+        num.repeat(a, rep, axis=0), np.repeat(anp, repnp, axis=0)
+    )
+    xnp = np.array([[1, 2], [3, 4]])
+    x = num.array([[1, 2], [3, 4]])
+    assert np.array_equal(
+        num.repeat(x, [1, 2], axis=0), np.repeat(xnp, [1, 2], axis=0)
+    )
+    assert np.array_equal(num.repeat(x, 0, axis=0), np.repeat(xnp, 0, axis=0))
+
+    np.random.seed(12345)
+    for ndim in range(1, LEGATE_MAX_DIM + 1):
+        a_shape = tuple(np.random.randint(1, 9) for i in range(ndim))
+        np_array = mk_seq_array(np, a_shape)
+        num_array = mk_seq_array(num, a_shape)
+        repeats = np.random.randint(0, 15)
+        res_num = num.repeat(num_array, repeats)
+        res_np = np.repeat(np_array, repeats)
+        assert np.array_equal(res_num, res_np)
+        for axis in range(0, ndim):
+            res_num2 = num.repeat(num_array, repeats, axis)
+            res_np2 = np.repeat(np_array, repeats, axis)
+            assert np.array_equal(res_num2, res_np2)
+            rep_shape = (a_shape[axis],)
+            rep_arr_np = mk_seq_array(np, rep_shape)
+            rep_arr_num = mk_seq_array(num, rep_shape)
+            res_num3 = num.repeat(num_array, rep_arr_num, axis)
+            res_np3 = np.repeat(np_array, rep_arr_np, axis)
+            assert np.array_equal(res_num3, res_np3)
+
+
+if __name__ == "__main__":
+    test()


### PR DESCRIPTION
This PR updates operator implementations using unbound stores to be compliant with the new unbound store API. This also extends the `repeat` implementation to support N-D cases.