### PR TITLE
Slicing-based `np.block` implementation

### DIFF
--- a/cunumeric/module.py
+++ b/cunumeric/module.py
@@ -1378,7 +1378,6 @@ def _concatenate(
     out=None,
     dtype=None,
     casting="same_kind",
-    slicing_only=False,
 ):
     if axis < 0:
         axis += len(common_info.shape)


### PR DESCRIPTION
Reimplemented `np.block` w/ slices to avoid creating intermediate arrays by concatenation. 
This PR includes changes in _concatenate, which removes verbose code.

Slicing-based block performs better for most cases on a single node. 
For multi-node, the communication from src to dest can be different depending on how intermediate arrays are partitioned. 
We keep the slicing-based block only and will come up with some ways to avoid perf degradations for some cases in a separate PR.