### PR TITLE
Split up sort.cu for parallel compilation

### DIFF
--- a/src/cunumeric.mk
+++ b/src/cunumeric.mk
@@ -46,7 +46,6 @@ GEN_CPU_SRC += cunumeric/ternary/where.cc               \
 							 cunumeric/search/nonzero.cc              \
 							 cunumeric/set/unique.cc                  \
 							 cunumeric/set/unique_reduce.cc           \
-							 cunumeric/sort/sort.cc                   \
 							 cunumeric/stat/bincount.cc               \
 							 cunumeric/convolution/convolve.cc        \
 							 cunumeric/transform/flip.cc              \
@@ -82,15 +81,10 @@ GEN_CPU_SRC += cunumeric/ternary/where_omp.cc          \
 							 cunumeric/random/rand_omp.cc            \
 							 cunumeric/search/nonzero_omp.cc         \
 							 cunumeric/set/unique_omp.cc             \
-							 cunumeric/sort/sort_omp.cc              \
 							 cunumeric/stat/bincount_omp.cc          \
 							 cunumeric/convolution/convolve_omp.cc   \
 							 cunumeric/transform/flip_omp.cc
 endif
-
-GEN_CPU_SRC += cunumeric/cunumeric.cc # This must always be the last file!
-                                      # It guarantees we do our registration callback
-                                      # only after all task variants are recorded
 
 GEN_GPU_SRC += cunumeric/ternary/where.cu               \
 							 cunumeric/binary/binary_op.cu            \
@@ -121,7 +115,6 @@ GEN_GPU_SRC += cunumeric/ternary/where.cu               \
 							 cunumeric/random/rand.cu                 \
 							 cunumeric/search/nonzero.cu              \
 							 cunumeric/set/unique.cu                  \
-							 cunumeric/sort/sort.cu                   \
 							 cunumeric/stat/bincount.cu               \
 							 cunumeric/convolution/convolve.cu        \
 							 cunumeric/transform/flip.cu              \
@@ -129,3 +122,9 @@ GEN_GPU_SRC += cunumeric/ternary/where.cu               \
 							 cunumeric/cunumeric.cu
 
 GEN_DEVICE_SRC += cunumeric/convolution/convolve_callbacks.cu
+
+include cunumeric/sort/sort.mk
+
+GEN_CPU_SRC += cunumeric/cunumeric.cc # This must always be the last file!
+                                      # It guarantees we do our registration callback
+                                      # only after all task variants are recorded

--- a/src/cunumeric/sort/cub_sort.cuh
+++ b/src/cunumeric/sort/cub_sort.cuh
@@ -1,0 +1,198 @@
+/* Copyright 2022 NVIDIA Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#pragma once
+
+#include "core/data/buffer.h"
+
+#include <cub/device/device_radix_sort.cuh>
+#include <cub/device/device_segmented_radix_sort.cuh>
+
+#include <thrust/iterator/counting_iterator.h>
+#include <thrust/iterator/transform_iterator.h>
+#include <thrust/iterator/zip_iterator.h>
+
+#include "cunumeric/cuda_help.h"
+
+namespace cunumeric {
+namespace detail {
+
+using namespace legate;
+using namespace Legion;
+
+struct multiply : public thrust::unary_function<int, int> {
+  const int constant;
+
+  multiply(int _constant) : constant(_constant) {}
+
+  __host__ __device__ int operator()(int& input) const { return input * constant; }
+};
+
+template <class VAL>
+void cub_local_sort(const VAL* values_in,
+                    VAL* values_out,
+                    const int64_t* indices_in,
+                    int64_t* indices_out,
+                    const size_t volume,
+                    const size_t sort_dim_size,
+                    cudaStream_t stream)
+{
+  Buffer<VAL> keys_in;
+  const VAL* values_in_cub = values_in;
+  if (values_in == values_out) {
+    keys_in       = create_buffer<VAL>(volume, Memory::Kind::GPU_FB_MEM);
+    values_in_cub = keys_in.ptr(0);
+    CHECK_CUDA(cudaMemcpyAsync(
+      keys_in.ptr(0), values_out, sizeof(VAL) * volume, cudaMemcpyDeviceToDevice, stream));
+  }
+
+  size_t temp_storage_bytes = 0;
+  if (indices_out == nullptr) {
+    if (volume == sort_dim_size) {
+      // sort (initial call to compute buffer size)
+      cub::DeviceRadixSort::SortKeys(
+        nullptr, temp_storage_bytes, values_in_cub, values_out, volume, 0, sizeof(VAL) * 8, stream);
+      auto temp_storage =
+        create_buffer<unsigned char>(temp_storage_bytes, Memory::Kind::GPU_FB_MEM);
+      cub::DeviceRadixSort::SortKeys(temp_storage.ptr(0),
+                                     temp_storage_bytes,
+                                     values_in_cub,
+                                     values_out,
+                                     volume,
+                                     0,
+                                     sizeof(VAL) * 8,
+                                     stream);
+      temp_storage.destroy();
+    } else {
+      // segmented sort (initial call to compute buffer size)
+      // generate start/end positions for all segments via iterators to avoid allocating buffers
+      auto off_start_pos_it =
+        thrust::make_transform_iterator(thrust::make_counting_iterator(0), multiply(sort_dim_size));
+      auto off_end_pos_it =
+        thrust::make_transform_iterator(thrust::make_counting_iterator(1), multiply(sort_dim_size));
+
+      cub::DeviceSegmentedRadixSort::SortKeys(nullptr,
+                                              temp_storage_bytes,
+                                              values_in_cub,
+                                              values_out,
+                                              volume,
+                                              volume / sort_dim_size,
+                                              off_start_pos_it,
+                                              off_end_pos_it,
+                                              0,
+                                              sizeof(VAL) * 8,
+                                              stream);
+      auto temp_storage =
+        create_buffer<unsigned char>(temp_storage_bytes, Memory::Kind::GPU_FB_MEM);
+
+      cub::DeviceSegmentedRadixSort::SortKeys(temp_storage.ptr(0),
+                                              temp_storage_bytes,
+                                              values_in_cub,
+                                              values_out,
+                                              volume,
+                                              volume / sort_dim_size,
+                                              off_start_pos_it,
+                                              off_end_pos_it,
+                                              0,
+                                              sizeof(VAL) * 8,
+                                              stream);
+      temp_storage.destroy();
+    }
+  } else {
+    Buffer<int64_t> idx_in;
+    const int64_t* indices_in_cub = indices_in;
+    if (indices_in == indices_out) {
+      idx_in         = create_buffer<int64_t>(volume, Memory::Kind::GPU_FB_MEM);
+      indices_in_cub = idx_in.ptr(0);
+      CHECK_CUDA(cudaMemcpyAsync(
+        idx_in.ptr(0), indices_out, sizeof(int64_t) * volume, cudaMemcpyDeviceToDevice, stream));
+    }
+
+    if (volume == sort_dim_size) {
+      // argsort (initial call to compute buffer size)
+      cub::DeviceRadixSort::SortPairs(nullptr,
+                                      temp_storage_bytes,
+                                      values_in_cub,
+                                      values_out,
+                                      indices_in_cub,
+                                      indices_out,
+                                      volume,
+                                      0,
+                                      sizeof(VAL) * 8,
+                                      stream);
+
+      auto temp_storage =
+        create_buffer<unsigned char>(temp_storage_bytes, Memory::Kind::GPU_FB_MEM);
+
+      cub::DeviceRadixSort::SortPairs(temp_storage.ptr(0),
+                                      temp_storage_bytes,
+                                      values_in_cub,
+                                      values_out,
+                                      indices_in_cub,
+                                      indices_out,
+                                      volume,
+                                      0,
+                                      sizeof(VAL) * 8,
+                                      stream);
+      temp_storage.destroy();
+    } else {
+      // segmented argsort (initial call to compute buffer size)
+      // generate start/end positions for all segments via iterators to avoid allocating buffers
+      auto off_start_pos_it =
+        thrust::make_transform_iterator(thrust::make_counting_iterator(0), multiply(sort_dim_size));
+      auto off_end_pos_it =
+        thrust::make_transform_iterator(thrust::make_counting_iterator(1), multiply(sort_dim_size));
+
+      cub::DeviceSegmentedRadixSort::SortPairs(nullptr,
+                                               temp_storage_bytes,
+                                               values_in_cub,
+                                               values_out,
+                                               indices_in_cub,
+                                               indices_out,
+                                               volume,
+                                               volume / sort_dim_size,
+                                               off_start_pos_it,
+                                               off_end_pos_it,
+                                               0,
+                                               sizeof(VAL) * 8,
+                                               stream);
+
+      auto temp_storage =
+        create_buffer<unsigned char>(temp_storage_bytes, Memory::Kind::GPU_FB_MEM);
+
+      cub::DeviceSegmentedRadixSort::SortPairs(temp_storage.ptr(0),
+                                               temp_storage_bytes,
+                                               values_in_cub,
+                                               values_out,
+                                               indices_in_cub,
+                                               indices_out,
+                                               volume,
+                                               volume / sort_dim_size,
+                                               off_start_pos_it,
+                                               off_end_pos_it,
+                                               0,
+                                               sizeof(VAL) * 8,
+                                               stream);
+      temp_storage.destroy();
+    }
+    if (indices_in == indices_out) idx_in.destroy();
+  }
+
+  if (values_in == values_out) keys_in.destroy();
+}
+
+}  // namespace detail
+}  // namespace cunumeric

--- a/src/cunumeric/sort/cub_sort.h
+++ b/src/cunumeric/sort/cub_sort.h
@@ -1,0 +1,117 @@
+/* Copyright 2022 NVIDIA Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#pragma once
+
+namespace cunumeric {
+
+void cub_local_sort(const bool* values_in,
+                    bool* values_out,
+                    const int64_t* indices_in,
+                    int64_t* indices_out,
+                    const size_t volume,
+                    const size_t sort_dim_size,
+                    cudaStream_t stream);
+
+void cub_local_sort(const int8_t* values_in,
+                    int8_t* values_out,
+                    const int64_t* indices_in,
+                    int64_t* indices_out,
+                    const size_t volume,
+                    const size_t sort_dim_size,
+                    cudaStream_t stream);
+
+void cub_local_sort(const int16_t* values_in,
+                    int16_t* values_out,
+                    const int64_t* indices_in,
+                    int64_t* indices_out,
+                    const size_t volume,
+                    const size_t sort_dim_size,
+                    cudaStream_t stream);
+
+void cub_local_sort(const int32_t* values_in,
+                    int32_t* values_out,
+                    const int64_t* indices_in,
+                    int64_t* indices_out,
+                    const size_t volume,
+                    const size_t sort_dim_size,
+                    cudaStream_t stream);
+
+void cub_local_sort(const int64_t* values_in,
+                    int64_t* values_out,
+                    const int64_t* indices_in,
+                    int64_t* indices_out,
+                    const size_t volume,
+                    const size_t sort_dim_size,
+                    cudaStream_t stream);
+
+void cub_local_sort(const uint8_t* values_in,
+                    uint8_t* values_out,
+                    const int64_t* indices_in,
+                    int64_t* indices_out,
+                    const size_t volume,
+                    const size_t sort_dim_size,
+                    cudaStream_t stream);
+
+void cub_local_sort(const uint16_t* values_in,
+                    uint16_t* values_out,
+                    const int64_t* indices_in,
+                    int64_t* indices_out,
+                    const size_t volume,
+                    const size_t sort_dim_size,
+                    cudaStream_t stream);
+
+void cub_local_sort(const uint32_t* values_in,
+                    uint32_t* values_out,
+                    const int64_t* indices_in,
+                    int64_t* indices_out,
+                    const size_t volume,
+                    const size_t sort_dim_size,
+                    cudaStream_t stream);
+
+void cub_local_sort(const uint64_t* values_in,
+                    uint64_t* values_out,
+                    const int64_t* indices_in,
+                    int64_t* indices_out,
+                    const size_t volume,
+                    const size_t sort_dim_size,
+                    cudaStream_t stream);
+
+void cub_local_sort(const __half* values_in,
+                    __half* values_out,
+                    const int64_t* indices_in,
+                    int64_t* indices_out,
+                    const size_t volume,
+                    const size_t sort_dim_size,
+                    cudaStream_t stream);
+
+void cub_local_sort(const float* values_in,
+                    float* values_out,
+                    const int64_t* indices_in,
+                    int64_t* indices_out,
+                    const size_t volume,
+                    const size_t sort_dim_size,
+                    cudaStream_t stream);
+
+void cub_local_sort(const double* values_in,
+                    double* values_out,
+                    const int64_t* indices_in,
+                    int64_t* indices_out,
+                    const size_t volume,
+                    const size_t sort_dim_size,
+                    cudaStream_t stream);
+
+}  // namespace cunumeric

--- a/src/cunumeric/sort/cub_sort_bool.cu
+++ b/src/cunumeric/sort/cub_sort_bool.cu
@@ -14,24 +14,20 @@
  *
  */
 
