### PR TITLE
Bump up NumPy version

### DIFF
--- a/conda/cunumeric_dev.yml
+++ b/conda/cunumeric_dev.yml
@@ -9,7 +9,7 @@ dependencies:
   - cutensor>=1.3.3
   - mock
   - nccl
-  - numpy
+  - numpy>=1.22
   - opt_einsum
   - pre-commit
   - pyarrow>=5

--- a/cunumeric/eager.py
+++ b/cunumeric/eager.py
@@ -62,6 +62,15 @@ _UNARY_OPS = {
     UnaryOpCode.TRUNC: np.trunc,
 }
 
+_UNARY_RED_OPS = {
+    UnaryRedCode.ALL: np.all,
+    UnaryRedCode.ANY: np.any,
+    UnaryRedCode.MAX: np.max,
+    UnaryRedCode.MIN: np.min,
+    UnaryRedCode.PROD: np.prod,
+    UnaryRedCode.SUM: np.sum,
+}
+
 _BINARY_OPS = {
     BinaryOpCode.ADD: np.add,
     BinaryOpCode.ARCTAN2: np.arctan2,
@@ -641,18 +650,13 @@ class EagerArray(NumPyThunk):
                 initial,
             )
             return
-        if op == UnaryRedCode.ALL:
-            np.all(
-                rhs.array,
-                out=self.array,
-                axis=axes,
-                keepdims=keepdims,
-                where=where
-                if not isinstance(where, EagerArray)
-                else where.array,
-            )
-        elif op == UnaryRedCode.ANY:
-            np.any(
+        if op in _UNARY_RED_OPS:
+            fn = _UNARY_RED_OPS[op]
+            if initial is None:
+                # NumPy starts using this predefined constant, instead of None,
+                # to mean no value was given by the caller
+                initial = np._NoValue
+            fn(
                 rhs.array,
                 out=self.array,
                 axis=axes,
@@ -669,66 +673,6 @@ class EagerArray(NumPyThunk):
             np.argmin(rhs.array, out=self.array, axis=axes[0])
         elif op == UnaryRedCode.CONTAINS:
             self.array.fill(args[0] in rhs.array)
-        elif op == UnaryRedCode.MAX:
-            try:
-                # Try the new version of this interface for NumPy
-                rhs.array.max(
-                    axis=axes,
-                    out=self.array,
-                    keepdims=keepdims,
-                    initial=initial,
-                    where=where
-                    if not isinstance(where, EagerArray)
-                    else where.array,
-                )
-            except Exception:  # TDB: refine exception
-                rhs.array.max(axis=axes, out=self.array, keepdims=keepdims)
-        elif op == UnaryRedCode.MIN:
-            try:
-                # Try the new version of this interface for NumPy
-                rhs.array.min(
-                    axis=axes,
-                    out=self.array,
-                    keepdims=keepdims,
-                    initial=initial,
-                    where=where
-                    if not isinstance(where, EagerArray)
-                    else where.array,
-                )
-            except Exception:  # TDB: refine exception
-                rhs.array.min(axis=axes, out=self.array, keepdims=keepdims)
-        elif op == UnaryRedCode.PROD:
-            try:
-                # Try the new version of this interface for NumPy
-                np.prod(
-                    rhs.array,
-                    out=self.array,
-                    axis=axes,
-                    keepdims=keepdims,
-                    initial=initial,
-                    where=where
-                    if not isinstance(where, EagerArray)
-                    else where.array,
-                )
-            except Exception:
-                np.prod(
-                    rhs.array, out=self.array, axis=axes, keepdims=keepdims
-                )
-        elif op == UnaryRedCode.SUM:
-            try:
-                # Try the new version of this interface for NumPy
-                np.sum(
-                    rhs.array,
-                    out=self.array,
-                    axis=axes,
-                    keepdims=keepdims,
-                    initial=initial,
-                    where=where
-                    if not isinstance(where, EagerArray)
-                    else where.array,
-                )
-            except Exception:
-                np.sum(rhs.array, out=self.array, axis=axes, keepdims=keepdims)
         elif op == UnaryRedCode.COUNT_NONZERO:
             self.array[()] = np.count_nonzero(rhs.array, axis=axes)
         else:


### PR DESCRIPTION
This PR bumps up the minimum NumPy version to 1.22 and removes code that becomes obsolete due to that change.