### PR TITLE
Some misc tests and types

### DIFF
--- a/conda/cunumeric_dev.yml
+++ b/conda/cunumeric_dev.yml
@@ -21,3 +21,4 @@ dependencies:
   - sphinx
   - sphinx-copybutton
   - sphinx-markdown-tables
+  - typing_extensions

--- a/cunumeric/_ufunc/ufunc.py
+++ b/cunumeric/_ufunc/ufunc.py
@@ -14,11 +14,9 @@
 #
 
 import numpy as np
-from cunumeric.array import (
-    broadcast_shapes,
-    convert_to_cunumeric_ndarray,
-    ndarray,
-)
+
+from ..array import convert_to_cunumeric_ndarray, ndarray
+from ..utils import broadcast_shapes
 
 _UNARY_DOCSTRING_TEMPLATE = """{}
 

--- a/cunumeric/array.py
+++ b/cunumeric/array.py
@@ -26,7 +26,7 @@ from legate.core import Array
 from .config import UnaryOpCode, UnaryRedCode
 from .coverage import clone_class
 from .runtime import runtime
-from .utils import dot_modes
+from .utils import broadcast_shapes, dot_modes
 
 
 def add_boilerplate(*array_params: str, mutates_self: bool = False):
@@ -141,11 +141,6 @@ def add_boilerplate(*array_params: str, mutates_self: bool = False):
         return wrapper
 
     return decorator
-
-
-def broadcast_shapes(*args):
-    arrays = [np.empty(x, dtype=[]) for x in args]
-    return np.broadcast(*arrays).shape
 
 
 def convert_to_cunumeric_ndarray(obj, share=False):

--- a/cunumeric/deferred.py
+++ b/cunumeric/deferred.py
@@ -36,7 +36,7 @@ from .config import (
 from .linalg.cholesky import cholesky
 from .sort import sort
 from .thunk import NumPyThunk
-from .utils import get_arg_value_dtype
+from .utils import get_arg_value_dtype, is_advanced_indexing
 
 
 def _complex_field_dtype(dtype):
@@ -395,7 +395,7 @@ class DeferredArray(NumPyThunk):
 
     def get_item(self, key):
         # Check to see if this is advanced indexing or not
-        if self._is_advanced_indexing(key):
+        if is_advanced_indexing(key):
             # Create the indexing array
             index_array = self._create_indexing_array(key)
             # Create a new array to be the result
@@ -440,7 +440,7 @@ class DeferredArray(NumPyThunk):
     def set_item(self, key, rhs):
         assert self.dtype == rhs.dtype
         # Check to see if this is advanced indexing or not
-        if self._is_advanced_indexing(key):
+        if is_advanced_indexing(key):
             # Create the indexing array
             index_array = self._create_indexing_array(key)
             if index_array.shape != rhs.shape:

--- a/cunumeric/eager.py
+++ b/cunumeric/eager.py
@@ -17,6 +17,7 @@ import numpy as np
 
 from .config import BinaryOpCode, UnaryOpCode, UnaryRedCode
 from .thunk import NumPyThunk
+from .utils import is_advanced_indexing
 
 _UNARY_OPS = {
     UnaryOpCode.ABSOLUTE: np.absolute,
@@ -300,7 +301,7 @@ class EagerArray(NumPyThunk):
     def get_item(self, key):
         if self.deferred is not None:
             return self.deferred.get_item(key)
-        if self._is_advanced_indexing(key):
+        if is_advanced_indexing(key):
             index_key = self._create_indexing_key(key)
             out = self.array[index_key]
             result = EagerArray(self.runtime, out)
@@ -319,7 +320,7 @@ class EagerArray(NumPyThunk):
         if self.deferred is not None:
             self.deferred.set_item(key, value)
         else:
-            if self._is_advanced_indexing(key):
+            if is_advanced_indexing(key):
                 index_key = self._create_indexing_key(key)
                 if isinstance(value, EagerArray):
                     self.array[index_key] = value.array

--- a/cunumeric/module.py
+++ b/cunumeric/module.py
@@ -149,14 +149,6 @@ def add_boilerplate(*array_params: str):
     return decorator
 
 
-def _output_float_dtype(input):
-    # Floats keep their floating point kind, otherwise switch to float64
-    if input.dtype.kind in ("f", "c"):
-        return input.dtype
-    else:
-        return np.dtype(np.float64)
-
-
 #########################
 # Array creation routines
 #########################

--- a/cunumeric/runtime.py
+++ b/cunumeric/runtime.py
@@ -139,7 +139,9 @@ class Runtime(object):
         except ValueError:
             self.report_dump_csv = None
 
-    def record_api_call(self, name, location, implemented):
+    def record_api_call(
+        self, name: str, location: str, implemented: bool
+    ) -> None:
         assert self.report_coverage
         self.api_calls.append((name, location, implemented))
 

--- a/cunumeric/thunk.py
+++ b/cunumeric/thunk.py
@@ -15,8 +15,6 @@
 
 from abc import ABC, abstractmethod
 
-import numpy
-
 
 class NumPyThunk(ABC):
     """This is the base class for NumPy computations. It has methods