-#pragma once
-
-#include "legate.h"
+#include "cunumeric/sort/cub_sort.cuh"
 
 namespace cunumeric {
 
-class ThrustAllocator : public legate::ScopedAllocator {
- public:
-  using value_type = char;
-
-  ThrustAllocator(Legion::Memory::Kind kind) : legate::ScopedAllocator(kind) {}
-
-  char* allocate(size_t num_bytes)
-  {
-    return static_cast<char*>(ScopedAllocator::allocate(num_bytes));
-  }
-
-  void deallocate(char* ptr, size_t n) { ScopedAllocator::deallocate(ptr); }
-};
+void cub_local_sort(const bool* values_in,
+                    bool* values_out,
+                    const int64_t* indices_in,
+                    int64_t* indices_out,
+                    const size_t volume,
+                    const size_t sort_dim_size,
+                    cudaStream_t stream)
+{
+  detail::cub_local_sort(
+    values_in, values_out, indices_in, indices_out, volume, sort_dim_size, stream);
+}
 
 }  // namespace cunumeric

--- a/src/cunumeric/sort/cub_sort_double.cu
+++ b/src/cunumeric/sort/cub_sort_double.cu
@@ -14,24 +14,20 @@
  *
  */
 
-#pragma once
-
-#include "legate.h"
+#include "cunumeric/sort/cub_sort.cuh"
 
 namespace cunumeric {
 
-class ThrustAllocator : public legate::ScopedAllocator {
- public:
-  using value_type = char;
-
-  ThrustAllocator(Legion::Memory::Kind kind) : legate::ScopedAllocator(kind) {}
-
-  char* allocate(size_t num_bytes)
-  {
-    return static_cast<char*>(ScopedAllocator::allocate(num_bytes));
-  }
-
-  void deallocate(char* ptr, size_t n) { ScopedAllocator::deallocate(ptr); }
-};
+void cub_local_sort(const double* values_in,
+                    double* values_out,
+                    const int64_t* indices_in,
+                    int64_t* indices_out,
+                    const size_t volume,
+                    const size_t sort_dim_size,
+                    cudaStream_t stream)
+{
+  detail::cub_local_sort(
+    values_in, values_out, indices_in, indices_out, volume, sort_dim_size, stream);
+}
 
 }  // namespace cunumeric

--- a/src/cunumeric/sort/cub_sort_float.cu
+++ b/src/cunumeric/sort/cub_sort_float.cu
@@ -14,24 +14,20 @@
  *
  */
 
-#pragma once
-
-#include "legate.h"
+#include "cunumeric/sort/cub_sort.cuh"
 
 namespace cunumeric {
 
-class ThrustAllocator : public legate::ScopedAllocator {
- public:
-  using value_type = char;
-
-  ThrustAllocator(Legion::Memory::Kind kind) : legate::ScopedAllocator(kind) {}
-
-  char* allocate(size_t num_bytes)
-  {
-    return static_cast<char*>(ScopedAllocator::allocate(num_bytes));
-  }
-
-  void deallocate(char* ptr, size_t n) { ScopedAllocator::deallocate(ptr); }
-};
+void cub_local_sort(const float* values_in,
+                    float* values_out,
+                    const int64_t* indices_in,
+                    int64_t* indices_out,
+                    const size_t volume,
+                    const size_t sort_dim_size,
+                    cudaStream_t stream)
+{
+  detail::cub_local_sort(
+    values_in, values_out, indices_in, indices_out, volume, sort_dim_size, stream);
+}
 
 }  // namespace cunumeric

--- a/src/cunumeric/sort/cub_sort_half.cu
+++ b/src/cunumeric/sort/cub_sort_half.cu
@@ -14,24 +14,20 @@
  *
  */
 
-#pragma once
-
-#include "legate.h"
+#include "cunumeric/sort/cub_sort.cuh"
 
 namespace cunumeric {
 
-class ThrustAllocator : public legate::ScopedAllocator {
- public:
-  using value_type = char;
-
-  ThrustAllocator(Legion::Memory::Kind kind) : legate::ScopedAllocator(kind) {}
-
-  char* allocate(size_t num_bytes)
-  {
-    return static_cast<char*>(ScopedAllocator::allocate(num_bytes));
-  }
-
-  void deallocate(char* ptr, size_t n) { ScopedAllocator::deallocate(ptr); }
-};
+void cub_local_sort(const __half* values_in,
+                    __half* values_out,
+                    const int64_t* indices_in,
+                    int64_t* indices_out,
+                    const size_t volume,
+                    const size_t sort_dim_size,
+                    cudaStream_t stream)
+{
+  detail::cub_local_sort(
+    values_in, values_out, indices_in, indices_out, volume, sort_dim_size, stream);
+}
 
 }  // namespace cunumeric

