### PR TITLE
Update example programs

### DIFF
--- a/examples/cg.py
+++ b/examples/cg.py
@@ -16,9 +16,9 @@
 #
 
 import argparse
-import datetime
 
 from benchmark import run_benchmark
+from legate.timing import time
 
 import cunumeric as np
 
@@ -175,9 +175,9 @@ def run_cg(
     timing,
     verbose,
 ):
-    start = datetime.datetime.now()
     # A, b = generate_random(N)
     A, b = generate_2D(N, corners)
+    start = time()
     if preconditioner:
         M = precondition(A, N, corners)
         x = preconditioned_solve(
@@ -187,11 +187,10 @@ def run_cg(
         x = solve(A, b, conv_iters, max_iters, conv_threshold, verbose)
     if perform_check:
         check(A, x, b)
-    stop = datetime.datetime.now()
-    delta = stop - start
-    total = delta.total_seconds() * 1000.0
+    stop = time()
+    total = (stop - start) / 1000.0
     if timing:
-        print("Elapsed Time: " + str(total) + " ms")
+        print(f"Elapsed Time: {total} ms")
     return total
 
 

--- a/examples/jacobi.py
+++ b/examples/jacobi.py
@@ -16,10 +16,10 @@
 #
 
 import argparse
-import datetime
 import math
 
 from benchmark import run_benchmark
+from legate.timing import time
 
 import cunumeric as np
 
@@ -54,19 +54,18 @@ def check(A, x, b):
 
 
 def run_jacobi(N, iters, perform_check, timing, verbose):
-    start = datetime.datetime.now()
     A, b = generate_random(N)
+    start = time()
     x = solve(A, b, iters, verbose)
     if perform_check:
         check(A, x, b)
     else:
         # Need a synchronization here for timing
         assert not math.isnan(np.sum(x))
-    stop = datetime.datetime.now()
-    delta = stop - start
-    total = delta.total_seconds() * 1000.0
+    stop = time()
+    total = (stop - start) / 1000.0
     if timing:
-        print("Elapsed Time: " + str(total) + " ms")
+        print(f"Elapsed Time: {total} ms")
     return total
 
 

--- a/examples/logreg.py
+++ b/examples/logreg.py
@@ -16,10 +16,10 @@
 #
 
 import argparse
-import datetime
 import math
 
 from benchmark import run_benchmark
+from legate.timing import time
 
 import cunumeric as np
 
@@ -75,15 +75,14 @@ def run_logistic_regression(N, F, T, I, S, B):  # noqa: E741
     print("Number of data points: " + str(N) + "K")
     print("Number of features: " + str(F))
     print("Number of iterations: " + str(I))
-    start = datetime.datetime.now()
     features, target = initialize(N * 1000, F, T)
+    start = time()
     weights = logistic_regression(T, features, target, I, 1e-5, S, B)
-    # Check the weights for NaNs to synchronize before stopping timing
+    stop = time()
+    # Check the weights for NaNs
     assert not math.isnan(np.sum(weights))
-    stop = datetime.datetime.now()
-    delta = stop - start
-    total = delta.total_seconds() * 1000.0
-    print("Elapsed Time: " + str(total) + " ms")
+    total = (stop - start) / 1000.0
+    print(f"Elapsed Time: {total} ms")
     return total
 
 

--- a/examples/stencil.py
+++ b/examples/stencil.py
@@ -16,10 +16,10 @@
 #
 
 import argparse
-import datetime
 import math
 
 from benchmark import run_benchmark
+from legate.timing import time
 
 import cunumeric as np
 
@@ -51,17 +51,15 @@ def run(grid, I, N):  # noqa: E741
 
 
 def run_stencil(N, I, timing):  # noqa: E741
-    start = datetime.datetime.now()
     grid = initialize(N)
+    start = time()
     average = run(grid, I, N)
-    # This will sync the timing because we will need to wait for the result
-    assert not math.isnan(average)
-    stop = datetime.datetime.now()
+    stop = time()
     print("Average energy is %.8g" % average)
-    delta = stop - start
-    total = delta.total_seconds() * 1000.0
+    total = (stop - start) / 1000.0
+    assert not math.isnan(average)
     if timing:
-        print("Elapsed Time: " + str(total) + " ms")
+        print(f"Elapsed Time: {total} ms")
     return total
 
 


### PR DESCRIPTION
This PR updates some examples programs to make them use `legate.timing` and also report more accurate steady state timing.