@@ -48,21 +46,6 @@ class NumPyThunk(ABC):
         for p in self.shape:
             s *= p
         return s
-
-    def _is_advanced_indexing(self, key, first=True):
-        if key is Ellipsis or key is None:  # np.newdim case
-            return False
-        if numpy.isscalar(key):
-            return False
-        if isinstance(key, slice):
-            return False
-        if isinstance(key, tuple):
-            for k in key:
-                if self._is_advanced_indexing(k, first=False):
-                    return True
-            return False
-        # Any other kind of thing leads to advanced indexing
-        return True
 
     # Abstract methods
 

--- a/cunumeric/thunk.py
+++ b/cunumeric/thunk.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 
-from abc import ABC, abstractmethod
+from abc import ABC, abstractmethod, abstractproperty
 
 
 class NumPyThunk(ABC):
@@ -30,11 +30,6 @@ class NumPyThunk(ABC):
         self.dtype = dtype
 
     @property
-    def storage(self):
-        """Return the Legion storage primitive for this NumPy thunk"""
-        raise NotImplementedError("Implement in derived classes")
-
-    @property
     def ndim(self):
         return len(self.shape)
 
@@ -48,6 +43,11 @@ class NumPyThunk(ABC):
         return s
 
     # Abstract methods
+
+    @abstractproperty
+    def storage(self):
+        """Return the Legion storage primitive for this NumPy thunk"""
+        ...
 
     @abstractmethod
     def __numpy_array__(self):

--- a/cunumeric/utils.py
+++ b/cunumeric/utils.py
@@ -19,6 +19,22 @@ from string import ascii_lowercase, ascii_uppercase
 
 import numpy as np
 
+_SUPPORTED_DTYPES = [
+    np.float16,
+    np.float32,
+    np.float64,
+    float,
+    np.int16,
+    np.int32,
+    np.int64,
+    int,
+    np.uint16,
+    np.uint32,
+    np.uint64,
+    np.bool_,
+    bool,
+]
+
 
 def broadcast_shapes(*args):
     arrays = [np.empty(x, dtype=[]) for x in args]
@@ -73,34 +89,10 @@ def find_last_user_frames(top_only=True):
     return "|".join(get_line_number_from_frame(f) for f in frames)
 
 
-# These are the dtypes that we currently support for cuNumeric
 def is_supported_dtype(dtype):
     if not isinstance(dtype, np.dtype):
         raise TypeError("expected a NumPy dtype")
-    base_type = dtype.type
-    if (
-        base_type == np.float16
-        or base_type == np.float32
-        or base_type == np.float64
-        or base_type == float
-    ):
-        return True
-    if (
-        base_type == np.int16
-        or base_type == np.int32
-        or base_type == np.int64
-        or base_type == int
-    ):
-        return True
-    if (
-        base_type == np.uint16
-        or base_type == np.uint32
-        or base_type == np.uint64
-    ):
-        return True
-    if base_type == np.bool_ or base_type == bool:
-        return True
-    return False
+    return dtype.type in _SUPPORTED_DTYPES
 
 
 def calculate_volume(shape):

--- a/cunumeric/utils.py
+++ b/cunumeric/utils.py
@@ -18,7 +18,7 @@ import traceback
 from functools import reduce
 from string import ascii_lowercase, ascii_uppercase
 from types import FrameType