--- a/src/cunumeric/sort/cub_sort_int16.cu
+++ b/src/cunumeric/sort/cub_sort_int16.cu
@@ -14,24 +14,20 @@
  *
  */
 
-#pragma once
-
-#include "legate.h"
+#include "cunumeric/sort/cub_sort.cuh"
 
 namespace cunumeric {
 
-class ThrustAllocator : public legate::ScopedAllocator {
- public:
-  using value_type = char;
-
-  ThrustAllocator(Legion::Memory::Kind kind) : legate::ScopedAllocator(kind) {}
-
-  char* allocate(size_t num_bytes)
-  {
-    return static_cast<char*>(ScopedAllocator::allocate(num_bytes));
-  }
-
-  void deallocate(char* ptr, size_t n) { ScopedAllocator::deallocate(ptr); }
-};
+void cub_local_sort(const int16_t* values_in,
+                    int16_t* values_out,
+                    const int64_t* indices_in,
+                    int64_t* indices_out,
+                    const size_t volume,
+                    const size_t sort_dim_size,
+                    cudaStream_t stream)
+{
+  detail::cub_local_sort(
+    values_in, values_out, indices_in, indices_out, volume, sort_dim_size, stream);
+}
 
 }  // namespace cunumeric

--- a/src/cunumeric/sort/cub_sort_int32.cu
+++ b/src/cunumeric/sort/cub_sort_int32.cu
@@ -14,24 +14,20 @@
  *
  */
 
-#pragma once
-
-#include "legate.h"
+#include "cunumeric/sort/cub_sort.cuh"
 
 namespace cunumeric {
 
-class ThrustAllocator : public legate::ScopedAllocator {
- public:
-  using value_type = char;
-
-  ThrustAllocator(Legion::Memory::Kind kind) : legate::ScopedAllocator(kind) {}
-
-  char* allocate(size_t num_bytes)
-  {
-    return static_cast<char*>(ScopedAllocator::allocate(num_bytes));
-  }
-
-  void deallocate(char* ptr, size_t n) { ScopedAllocator::deallocate(ptr); }
-};
+void cub_local_sort(const int32_t* values_in,
+                    int32_t* values_out,
+                    const int64_t* indices_in,
+                    int64_t* indices_out,
+                    const size_t volume,
+                    const size_t sort_dim_size,
+                    cudaStream_t stream)
+{
+  detail::cub_local_sort(
+    values_in, values_out, indices_in, indices_out, volume, sort_dim_size, stream);
+}
 
 }  // namespace cunumeric

--- a/src/cunumeric/sort/cub_sort_int64.cu
+++ b/src/cunumeric/sort/cub_sort_int64.cu
@@ -14,24 +14,20 @@
  *
  */
 
-#pragma once
-
-#include "legate.h"
+#include "cunumeric/sort/cub_sort.cuh"
 
 namespace cunumeric {
 
-class ThrustAllocator : public legate::ScopedAllocator {
- public:
-  using value_type = char;
-
-  ThrustAllocator(Legion::Memory::Kind kind) : legate::ScopedAllocator(kind) {}
-
-  char* allocate(size_t num_bytes)
-  {
-    return static_cast<char*>(ScopedAllocator::allocate(num_bytes));
-  }
-
-  void deallocate(char* ptr, size_t n) { ScopedAllocator::deallocate(ptr); }
-};
+void cub_local_sort(const int64_t* values_in,
+                    int64_t* values_out,
+                    const int64_t* indices_in,
+                    int64_t* indices_out,
+                    const size_t volume,
+                    const size_t sort_dim_size,
+                    cudaStream_t stream)
+{
+  detail::cub_local_sort(
+    values_in, values_out, indices_in, indices_out, volume, sort_dim_size, stream);
+}
 
 }  // namespace cunumeric

--- a/src/cunumeric/sort/cub_sort_int8.cu
+++ b/src/cunumeric/sort/cub_sort_int8.cu
@@ -14,24 +14,20 @@
  *
  */
 
-#pragma once
-
-#include "legate.h"
+#include "cunumeric/sort/cub_sort.cuh"
 
 namespace cunumeric {
 
-class ThrustAllocator : public legate::ScopedAllocator {
- public:
-  using value_type = char;
-
-  ThrustAllocator(Legion::Memory::Kind kind) : legate::ScopedAllocator(kind) {}
-
-  char* allocate(size_t num_bytes)
-  {
-    return static_cast<char*>(ScopedAllocator::allocate(num_bytes));
-  }
-
-  void deallocate(char* ptr, size_t n) { ScopedAllocator::deallocate(ptr); }
-};
+void cub_local_sort(const int8_t* values_in,
+                    int8_t* values_out,
+                    const int64_t* indices_in,
+                    int64_t* indices_out,
+                    const size_t volume,
+                    const size_t sort_dim_size,
+                    cudaStream_t stream)
+{
+  detail::cub_local_sort(
+    values_in, values_out, indices_in, indices_out, volume, sort_dim_size, stream);
+}
 
 }  // namespace cunumeric

--- a/src/cunumeric/sort/cub_sort_uint16.cu
+++ b/src/cunumeric/sort/cub_sort_uint16.cu
@@ -14,24 +14,20 @@
  *
  */
 
-#pragma once
-
-#include "legate.h"
+#include "cunumeric/sort/cub_sort.cuh"
 
 namespace cunumeric {
 
-class ThrustAllocator : public legate::ScopedAllocator {
- public:
-  using value_type = char;
-
-  ThrustAllocator(Legion::Memory::Kind kind) : legate::ScopedAllocator(kind) {}
-
-  char* allocate(size_t num_bytes)
-  {
-    return static_cast<char*>(ScopedAllocator::allocate(num_bytes));
-  }
-
-  void deallocate(char* ptr, size_t n) { ScopedAllocator::deallocate(ptr); }
-};
+void cub_local_sort(const uint16_t* values_in,
+                    uint16_t* values_out,
+                    const int64_t* indices_in,
+                    int64_t* indices_out,
+                    const size_t volume,
+                    const size_t sort_dim_size,
+                    cudaStream_t stream)
+{
+  detail::cub_local_sort(
+    values_in, values_out, indices_in, indices_out, volume, sort_dim_size, stream);
+}
 
 }  // namespace cunumeric

--- a/src/cunumeric/sort/cub_sort_uint32.cu
+++ b/src/cunumeric/sort/cub_sort_uint32.cu
@@ -14,24 +14,20 @@
  *
  */
 
-#pragma once
-
-#include "legate.h"
+#include "cunumeric/sort/cub_sort.cuh"
 
 namespace cunumeric {
 
-class ThrustAllocator : public legate::ScopedAllocator {
- public:
-  using value_type = char;
-
-  ThrustAllocator(Legion::Memory::Kind kind) : legate::ScopedAllocator(kind) {}
-
-  char* allocate(size_t num_bytes)
-  {
-    return static_cast<char*>(ScopedAllocator::allocate(num_bytes));
-  }
-
-  void deallocate(char* ptr, size_t n) { ScopedAllocator::deallocate(ptr); }
-};
+void cub_local_sort(const uint32_t* values_in,
+                    uint32_t* values_out,
+                    const int64_t* indices_in,
+                    int64_t* indices_out,
+                    const size_t volume,
+                    const size_t sort_dim_size,
+                    cudaStream_t stream)
+{
+  detail::cub_local_sort(
+    values_in, values_out, indices_in, indices_out, volume, sort_dim_size, stream);
+}
 
 }  // namespace cunumeric

--- a/src/cunumeric/sort/cub_sort_uint64.cu
+++ b/src/cunumeric/sort/cub_sort_uint64.cu
@@ -14,24 +14,20 @@
  *
  */
 
