### PR TITLE
reduce testcases for partition test

### DIFF
--- a/tests/partition.py
+++ b/tests/partition.py
@@ -157,24 +157,13 @@ def generate_random(shape, datatype):
 
 def test_dtypes():
     np.random.seed(42)
-    test_api(generate_random((2, 5, 7), np.uint8))
-    test_api(generate_random((8, 5), np.uint16))
-    test_api(generate_random((22, 5, 7), np.uint32))
     test_api(generate_random((220,), np.uint32))
 
     test_api(generate_random((2, 5, 7), np.int8))
-    test_api(generate_random((8, 5), np.int16))
-    test_api(generate_random((22, 5, 7), np.int32))
-    test_api(generate_random((2, 5, 7), np.int64))
 
     test_api(generate_random((8, 5), np.float32))
-    test_api(generate_random((8, 5), np.float64))
-    test_api(generate_random((22, 5, 7), np.double))
-    test_api(generate_random((220,), np.double))
 
-    test_api(generate_random((2, 5, 7), np.complex64))
     test_api(generate_random((2, 5, 7), np.complex128))
-    test_api(generate_random((220,), np.complex128))
 
 
 def test():


### PR DESCRIPTION
in order to reduce test duration some redundant testcases have been removed