-from typing import Any, List, Sequence, Tuple, Union
+from typing import Any, List, Sequence, Tuple, Union, cast
 
 import numpy as np
 
@@ -109,8 +109,9 @@ def get_arg_dtype(dtype: np.dtype[Any]) -> np.dtype[Any]:
     )
 
 
-def get_arg_value_dtype(dtype: np.dtype[Any]) -> Any:
-    return dtype.fields["arg_value"][0].type  # type: ignore [index]
+def get_arg_value_dtype(dtype: np.dtype[Any]) -> np.dtype[Any]:
+    dt = dtype.fields["arg_value"][0].type  # type: ignore [index]
+    return cast(np.dtype[Any], dt)
 
 
 Modes = Tuple[List[str], List[str], List[str]]

--- a/cunumeric/utils.py
+++ b/cunumeric/utils.py
@@ -111,7 +111,7 @@ def get_arg_dtype(dtype: np.dtype[Any]) -> np.dtype[Any]:
 
 def get_arg_value_dtype(dtype: np.dtype[Any]) -> np.dtype[Any]:
     dt = dtype.fields["arg_value"][0].type  # type: ignore [index]
-    return cast(np.dtype[Any], dt)
+    return cast(Any, dt)
 
 
 Modes = Tuple[List[str], List[str], List[str]]

--- a/cunumeric/utils.py
+++ b/cunumeric/utils.py
@@ -20,6 +20,11 @@ from string import ascii_lowercase, ascii_uppercase
 import numpy as np
 
 
+def broadcast_shapes(*args):
+    arrays = [np.empty(x, dtype=[]) for x in args]
+    return np.broadcast(*arrays).shape
+
+
 def is_advanced_indexing(key):
     if key is Ellipsis or key is None:  # np.newdim case
         return False

--- a/cunumeric/utils.py
+++ b/cunumeric/utils.py
@@ -20,6 +20,19 @@ from string import ascii_lowercase, ascii_uppercase
 import numpy as np
 
 
+def is_advanced_indexing(key):
+    if key is Ellipsis or key is None:  # np.newdim case
+        return False
+    if np.isscalar(key):
+        return False
+    if isinstance(key, slice):
+        return False
+    if isinstance(key, tuple):
+        return any(is_advanced_indexing(k) for k in key)
+    # Any other kind of thing leads to advanced indexing
+    return True
+
+
 def find_last_user_stacklevel():
     stacklevel = 1
     for (frame, _) in traceback.walk_stack(None):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,3 +15,60 @@ exclude = '''
     dist
 )/
 '''
+
+[tool.mypy]
+python_version = "3.10"
+mypy_path = "typings/"
+
+pretty = true
+show_error_codes = true
+show_error_context = true
+show_column_numbers = true
+
+namespace_packages = true
+ignore_missing_imports = false
+
+disallow_any_unimported = true
+disallow_any_expr = false
+disallow_any_decorated = false
+disallow_any_explicit = false
+disallow_any_generics = true
+disallow_subclassing_any = true
+
+disallow_untyped_calls = true
+disallow_untyped_defs = true
+disallow_incomplete_defs = true
+check_untyped_defs = true
+disallow_untyped_decorators = true
+no_implicit_optional = true
+strict_optional = true
+
+warn_redundant_casts = true
+warn_unused_ignores = true
+warn_no_return = true
+warn_return_any = false
+warn_unreachable = true
+
+show_none_errors = true
+ignore_errors = false
+
+allow_untyped_globals = false
+allow_redefinition = false
+implicit_reexport = true
+strict_equality = true
+
+warn_unused_configs = true
+
+# For now enable each typed module individually.
+[[tool.mypy.overrides]]
+module = [
+    "cunumeric.*",
+]
+ignore_errors = true
+
+[[tool.mypy.overrides]]
+module = [
+    "cunumeric.coverage",
+    "cunumeric.utils",
+]
+ignore_errors = false

--- a/tests/unit/cunumeric/test_utils.py
+++ b/tests/unit/cunumeric/test_utils.py
@@ -37,6 +37,20 @@ SUPPORTED_DTYPES = [
 ]
 
 