-#pragma once
-
-#include "legate.h"
+#include "cunumeric/sort/cub_sort.cuh"
 
 namespace cunumeric {
 
-class ThrustAllocator : public legate::ScopedAllocator {
- public:
-  using value_type = char;
-
-  ThrustAllocator(Legion::Memory::Kind kind) : legate::ScopedAllocator(kind) {}
-
-  char* allocate(size_t num_bytes)
-  {
-    return static_cast<char*>(ScopedAllocator::allocate(num_bytes));
-  }
-
-  void deallocate(char* ptr, size_t n) { ScopedAllocator::deallocate(ptr); }
-};
+void cub_local_sort(const uint64_t* values_in,
+                    uint64_t* values_out,
+                    const int64_t* indices_in,
+                    int64_t* indices_out,
+                    const size_t volume,
+                    const size_t sort_dim_size,
+                    cudaStream_t stream)
+{
+  detail::cub_local_sort(
+    values_in, values_out, indices_in, indices_out, volume, sort_dim_size, stream);
+}
 
 }  // namespace cunumeric

--- a/src/cunumeric/sort/cub_sort_uint8.cu
+++ b/src/cunumeric/sort/cub_sort_uint8.cu
@@ -14,24 +14,20 @@
  *
  */
 
-#pragma once
-
-#include "legate.h"
+#include "cunumeric/sort/cub_sort.cuh"
 
 namespace cunumeric {
 
-class ThrustAllocator : public legate::ScopedAllocator {
- public:
-  using value_type = char;
-
-  ThrustAllocator(Legion::Memory::Kind kind) : legate::ScopedAllocator(kind) {}
-
-  char* allocate(size_t num_bytes)
-  {
-    return static_cast<char*>(ScopedAllocator::allocate(num_bytes));
-  }
-
-  void deallocate(char* ptr, size_t n) { ScopedAllocator::deallocate(ptr); }
-};
+void cub_local_sort(const uint8_t* values_in,
+                    uint8_t* values_out,
+                    const int64_t* indices_in,
+                    int64_t* indices_out,
+                    const size_t volume,
+                    const size_t sort_dim_size,
+                    cudaStream_t stream)
+{
+  detail::cub_local_sort(
+    values_in, values_out, indices_in, indices_out, volume, sort_dim_size, stream);
+}
 
 }  // namespace cunumeric

--- a/src/cunumeric/sort/sort.cu
+++ b/src/cunumeric/sort/sort.cu
@@ -16,17 +16,15 @@
 
 #include "cunumeric/sort/sort.h"
 #include "cunumeric/sort/sort_template.inl"
+#include "cunumeric/sort/cub_sort.h"
+#include "cunumeric/sort/thrust_sort.h"
 #include "cunumeric/utilities/thrust_allocator.h"
 
-#include <thrust/scan.h>
-#include <thrust/sort.h>
-#include <thrust/device_vector.h>
-#include <thrust/iterator/zip_iterator.h>
 #include <thrust/binary_search.h>
-#include <thrust/tuple.h>
 #include <thrust/execution_policy.h>
-#include <cub/device/device_radix_sort.cuh>
-#include <cub/device/device_segmented_radix_sort.cuh>
+#include <thrust/sequence.h>
+#include <thrust/iterator/transform_iterator.h>
+
 #include <cub/thread/thread_search.cuh>
 
 #include "cunumeric/cuda_help.h"
