### PR TITLE
Fix nonzero

### DIFF
--- a/src/cunumeric/search/nonzero_template.inl
+++ b/src/cunumeric/search/nonzero_template.inl
@@ -37,7 +37,7 @@ struct NonzeroImpl {
     size_t volume = pitches.flatten(rect);
 
     if (volume == 0) {
-      auto empty = create_buffer<VAL>(0);
+      auto empty = create_buffer<int64_t>(0);
       for (auto& store : args.results) store.return_data(empty, Point<1>(0));
       return;
     }


### PR DESCRIPTION
The `nonzero` task was using the input element type when creating an empty buffer to return. This PR fixes that bug.