### PR TITLE
add missing comparison functions

### DIFF
--- a/docs/cunumeric/source/comparison/_comparison_generator.py
+++ b/docs/cunumeric/source/comparison/_comparison_generator.py
@@ -15,11 +15,8 @@ blocklist = [
     "fastCopyAndTranspose",
     "get_array_wrap",
     "iterable",
-    "loads",
-    "mafromtxt",
     "max",
     "min",
-    "ndfromtxt",
     "ndim",
     "product",
     "recfromcsv",
@@ -31,6 +28,13 @@ blocklist = [
     "sometrue",
     "test",
 ]
+
+# these do not have valid intersphinx references
+missing_numpy_refs = {
+    "loads",
+    "mafromtxt",
+    "ndfromtxt",
+}
 
 
 def check_ufunc(obj, n):
@@ -122,7 +126,10 @@ def _section(
         "",
     ]
     for f in sorted(base_funcs):
-        base_cell = base_fmt.format(f)
+        if f not in missing_numpy_refs:
+            base_cell = base_fmt.format(f)
+        else:
+            base_cell = f"``numpy.{f}``"
         lg_cell = r"\-"
         single_gpu_cell = ""
         multi_gpu_cell = ""


### PR DESCRIPTION
fixed #226 

This is a quick fix for the functions that were missing from the comparison table. Note that for whatever reason, intersphinx references for these functions do not exist (i.e. they are omitted from the numpy docs site). That's the proximate reason they were added to the blocklist. The current PR just renders those entries in the code font:

![image](https://user-images.githubusercontent.com/1078448/163481898-b0375dba-5265-4803-b101-5e461bd59ba4.png)

I would like to overhaul the comparison generation in general, and move it to a sphinx extension. But that will be a larger issue I will submit for consideration. 