### PR TITLE
fix the compilation for power pc

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -41,9 +41,21 @@ include $(LEGATE_DIR)/share/legate/config.mk
 
 LIBNAME = libcunumeric
 
+ARCH_NAME = $(shell uname -m)
+ifneq (,$(findstring ppc,$(ARCH_NAME)))
+    CPU_ARCH = ppc
+else ifneq (,$(findstring x86,$(ARCH_NAME))) 
+    CPU_ARCH = x86
+else
+    $(error Unsupported arch $(ARCH_NAME), aborting build)
+endif
+
 CC_FLAGS ?=
 CC_FLAGS += -I. -I$(OPENBLAS_PATH)/include -I$(TBLIS_PATH)/include -I$(THRUST_PATH)
 CC_FLAGS += -DTHRUST_HOST_SYSTEM=THRUST_HOST_SYSTEM_CPP -DTHRUST_DEVICE_SYSTEM=THRUST_DEVICE_SYSTEM_OMP
+ifeq ($(strip $(CPU_ARCH)),ppc)
+CC_FLAGS += -DNO_WARN_X86_INTRINSICS
+endif
 
 LD_FLAGS ?=
 LD_FLAGS += -L$(OPENBLAS_PATH)/lib -l$(OPENBLAS_LIBNAME) -Wl,-rpath,$(OPENBLAS_PATH)/lib


### PR DESCRIPTION
This PR is to fix the following error on power pc
```
In file included from /autofs/nccs-svm1_home1/wwu12/install/TBLIS/include/tblis/util/../external/marray/include/expression.hpp:4,
                 from /autofs/nccs-svm1_home1/wwu12/install/TBLIS/include/tblis/util/../external/marray/include/marray_base.hpp:509,
                 from /autofs/nccs-svm1_home1/wwu12/install/TBLIS/include/tblis/util/../external/marray/include/varray_base.hpp:4,
                 from /autofs/nccs-svm1_home1/wwu12/install/TBLIS/include/tblis/util/../external/marray/include/varray_view.hpp:4,
                 from /autofs/nccs-svm1_home1/wwu12/install/TBLIS/include/tblis/util/../external/marray/include/varray.hpp:4,
                 from /autofs/nccs-svm1_home1/wwu12/install/TBLIS/include/tblis/util/basic_types.h:38,
                 from /autofs/nccs-svm1_home1/wwu12/install/TBLIS/include/tblis/util/configs.h:4,
                 from /autofs/nccs-svm1_home1/wwu12/install/TBLIS/include/tblis/tblis.h:4,
                 from cunumeric/matrix/contract.cc:21:
/autofs/nccs-svm1_sw/summit/gcc/9.3.0-2/lib/gcc/powerpc64le-unknown-linux-gnu/9.3.0/include/x86intrin.h:32:2: error: #error "Please read comment above.  Use -DNO_WARN_X86_INTRINSICS to disable this error."
```