### PR TITLE
fix return value of ndarray.argsort

### DIFF
--- a/cunumeric/array.py
+++ b/cunumeric/array.py
@@ -2597,12 +2597,44 @@ class ndarray:
         self.__array__().setflags(write=write, align=align, uic=uic)
 
     def sort(self, axis=-1, kind="quicksort", order=None):
+        """a.sort(axis=-1, kind=None, order=None)
+
+        Sort an array in-place.
+
+        Refer to :func:`cunumeric.sort` for full documentation.
+
+        See Also
+        --------
+        cunumeric.sort : equivalent function
+
+        Availability
+        --------
+        Multiple GPUs, Single CPU
+
+        """
         self._thunk.sort(rhs=self._thunk, axis=axis, kind=kind, order=order)
 
-    def argsort(self, axis=-1, kind="quicksort", order=None):
-        self._thunk.sort(
+    def argsort(self, axis=-1, kind=None, order=None):
+        """a.argsort(axis=-1, kind=None, order=None)
+
+        Returns the indices that would sort this array.
+
+        Refer to :func:`cunumeric.argsort` for full documentation.
+
+        See Also
+        --------
+        cunumeric.argsort : equivalent function
+
+        Availability
+        --------
+        Multiple GPUs, Single CPU
+
+        """
+        result = ndarray(self.shape, np.int64)
+        result._thunk.sort(
             rhs=self._thunk, argsort=True, axis=axis, kind=kind, order=order
         )
+        return result
 
     def squeeze(self, axis=None):
         """a.squeeze(axis=None)

--- a/src/cunumeric/mapper.cc
+++ b/src/cunumeric/mapper.cc
@@ -154,10 +154,18 @@ std::vector<StoreMapping> CuNumericMapper::store_mappings(
     }
     case CUNUMERIC_SORT: {
       std::vector<StoreMapping> mappings;
-      auto& inputs = task.inputs();
-      mappings.push_back(StoreMapping::default_mapping(inputs[0], options.front()));
-      mappings.back().policy.ordering.c_order();
-      mappings.back().policy.exact = true;
+      auto& inputs  = task.inputs();
+      auto& outputs = task.outputs();
+      for (auto& input : inputs) {
+        mappings.push_back(StoreMapping::default_mapping(input, options.front()));
+        mappings.back().policy.ordering.c_order();
+        mappings.back().policy.exact = true;
+      }
+      for (auto& output : outputs) {
+        mappings.push_back(StoreMapping::default_mapping(output, options.front()));
+        mappings.back().policy.ordering.c_order();
+        mappings.back().policy.exact = true;
+      }
       return std::move(mappings);
     }
     default: {

--- a/src/cunumeric/sort/sort.cc
+++ b/src/cunumeric/sort/sort.cc
@@ -86,6 +86,7 @@ struct SortImplBody<VariantKind::CPU, CODE, DIM> {
       }
 
       AccessorWO<int64_t, DIM> output = output_array.write_accessor<int64_t, DIM>(rect);
+      assert(output.accessor.is_dense_row_major(rect));
 
       // sort data in place
       thrust_local_sort_inplace(
@@ -93,6 +94,7 @@ struct SortImplBody<VariantKind::CPU, CODE, DIM> {
 
     } else {
       AccessorWO<VAL, DIM> output = output_array.write_accessor<VAL, DIM>(rect);
+      assert(output.accessor.is_dense_row_major(rect));
 
       // init output values
       auto* src    = input.ptr(rect.lo);

--- a/src/cunumeric/sort/sort_omp.cc
+++ b/src/cunumeric/sort/sort_omp.cc
@@ -87,6 +87,7 @@ struct SortImplBody<VariantKind::OMP, CODE, DIM> {
       }
 
       AccessorWO<int64_t, DIM> output = output_array.write_accessor<int64_t, DIM>(rect);
+      assert(output.accessor.is_dense_row_major(rect));
 
       // sort data in place
       thrust_local_sort_inplace(
@@ -94,6 +95,7 @@ struct SortImplBody<VariantKind::OMP, CODE, DIM> {
 
     } else {
       AccessorWO<VAL, DIM> output = output_array.write_accessor<VAL, DIM>(rect);
+      assert(output.accessor.is_dense_row_major(rect));
 
       // init output values
       auto* src    = input.ptr(rect.lo);

--- a/tests/sort.py
+++ b/tests/sort.py
@@ -152,6 +152,15 @@ def test_api(a=None):
     copy_a_num.sort()
     compare_assert(copy_a, copy_a_num)
 
+    # ndarray.argsort -- no change to array
+    copy_a = a.copy()
+    copy_a_num = a_num.copy()
+    compare_assert(
+        copy_a.argsort(kind="stable"), copy_a_num.argsort(kind="stable")
+    )
+    compare_assert(copy_a, a_num)
+    compare_assert(a, copy_a_num)
+
     # argsort
     for i in range(a.ndim):
         compare_assert(a, a_num)


### PR DESCRIPTION
I noticed that cunumeric.ndarray.argsort returns the result in-place while numpy returns a copy. I adjusted the behavior and added a testcase.