+@pytest.mark.parametrize(
+    "args, result",
+    [
+        ([(4,), (1,)], (4,)),
+        ([(2, 3), (2, 3)], (2, 3)),
+        ([(1, 2, 3), (2, 3)], (1, 2, 3)),
+        ([(2, 1, 3), (2, 3)], (2, 2, 3)),
+    ],
+)
+def test_broadcast_shapes(args, result):
+    assert m.broadcast_shapes(*args) == result
+    assert m.broadcast_shapes(*reversed(args)) == result
+
+
 class Test_is_advanced_indexing:
     def test_Ellipsis(self):
         assert not m.is_advanced_indexing(...)

--- a/tests/unit/cunumeric/test_utils.py
+++ b/tests/unit/cunumeric/test_utils.py
@@ -20,7 +20,7 @@ import cunumeric.utils as m  # module under test
 import numpy as np
 import pytest
 
-SUPPORTED_DTYPES = [
+EXPECTED_SUPPORTED_DTYPES = [
     np.float16,
     np.float32,
     np.float64,
@@ -58,7 +58,7 @@ class Test_is_advanced_indexing:
     def test_None(self):
         assert not m.is_advanced_indexing(None)
 
-    @pytest.mark.parametrize("typ", SUPPORTED_DTYPES)
+    @pytest.mark.parametrize("typ", EXPECTED_SUPPORTED_DTYPES)
     def test_np_scalar(self, typ):
         assert not m.is_advanced_indexing(typ(10))
 
@@ -122,6 +122,10 @@ class Test_find_last_user_frames:
         assert all(len(x.split(":")) == 2 for x in result.split("|"))
 
 
+def test__SUPPORTED_DTYPES():
+    assert m._SUPPORTED_DTYPES == EXPECTED_SUPPORTED_DTYPES
+
+
 class Test_is_supported_dtype:
     @pytest.mark.parametrize(
         "value", ["foo", 10, 10.2, [], (), {}, set(), None]
@@ -130,7 +134,7 @@ class Test_is_supported_dtype:
         with pytest.raises(TypeError):
             m.is_supported_dtype(value)
 
-    @pytest.mark.parametrize("value", SUPPORTED_DTYPES)
+    @pytest.mark.parametrize("value", EXPECTED_SUPPORTED_DTYPES)
     def test_supported(self, value) -> None:
         assert m.is_supported_dtype(np.dtype(value))
 

--- a/tests/unit/cunumeric/test_utils.py
+++ b/tests/unit/cunumeric/test_utils.py
@@ -37,6 +37,33 @@ SUPPORTED_DTYPES = [
 ]
 
 
+class Test_is_advanced_indexing:
+    def test_Ellipsis(self):
+        assert not m.is_advanced_indexing(...)
+
+    def test_None(self):
+        assert not m.is_advanced_indexing(None)
+
+    @pytest.mark.parametrize("typ", SUPPORTED_DTYPES)
+    def test_np_scalar(self, typ):
+        assert not m.is_advanced_indexing(typ(10))
+
+    def test_slice(self):
+        assert not m.is_advanced_indexing(slice(None, 10))
+        assert not m.is_advanced_indexing(slice(1, 10))
+        assert not m.is_advanced_indexing(slice(None, 10, 2))
+
+    def test_tuple_False(self):
+        assert not m.is_advanced_indexing((..., None, np.int32()))
+
+    def test_tuple_True(self):
+        assert m.is_advanced_indexing(([1, 2, 3], np.array([1, 2])))
+
+    def test_advanced(self):
+        assert m.is_advanced_indexing([1, 2, 3])
+        assert m.is_advanced_indexing(np.array([1, 2, 3]))
+
+
 def test_find_last_user_stacklevel() -> None:
     n = m.find_last_user_stacklevel()
     assert isinstance(n, int)


### PR DESCRIPTION
This PR is a bit of a grab bag of minor things:

* moved helpers  `broadcast_shapes` and `is_advanced_indexing` to `utils` and put under test
* removed unused cruft `_output_float_dtype`
* use `abstractproperty` on where applicable on an ABC
* made wrapping handled consistenty in `coverage`
* enabled type annotations for `coverage` and `utils`