@@ -37,258 +35,6 @@
 #define SEGMENT_THRESHOLD_RADIX_SORT 400
 
 namespace cunumeric {
-
-using namespace Legion;
-
-struct multiply : public thrust::unary_function<int, int> {
-  const int constant;
-
-  multiply(int _constant) : constant(_constant) {}
-
-  __host__ __device__ int operator()(int& input) const { return input * constant; }
-};
-
-template <class VAL>
-void cub_local_sort(const VAL* values_in,
-                    VAL* values_out,
-                    const int64_t* indices_in,
-                    int64_t* indices_out,
-                    const size_t volume,
-                    const size_t sort_dim_size,
-                    cudaStream_t stream)
-{
-  Buffer<VAL> keys_in;
-  const VAL* values_in_cub = values_in;
-  if (values_in == values_out) {
-    keys_in       = create_buffer<VAL>(volume, Legion::Memory::Kind::GPU_FB_MEM);
-    values_in_cub = keys_in.ptr(0);
-    CHECK_CUDA(cudaMemcpyAsync(
-      keys_in.ptr(0), values_out, sizeof(VAL) * volume, cudaMemcpyDeviceToDevice, stream));
-  }
-
-  size_t temp_storage_bytes = 0;
-  if (indices_out == nullptr) {
-    if (volume == sort_dim_size) {
-      // sort (initial call to compute buffer size)
-      cub::DeviceRadixSort::SortKeys(
-        nullptr, temp_storage_bytes, values_in_cub, values_out, volume, 0, sizeof(VAL) * 8, stream);
-      auto temp_storage =
-        create_buffer<unsigned char>(temp_storage_bytes, Legion::Memory::Kind::GPU_FB_MEM);
-      cub::DeviceRadixSort::SortKeys(temp_storage.ptr(0),
-                                     temp_storage_bytes,
-                                     values_in_cub,
-                                     values_out,
-                                     volume,
-                                     0,
-                                     sizeof(VAL) * 8,
-                                     stream);
-      temp_storage.destroy();
-    } else {
-      // segmented sort (initial call to compute buffer size)
-      // generate start/end positions for all segments via iterators to avoid allocating buffers
-      auto off_start_pos_it =
-        thrust::make_transform_iterator(thrust::make_counting_iterator(0), multiply(sort_dim_size));
-      auto off_end_pos_it =
-        thrust::make_transform_iterator(thrust::make_counting_iterator(1), multiply(sort_dim_size));
-
-      cub::DeviceSegmentedRadixSort::SortKeys(nullptr,
-                                              temp_storage_bytes,
-                                              values_in_cub,
-                                              values_out,
-                                              volume,
-                                              volume / sort_dim_size,
-                                              off_start_pos_it,
-                                              off_end_pos_it,
-                                              0,
-                                              sizeof(VAL) * 8,
-                                              stream);
-      auto temp_storage =
-        create_buffer<unsigned char>(temp_storage_bytes, Legion::Memory::Kind::GPU_FB_MEM);
-
-      cub::DeviceSegmentedRadixSort::SortKeys(temp_storage.ptr(0),
-                                              temp_storage_bytes,
-                                              values_in_cub,
-                                              values_out,
-                                              volume,
-                                              volume / sort_dim_size,
-                                              off_start_pos_it,
-                                              off_end_pos_it,
-                                              0,
-                                              sizeof(VAL) * 8,
-                                              stream);
-      temp_storage.destroy();
-    }
-  } else {
-    Buffer<int64_t> idx_in;
-    const int64_t* indices_in_cub = indices_in;
-    if (indices_in == indices_out) {
-      idx_in         = create_buffer<int64_t>(volume, Legion::Memory::Kind::GPU_FB_MEM);
-      indices_in_cub = idx_in.ptr(0);
-      CHECK_CUDA(cudaMemcpyAsync(
-        idx_in.ptr(0), indices_out, sizeof(int64_t) * volume, cudaMemcpyDeviceToDevice, stream));
-    }
-
-    if (volume == sort_dim_size) {
-      // argsort (initial call to compute buffer size)
-      cub::DeviceRadixSort::SortPairs(nullptr,
-                                      temp_storage_bytes,
-                                      values_in_cub,
-                                      values_out,
-                                      indices_in_cub,
-                                      indices_out,
-                                      volume,
-                                      0,
-                                      sizeof(VAL) * 8,
-                                      stream);
-
-      auto temp_storage =
-        create_buffer<unsigned char>(temp_storage_bytes, Legion::Memory::Kind::GPU_FB_MEM);
-
-      cub::DeviceRadixSort::SortPairs(temp_storage.ptr(0),
-                                      temp_storage_bytes,
-                                      values_in_cub,
-                                      values_out,
-                                      indices_in_cub,
-                                      indices_out,
-                                      volume,
-                                      0,
-                                      sizeof(VAL) * 8,
-                                      stream);
-      temp_storage.destroy();
-    } else {
-      // segmented argsort (initial call to compute buffer size)
-      // generate start/end positions for all segments via iterators to avoid allocating buffers
-      auto off_start_pos_it =
-        thrust::make_transform_iterator(thrust::make_counting_iterator(0), multiply(sort_dim_size));
-      auto off_end_pos_it =
-        thrust::make_transform_iterator(thrust::make_counting_iterator(1), multiply(sort_dim_size));
-
-      cub::DeviceSegmentedRadixSort::SortPairs(nullptr,
-                                               temp_storage_bytes,
-                                               values_in_cub,
-                                               values_out,
-                                               indices_in_cub,
-                                               indices_out,
-                                               volume,
-                                               volume / sort_dim_size,
-                                               off_start_pos_it,
-                                               off_end_pos_it,
-                                               0,
-                                               sizeof(VAL) * 8,
-                                               stream);
-
-      auto temp_storage =
-        create_buffer<unsigned char>(temp_storage_bytes, Legion::Memory::Kind::GPU_FB_MEM);
-
-      cub::DeviceSegmentedRadixSort::SortPairs(temp_storage.ptr(0),
-                                               temp_storage_bytes,
-                                               values_in_cub,
-                                               values_out,
-                                               indices_in_cub,
-                                               indices_out,
-                                               volume,
-                                               volume / sort_dim_size,
-                                               off_start_pos_it,
-                                               off_end_pos_it,
-                                               0,
-                                               sizeof(VAL) * 8,
-                                               stream);
-      temp_storage.destroy();
-    }
-    if (indices_in == indices_out) idx_in.destroy();
-  }
-
-  if (values_in == values_out) keys_in.destroy();
-}
-
-template <class VAL>
-void thrust_local_sort(const VAL* values_in,
-                       VAL* values_out,
-                       const int64_t* indices_in,
-                       int64_t* indices_out,
-                       const size_t volume,
-                       const size_t sort_dim_size,
-                       const bool stable,
-                       cudaStream_t stream)
-{
-  auto alloc       = ThrustAllocator(Memory::GPU_FB_MEM);
-  auto exec_policy = thrust::cuda::par(alloc).on(stream);
-
-  if (values_in != values_out) {
-    // not in-place --> need a copy
-    CHECK_CUDA(cudaMemcpyAsync(
-      values_out, values_in, sizeof(VAL) * volume, cudaMemcpyDeviceToDevice, stream));
-  }
-  if (indices_in != indices_out) {
-    // not in-place --> need a copy
-    CHECK_CUDA(cudaMemcpyAsync(
-      indices_out, values_in, sizeof(int64_t) * volume, cudaMemcpyDeviceToDevice, stream));
-  }
-
-  if (indices_out == nullptr) {
-    if (volume == sort_dim_size) {
-      if (stable) {
-        thrust::stable_sort(exec_policy, values_out, values_out + volume);
-      } else {
-        thrust::sort(exec_policy, values_out, values_out + volume);
-      }
-    } else {
-      auto sort_id = create_buffer<uint64_t>(volume, Legion::Memory::Kind::GPU_FB_MEM);
-      // init combined keys
-      thrust::transform(exec_policy,
-                        thrust::make_counting_iterator<uint64_t>(0),
-                        thrust::make_counting_iterator<uint64_t>(volume),
-                        thrust::make_constant_iterator<uint64_t>(sort_dim_size),
-                        sort_id.ptr(0),
-                        thrust::divides<uint64_t>());
-      auto combined = thrust::make_zip_iterator(thrust::make_tuple(sort_id.ptr(0), values_out));
-
-      if (stable) {
-        thrust::stable_sort(
-          exec_policy, combined, combined + volume, thrust::less<thrust::tuple<size_t, VAL>>());
-      } else {
-        thrust::sort(
-          exec_policy, combined, combined + volume, thrust::less<thrust::tuple<size_t, VAL>>());
-      }
-
-      sort_id.destroy();
-    }
-  } else {
-    if (volume == sort_dim_size) {
-      if (stable) {
-        thrust::stable_sort_by_key(exec_policy, values_out, values_out + volume, indices_out);
-      } else {
-        thrust::sort_by_key(exec_policy, values_out, values_out + volume, indices_out);
-      }
-    } else {
-      auto sort_id = create_buffer<uint64_t>(volume, Legion::Memory::Kind::GPU_FB_MEM);
-      // init combined keys
-      thrust::transform(exec_policy,
-                        thrust::make_counting_iterator<uint64_t>(0),
-                        thrust::make_counting_iterator<uint64_t>(volume),
-                        thrust::make_constant_iterator<uint64_t>(sort_dim_size),
-                        sort_id.ptr(0),
-                        thrust::divides<uint64_t>());
-      auto combined = thrust::make_zip_iterator(thrust::make_tuple(sort_id.ptr(0), values_out));
-
-      if (stable) {
-        thrust::stable_sort_by_key(exec_policy,
-                                   combined,
-                                   combined + volume,
-                                   indices_out,
-                                   thrust::less<thrust::tuple<size_t, VAL>>());
-      } else {
-        thrust::sort_by_key(exec_policy,
-                            combined,
-                            combined + volume,
-                            indices_out,
-                            thrust::less<thrust::tuple<size_t, VAL>>());
-      }
-
-      sort_id.destroy();
-    }
-  }
-}
 
 template <LegateTypeCode CODE>
 struct support_cub : std::true_type {
@@ -313,10 +59,9 @@ void local_sort(const legate_type_of<CODE>* values_in,
   using VAL = legate_type_of<CODE>;
   // fallback to thrust approach as segmented radix sort is not suited for small segments
   if (volume == sort_dim_size || sort_dim_size > SEGMENT_THRESHOLD_RADIX_SORT) {
-    cub_local_sort<VAL>(
-      values_in, values_out, indices_in, indices_out, volume, sort_dim_size, stream);
+    cub_local_sort(values_in, values_out, indices_in, indices_out, volume, sort_dim_size, stream);
   } else {
-    thrust_local_sort<VAL>(
+    thrust_local_sort(
       values_in, values_out, indices_in, indices_out, volume, sort_dim_size, stable, stream);
   }
 }
@@ -332,7 +77,7 @@ void local_sort(const legate_type_of<CODE>* values_in,
                 cudaStream_t stream)
 {
   using VAL = legate_type_of<CODE>;
-  thrust_local_sort<VAL>(
+  thrust_local_sort(
     values_in, values_out, indices_in, indices_out, volume, sort_dim_size, stable, stream);
 }
 

--- a/src/cunumeric/sort/sort.mk
+++ b/src/cunumeric/sort/sort.mk
@@ -1,0 +1,48 @@
+# Copyright 2022 NVIDIA Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+GEN_CPU_SRC += cunumeric/sort/sort.cc
+
+ifeq ($(strip $(USE_OPENMP)),1)
+GEN_CPU_SRC += cunumeric/sort/sort_omp.cc
+endif
+
+GEN_GPU_SRC += cunumeric/sort/sort.cu                   \
+							 cunumeric/sort/cub_sort_bool.cu          \
+							 cunumeric/sort/cub_sort_int8.cu          \
+							 cunumeric/sort/cub_sort_int16.cu         \
+							 cunumeric/sort/cub_sort_int32.cu         \
+							 cunumeric/sort/cub_sort_int64.cu         \
+							 cunumeric/sort/cub_sort_uint8.cu         \
+							 cunumeric/sort/cub_sort_uint16.cu        \
+							 cunumeric/sort/cub_sort_uint32.cu        \
+							 cunumeric/sort/cub_sort_uint64.cu        \
+							 cunumeric/sort/cub_sort_half.cu          \
+							 cunumeric/sort/cub_sort_float.cu         \
+							 cunumeric/sort/cub_sort_double.cu        \
+							 cunumeric/sort/thrust_sort_bool.cu       \
+							 cunumeric/sort/thrust_sort_int8.cu       \
+							 cunumeric/sort/thrust_sort_int16.cu      \
+							 cunumeric/sort/thrust_sort_int32.cu      \
+							 cunumeric/sort/thrust_sort_int64.cu      \
+							 cunumeric/sort/thrust_sort_uint8.cu      \
+							 cunumeric/sort/thrust_sort_uint16.cu     \
+							 cunumeric/sort/thrust_sort_uint32.cu     \
+							 cunumeric/sort/thrust_sort_uint64.cu     \
+							 cunumeric/sort/thrust_sort_half.cu       \
+							 cunumeric/sort/thrust_sort_float.cu      \
+							 cunumeric/sort/thrust_sort_double.cu     \
+							 cunumeric/sort/thrust_sort_complex64.cu  \
+							 cunumeric/sort/thrust_sort_complex128.cu

--- a/src/cunumeric/sort/thrust_sort.cuh
+++ b/src/cunumeric/sort/thrust_sort.cuh
@@ -1,0 +1,124 @@
+/* Copyright 2022 NVIDIA Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#pragma once
+
+#include "core/data/buffer.h"
+#include "cunumeric/utilities/thrust_allocator.h"
+
+#include <thrust/sort.h>
+#include <thrust/iterator/zip_iterator.h>
+#include <thrust/execution_policy.h>
+
+#include "cunumeric/cuda_help.h"
+
+namespace cunumeric {
+namespace detail {
+
+using namespace legate;
+using namespace Legion;
+
+template <class VAL>
+void thrust_local_sort(const VAL* values_in,
+                       VAL* values_out,
+                       const int64_t* indices_in,
+                       int64_t* indices_out,
+                       const size_t volume,
+                       const size_t sort_dim_size,
+                       const bool stable,
+                       cudaStream_t stream)
+{
+  auto alloc       = ThrustAllocator(Memory::GPU_FB_MEM);
+  auto exec_policy = thrust::cuda::par(alloc).on(stream);
+
+  if (values_in != values_out) {
+    // not in-place --> need a copy
+    CHECK_CUDA(cudaMemcpyAsync(
+      values_out, values_in, sizeof(VAL) * volume, cudaMemcpyDeviceToDevice, stream));
+  }
+  if (indices_in != indices_out) {
+    // not in-place --> need a copy
+    CHECK_CUDA(cudaMemcpyAsync(
+      indices_out, values_in, sizeof(int64_t) * volume, cudaMemcpyDeviceToDevice, stream));
+  }
+
+  if (indices_out == nullptr) {
+    if (volume == sort_dim_size) {
+      if (stable) {
+        thrust::stable_sort(exec_policy, values_out, values_out + volume);
+      } else {
+        thrust::sort(exec_policy, values_out, values_out + volume);
+      }
+    } else {
+      auto sort_id = create_buffer<uint64_t>(volume, Legion::Memory::Kind::GPU_FB_MEM);
+      // init combined keys
+      thrust::transform(exec_policy,
+                        thrust::make_counting_iterator<uint64_t>(0),
+                        thrust::make_counting_iterator<uint64_t>(volume),
+                        thrust::make_constant_iterator<uint64_t>(sort_dim_size),
+                        sort_id.ptr(0),
+                        thrust::divides<uint64_t>());
+      auto combined = thrust::make_zip_iterator(thrust::make_tuple(sort_id.ptr(0), values_out));
+
+      if (stable) {
+        thrust::stable_sort(
+          exec_policy, combined, combined + volume, thrust::less<thrust::tuple<size_t, VAL>>());
+      } else {
+        thrust::sort(
+          exec_policy, combined, combined + volume, thrust::less<thrust::tuple<size_t, VAL>>());
+      }
+
+      sort_id.destroy();
+    }
+  } else {
+    if (volume == sort_dim_size) {
+      if (stable) {
+        thrust::stable_sort_by_key(exec_policy, values_out, values_out + volume, indices_out);
+      } else {
+        thrust::sort_by_key(exec_policy, values_out, values_out + volume, indices_out);
+      }
+    } else {
+      auto sort_id = create_buffer<uint64_t>(volume, Legion::Memory::Kind::GPU_FB_MEM);
+      // init combined keys
+      thrust::transform(exec_policy,
+                        thrust::make_counting_iterator<uint64_t>(0),
+                        thrust::make_counting_iterator<uint64_t>(volume),
+                        thrust::make_constant_iterator<uint64_t>(sort_dim_size),
+                        sort_id.ptr(0),
+                        thrust::divides<uint64_t>());
+      auto combined = thrust::make_zip_iterator(thrust::make_tuple(sort_id.ptr(0), values_out));
+
+      if (stable) {
+        thrust::stable_sort_by_key(exec_policy,
+                                   combined,
+                                   combined + volume,
+                                   indices_out,
+                                   thrust::less<thrust::tuple<size_t, VAL>>());
+      } else {
+        thrust::sort_by_key(exec_policy,
+                            combined,
+                            combined + volume,
+                            indices_out,
+                            thrust::less<thrust::tuple<size_t, VAL>>());
+      }
+
+      sort_id.destroy();
+    }
+  }
+}
+
+}  // namespace detail
+}  // namespace cunumeric

--- a/src/cunumeric/sort/thrust_sort.h
+++ b/src/cunumeric/sort/thrust_sort.h
@@ -1,0 +1,147 @@
+/* Copyright 2022 NVIDIA Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#pragma once
+
+namespace cunumeric {
+
+void thrust_local_sort(const bool* values_in,
+                       bool* values_out,
+                       const int64_t* indices_in,
+                       int64_t* indices_out,
+                       const size_t volume,
+                       const size_t sort_dim_size,
+                       const bool stable,
+                       cudaStream_t stream);
+
+void thrust_local_sort(const int8_t* values_in,
+                       int8_t* values_out,
+                       const int64_t* indices_in,
+                       int64_t* indices_out,
+                       const size_t volume,
+                       const size_t sort_dim_size,
+                       const bool stable,
+                       cudaStream_t stream);
+
+void thrust_local_sort(const int16_t* values_in,
+                       int16_t* values_out,
+                       const int64_t* indices_in,
+                       int64_t* indices_out,
+                       const size_t volume,
+                       const size_t sort_dim_size,
+                       const bool stable,
+                       cudaStream_t stream);
+
+void thrust_local_sort(const int32_t* values_in,
+                       int32_t* values_out,
+                       const int64_t* indices_in,
+                       int64_t* indices_out,
+                       const size_t volume,
+                       const size_t sort_dim_size,
+                       const bool stable,
+                       cudaStream_t stream);
+
+void thrust_local_sort(const int64_t* values_in,
+                       int64_t* values_out,
+                       const int64_t* indices_in,
+                       int64_t* indices_out,
+                       const size_t volume,
+                       const size_t sort_dim_size,
+                       const bool stable,
+                       cudaStream_t stream);
+
+void thrust_local_sort(const uint8_t* values_in,
+                       uint8_t* values_out,
+                       const int64_t* indices_in,
+                       int64_t* indices_out,
+                       const size_t volume,
+                       const size_t sort_dim_size,
+                       const bool stable,
+                       cudaStream_t stream);
+
+void thrust_local_sort(const uint16_t* values_in,
+                       uint16_t* values_out,
+                       const int64_t* indices_in,
+                       int64_t* indices_out,
+                       const size_t volume,
+                       const size_t sort_dim_size,
+                       const bool stable,
+                       cudaStream_t stream);
+
+void thrust_local_sort(const uint32_t* values_in,
+                       uint32_t* values_out,
+                       const int64_t* indices_in,
+                       int64_t* indices_out,
+                       const size_t volume,
+                       const size_t sort_dim_size,
+                       const bool stable,
+                       cudaStream_t stream);
+
+void thrust_local_sort(const uint64_t* values_in,
+                       uint64_t* values_out,
+                       const int64_t* indices_in,
+                       int64_t* indices_out,
+                       const size_t volume,
+                       const size_t sort_dim_size,
+                       const bool stable,
+                       cudaStream_t stream);
+
+void thrust_local_sort(const __half* values_in,
+                       __half* values_out,
+                       const int64_t* indices_in,
+                       int64_t* indices_out,
+                       const size_t volume,
+                       const size_t sort_dim_size,
+                       const bool stable,
+                       cudaStream_t stream);
+
+void thrust_local_sort(const float* values_in,
+                       float* values_out,
+                       const int64_t* indices_in,
+                       int64_t* indices_out,
+                       const size_t volume,
+                       const size_t sort_dim_size,
+                       const bool stable,
+                       cudaStream_t stream);
+
+void thrust_local_sort(const double* values_in,
+                       double* values_out,
+                       const int64_t* indices_in,
+                       int64_t* indices_out,
+                       const size_t volume,
+                       const size_t sort_dim_size,
+                       const bool stable,
+                       cudaStream_t stream);
+
+void thrust_local_sort(const complex<float>* values_in,
+                       complex<float>* values_out,
+                       const int64_t* indices_in,
+                       int64_t* indices_out,
+                       const size_t volume,
+                       const size_t sort_dim_size,
+                       const bool stable,
+                       cudaStream_t stream);
+
+void thrust_local_sort(const complex<double>* values_in,
+                       complex<double>* values_out,
+                       const int64_t* indices_in,
+                       int64_t* indices_out,
+                       const size_t volume,
+                       const size_t sort_dim_size,
+                       const bool stable,
+                       cudaStream_t stream);
+
+}  // namespace cunumeric

--- a/src/cunumeric/sort/thrust_sort_bool.cu
+++ b/src/cunumeric/sort/thrust_sort_bool.cu
@@ -14,24 +14,21 @@
  *
  */
 
-#pragma once
-
-#include "legate.h"
+#include "cunumeric/sort/thrust_sort.cuh"
 
 namespace cunumeric {
 
-class ThrustAllocator : public legate::ScopedAllocator {
- public:
-  using value_type = char;
-
-  ThrustAllocator(Legion::Memory::Kind kind) : legate::ScopedAllocator(kind) {}
-
-  char* allocate(size_t num_bytes)
-  {
-    return static_cast<char*>(ScopedAllocator::allocate(num_bytes));
-  }
-
-  void deallocate(char* ptr, size_t n) { ScopedAllocator::deallocate(ptr); }
-};
+void thrust_local_sort(const bool* values_in,
+                       bool* values_out,
+                       const int64_t* indices_in,
+                       int64_t* indices_out,
+                       const size_t volume,
+                       const size_t sort_dim_size,
+                       const bool stable,
+                       cudaStream_t stream)
+{
+  detail::thrust_local_sort(
+    values_in, values_out, indices_in, indices_out, volume, sort_dim_size, stable, stream);
+}
 
 }  // namespace cunumeric

--- a/src/cunumeric/sort/thrust_sort_complex128.cu
+++ b/src/cunumeric/sort/thrust_sort_complex128.cu
@@ -14,24 +14,21 @@
  *
  */
 
-#pragma once
-
-#include "legate.h"
+#include "cunumeric/sort/thrust_sort.cuh"
 
 namespace cunumeric {
 
-class ThrustAllocator : public legate::ScopedAllocator {
- public:
-  using value_type = char;
-
-  ThrustAllocator(Legion::Memory::Kind kind) : legate::ScopedAllocator(kind) {}
-
-  char* allocate(size_t num_bytes)
-  {
-    return static_cast<char*>(ScopedAllocator::allocate(num_bytes));
-  }
-
-  void deallocate(char* ptr, size_t n) { ScopedAllocator::deallocate(ptr); }
-};
+void thrust_local_sort(const complex<double>* values_in,
+                       complex<double>* values_out,
+                       const int64_t* indices_in,
+                       int64_t* indices_out,
+                       const size_t volume,
+                       const size_t sort_dim_size,
+                       const bool stable,
+                       cudaStream_t stream)
+{
+  detail::thrust_local_sort(
+    values_in, values_out, indices_in, indices_out, volume, sort_dim_size, stable, stream);
+}
 
 }  // namespace cunumeric

--- a/src/cunumeric/sort/thrust_sort_complex64.cu
+++ b/src/cunumeric/sort/thrust_sort_complex64.cu
@@ -14,24 +14,21 @@
  *
  */
 
-#pragma once
-
-#include "legate.h"
+#include "cunumeric/sort/thrust_sort.cuh"
 
 namespace cunumeric {
 
-class ThrustAllocator : public legate::ScopedAllocator {
- public:
-  using value_type = char;
-
-  ThrustAllocator(Legion::Memory::Kind kind) : legate::ScopedAllocator(kind) {}
-
-  char* allocate(size_t num_bytes)
-  {
-    return static_cast<char*>(ScopedAllocator::allocate(num_bytes));
-  }
-
-  void deallocate(char* ptr, size_t n) { ScopedAllocator::deallocate(ptr); }
-};
+void thrust_local_sort(const complex<float>* values_in,
+                       complex<float>* values_out,
+                       const int64_t* indices_in,
+                       int64_t* indices_out,
+                       const size_t volume,
+                       const size_t sort_dim_size,
+                       const bool stable,
+                       cudaStream_t stream)
+{
+  detail::thrust_local_sort(
+    values_in, values_out, indices_in, indices_out, volume, sort_dim_size, stable, stream);
+}
 
 }  // namespace cunumeric

--- a/src/cunumeric/sort/thrust_sort_double.cu
+++ b/src/cunumeric/sort/thrust_sort_double.cu
@@ -14,24 +14,21 @@
  *
  */
 
-#pragma once
-
-#include "legate.h"
+#include "cunumeric/sort/thrust_sort.cuh"
 
 namespace cunumeric {
 
-class ThrustAllocator : public legate::ScopedAllocator {
- public:
-  using value_type = char;
-
-  ThrustAllocator(Legion::Memory::Kind kind) : legate::ScopedAllocator(kind) {}
-
-  char* allocate(size_t num_bytes)
-  {
-    return static_cast<char*>(ScopedAllocator::allocate(num_bytes));
-  }
-
-  void deallocate(char* ptr, size_t n) { ScopedAllocator::deallocate(ptr); }
-};
+void thrust_local_sort(const double* values_in,
+                       double* values_out,
+                       const int64_t* indices_in,
+                       int64_t* indices_out,
+                       const size_t volume,
+                       const size_t sort_dim_size,
+                       const bool stable,
+                       cudaStream_t stream)
+{
+  detail::thrust_local_sort(
+    values_in, values_out, indices_in, indices_out, volume, sort_dim_size, stable, stream);
+}
 
 }  // namespace cunumeric

--- a/src/cunumeric/sort/thrust_sort_float.cu
+++ b/src/cunumeric/sort/thrust_sort_float.cu
@@ -14,24 +14,21 @@
  *
  */
 
-#pragma once
-
-#include "legate.h"
+#include "cunumeric/sort/thrust_sort.cuh"
 
 namespace cunumeric {
 
-class ThrustAllocator : public legate::ScopedAllocator {
- public:
-  using value_type = char;
-
-  ThrustAllocator(Legion::Memory::Kind kind) : legate::ScopedAllocator(kind) {}
-
-  char* allocate(size_t num_bytes)
-  {
-    return static_cast<char*>(ScopedAllocator::allocate(num_bytes));
-  }
-
-  void deallocate(char* ptr, size_t n) { ScopedAllocator::deallocate(ptr); }
-};
+void thrust_local_sort(const float* values_in,
+                       float* values_out,
+                       const int64_t* indices_in,
+                       int64_t* indices_out,
+                       const size_t volume,
+                       const size_t sort_dim_size,
+                       const bool stable,
+                       cudaStream_t stream)
+{
+  detail::thrust_local_sort(
+    values_in, values_out, indices_in, indices_out, volume, sort_dim_size, stable, stream);
+}
 
 }  // namespace cunumeric

--- a/src/cunumeric/sort/thrust_sort_half.cu
+++ b/src/cunumeric/sort/thrust_sort_half.cu
@@ -14,24 +14,21 @@
  *
  */
 
-#pragma once
-
-#include "legate.h"
+#include "cunumeric/sort/thrust_sort.cuh"
 
 namespace cunumeric {
 
-class ThrustAllocator : public legate::ScopedAllocator {
- public:
-  using value_type = char;
-
-  ThrustAllocator(Legion::Memory::Kind kind) : legate::ScopedAllocator(kind) {}
-
-  char* allocate(size_t num_bytes)
-  {
-    return static_cast<char*>(ScopedAllocator::allocate(num_bytes));
-  }
-
-  void deallocate(char* ptr, size_t n) { ScopedAllocator::deallocate(ptr); }
-};
+void thrust_local_sort(const __half* values_in,
+                       __half* values_out,
+                       const int64_t* indices_in,
+                       int64_t* indices_out,
+                       const size_t volume,
+                       const size_t sort_dim_size,
+                       const bool stable,
+                       cudaStream_t stream)
+{
+  detail::thrust_local_sort(
+    values_in, values_out, indices_in, indices_out, volume, sort_dim_size, stable, stream);
+}
 
 }  // namespace cunumeric

--- a/src/cunumeric/sort/thrust_sort_int16.cu
+++ b/src/cunumeric/sort/thrust_sort_int16.cu
@@ -14,24 +14,21 @@
  *
  */
 
-#pragma once
-
-#include "legate.h"
+#include "cunumeric/sort/thrust_sort.cuh"
 
 namespace cunumeric {
 
-class ThrustAllocator : public legate::ScopedAllocator {
- public:
-  using value_type = char;
-
-  ThrustAllocator(Legion::Memory::Kind kind) : legate::ScopedAllocator(kind) {}
-
-  char* allocate(size_t num_bytes)
-  {
-    return static_cast<char*>(ScopedAllocator::allocate(num_bytes));
-  }
-
-  void deallocate(char* ptr, size_t n) { ScopedAllocator::deallocate(ptr); }
-};
+void thrust_local_sort(const int16_t* values_in,
+                       int16_t* values_out,
+                       const int64_t* indices_in,
+                       int64_t* indices_out,
+                       const size_t volume,
+                       const size_t sort_dim_size,
+                       const bool stable,
+                       cudaStream_t stream)
+{
+  detail::thrust_local_sort(
+    values_in, values_out, indices_in, indices_out, volume, sort_dim_size, stable, stream);
+}
 
 }  // namespace cunumeric

--- a/src/cunumeric/sort/thrust_sort_int32.cu
+++ b/src/cunumeric/sort/thrust_sort_int32.cu
@@ -14,24 +14,21 @@
  *
  */
 
-#pragma once
-
-#include "legate.h"
+#include "cunumeric/sort/thrust_sort.cuh"
 
 namespace cunumeric {
 
-class ThrustAllocator : public legate::ScopedAllocator {
- public:
-  using value_type = char;
-
-  ThrustAllocator(Legion::Memory::Kind kind) : legate::ScopedAllocator(kind) {}
-
-  char* allocate(size_t num_bytes)
-  {
-    return static_cast<char*>(ScopedAllocator::allocate(num_bytes));
-  }
-
-  void deallocate(char* ptr, size_t n) { ScopedAllocator::deallocate(ptr); }
-};
+void thrust_local_sort(const int32_t* values_in,
+                       int32_t* values_out,
+                       const int64_t* indices_in,
+                       int64_t* indices_out,
+                       const size_t volume,
+                       const size_t sort_dim_size,
+                       const bool stable,
+                       cudaStream_t stream)
+{
+  detail::thrust_local_sort(
+    values_in, values_out, indices_in, indices_out, volume, sort_dim_size, stable, stream);
+}
 
 }  // namespace cunumeric

--- a/src/cunumeric/sort/thrust_sort_int64.cu
+++ b/src/cunumeric/sort/thrust_sort_int64.cu
@@ -14,24 +14,21 @@
  *
  */
 
-#pragma once
-
-#include "legate.h"
+#include "cunumeric/sort/thrust_sort.cuh"
 
 namespace cunumeric {
 
-class ThrustAllocator : public legate::ScopedAllocator {
- public:
-  using value_type = char;
-
-  ThrustAllocator(Legion::Memory::Kind kind) : legate::ScopedAllocator(kind) {}
-
-  char* allocate(size_t num_bytes)
-  {
-    return static_cast<char*>(ScopedAllocator::allocate(num_bytes));
-  }
-
-  void deallocate(char* ptr, size_t n) { ScopedAllocator::deallocate(ptr); }
-};
+void thrust_local_sort(const int64_t* values_in,
+                       int64_t* values_out,
+                       const int64_t* indices_in,
+                       int64_t* indices_out,
+                       const size_t volume,
+                       const size_t sort_dim_size,
+                       const bool stable,
+                       cudaStream_t stream)
+{
+  detail::thrust_local_sort(
+    values_in, values_out, indices_in, indices_out, volume, sort_dim_size, stable, stream);
+}
 
 }  // namespace cunumeric

--- a/src/cunumeric/sort/thrust_sort_int8.cu
+++ b/src/cunumeric/sort/thrust_sort_int8.cu
@@ -14,24 +14,21 @@
  *
  */
 
-#pragma once
-
-#include "legate.h"
+#include "cunumeric/sort/thrust_sort.cuh"
 
 namespace cunumeric {
 
-class ThrustAllocator : public legate::ScopedAllocator {
- public:
-  using value_type = char;
-
-  ThrustAllocator(Legion::Memory::Kind kind) : legate::ScopedAllocator(kind) {}
-
-  char* allocate(size_t num_bytes)
-  {
-    return static_cast<char*>(ScopedAllocator::allocate(num_bytes));
-  }
-
-  void deallocate(char* ptr, size_t n) { ScopedAllocator::deallocate(ptr); }
-};
+void thrust_local_sort(const int8_t* values_in,
+                       int8_t* values_out,
+                       const int64_t* indices_in,
+                       int64_t* indices_out,
+                       const size_t volume,
+                       const size_t sort_dim_size,
+                       const bool stable,
+                       cudaStream_t stream)
+{
+  detail::thrust_local_sort(
+    values_in, values_out, indices_in, indices_out, volume, sort_dim_size, stable, stream);
+}
 
 }  // namespace cunumeric

--- a/src/cunumeric/sort/thrust_sort_uint16.cu
+++ b/src/cunumeric/sort/thrust_sort_uint16.cu
@@ -14,24 +14,21 @@
  *
  */
 
-#pragma once
-
-#include "legate.h"
+#include "cunumeric/sort/thrust_sort.cuh"
 
 namespace cunumeric {
 
-class ThrustAllocator : public legate::ScopedAllocator {
- public:
-  using value_type = char;
-
-  ThrustAllocator(Legion::Memory::Kind kind) : legate::ScopedAllocator(kind) {}
-
-  char* allocate(size_t num_bytes)
-  {
-    return static_cast<char*>(ScopedAllocator::allocate(num_bytes));
-  }
-
-  void deallocate(char* ptr, size_t n) { ScopedAllocator::deallocate(ptr); }
-};
+void thrust_local_sort(const uint16_t* values_in,
+                       uint16_t* values_out,
+                       const int64_t* indices_in,
+                       int64_t* indices_out,
+                       const size_t volume,
+                       const size_t sort_dim_size,
+                       const bool stable,
+                       cudaStream_t stream)
+{
+  detail::thrust_local_sort(
+    values_in, values_out, indices_in, indices_out, volume, sort_dim_size, stable, stream);
+}
 
 }  // namespace cunumeric

--- a/src/cunumeric/sort/thrust_sort_uint32.cu
+++ b/src/cunumeric/sort/thrust_sort_uint32.cu
@@ -14,24 +14,21 @@
  *
  */
 
-#pragma once
-
-#include "legate.h"
+#include "cunumeric/sort/thrust_sort.cuh"
 
 namespace cunumeric {
 
-class ThrustAllocator : public legate::ScopedAllocator {
- public:
-  using value_type = char;
-
-  ThrustAllocator(Legion::Memory::Kind kind) : legate::ScopedAllocator(kind) {}
-
-  char* allocate(size_t num_bytes)
-  {
-    return static_cast<char*>(ScopedAllocator::allocate(num_bytes));
-  }
-
-  void deallocate(char* ptr, size_t n) { ScopedAllocator::deallocate(ptr); }
-};
+void thrust_local_sort(const uint32_t* values_in,
+                       uint32_t* values_out,
+                       const int64_t* indices_in,
+                       int64_t* indices_out,
+                       const size_t volume,
+                       const size_t sort_dim_size,
+                       const bool stable,
+                       cudaStream_t stream)
+{
+  detail::thrust_local_sort(
+    values_in, values_out, indices_in, indices_out, volume, sort_dim_size, stable, stream);
+}
 
 }  // namespace cunumeric

--- a/src/cunumeric/sort/thrust_sort_uint64.cu
+++ b/src/cunumeric/sort/thrust_sort_uint64.cu
@@ -14,24 +14,21 @@
  *
  */
 
-#pragma once
-
-#include "legate.h"
+#include "cunumeric/sort/thrust_sort.cuh"
 
 namespace cunumeric {
 
-class ThrustAllocator : public legate::ScopedAllocator {
- public:
-  using value_type = char;
-
-  ThrustAllocator(Legion::Memory::Kind kind) : legate::ScopedAllocator(kind) {}
-
-  char* allocate(size_t num_bytes)
-  {
-    return static_cast<char*>(ScopedAllocator::allocate(num_bytes));
-  }
-
-  void deallocate(char* ptr, size_t n) { ScopedAllocator::deallocate(ptr); }
-};
+void thrust_local_sort(const uint64_t* values_in,
+                       uint64_t* values_out,
+                       const int64_t* indices_in,
+                       int64_t* indices_out,
+                       const size_t volume,
+                       const size_t sort_dim_size,
+                       const bool stable,
+                       cudaStream_t stream)
+{
+  detail::thrust_local_sort(
+    values_in, values_out, indices_in, indices_out, volume, sort_dim_size, stable, stream);
+}
 
 }  // namespace cunumeric

--- a/src/cunumeric/sort/thrust_sort_uint8.cu
+++ b/src/cunumeric/sort/thrust_sort_uint8.cu
@@ -14,24 +14,21 @@
  *
  */
 
-#pragma once
-
-#include "legate.h"
+#include "cunumeric/sort/thrust_sort.cuh"
 
 namespace cunumeric {
 
-class ThrustAllocator : public legate::ScopedAllocator {
- public:
-  using value_type = char;
-
-  ThrustAllocator(Legion::Memory::Kind kind) : legate::ScopedAllocator(kind) {}
-
-  char* allocate(size_t num_bytes)
-  {
-    return static_cast<char*>(ScopedAllocator::allocate(num_bytes));
-  }
-
-  void deallocate(char* ptr, size_t n) { ScopedAllocator::deallocate(ptr); }
-};
+void thrust_local_sort(const uint8_t* values_in,
+                       uint8_t* values_out,
+                       const int64_t* indices_in,
+                       int64_t* indices_out,
+                       const size_t volume,
+                       const size_t sort_dim_size,
+                       const bool stable,
+                       cudaStream_t stream)
+{
+  detail::thrust_local_sort(
+    values_in, values_out, indices_in, indices_out, volume, sort_dim_size, stable, stream);
+}
 
 }  // namespace cunumeric


### PR DESCRIPTION
`sort.cu` is greatly slowing down the build, so this PR is to split it up into multiple files so that we can build them in parallel.