### PR TITLE
Add a custom autodoc class for ufuncs

### DIFF
--- a/cunumeric/sphinxext/__init__.py
+++ b/cunumeric/sphinxext/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2021-2022 NVIDIA Corporation
+# Copyright 2022 NVIDIA Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/cunumeric/sphinxext/__init__.py
+++ b/cunumeric/sphinxext/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2021-2022 NVIDIA Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#

--- a/cunumeric/sphinxext/ufunc_formatter.py
+++ b/cunumeric/sphinxext/ufunc_formatter.py
@@ -1,4 +1,4 @@
-# Copyright 2021-2022 NVIDIA Corporation
+# Copyright 2022 NVIDIA Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/cunumeric/sphinxext/ufunc_formatter.py
+++ b/cunumeric/sphinxext/ufunc_formatter.py
@@ -1,0 +1,30 @@
+# Copyright 2021-2022 NVIDIA Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from sphinx.ext.autodoc import FunctionDocumenter
+
+from cunumeric import ufunc
+
+
+class UfuncDocumenter(FunctionDocumenter):
+    priority = 20
+
+    @classmethod
+    def can_document_member(cls, member, membername, isattr, parent):
+        return isinstance(getattr(member, "__wrapped__", None), ufunc)
+
+
+def setup(app):
+    app.add_autodocumenter(UfuncDocumenter)

--- a/cunumeric/sphinxext/ufunc_formatter.py
+++ b/cunumeric/sphinxext/ufunc_formatter.py
@@ -19,6 +19,8 @@ from cunumeric import ufunc
 
 
 class UfuncDocumenter(FunctionDocumenter):
+    directivetype = "function"
+    objtype = "ufunc"
     priority = 20
 
     @classmethod

--- a/docs/cunumeric/source/comparison/_comparison_generator.py
+++ b/docs/cunumeric/source/comparison/_comparison_generator.py
@@ -94,7 +94,7 @@ def _section(
     lg_funcs = []
     for f in _get_functions(lg_obj):
         obj = getattr(lg_obj, f)
-        if not hasattr(obj, "_cunumeric") or not obj._cunumeric.implemented:
+        if hasattr(obj, "_cunumeric") and obj._cunumeric.implemented:
             lg_funcs.append(f)
     lg_funcs = set(lg_funcs)
 

--- a/docs/cunumeric/source/conf.py
+++ b/docs/cunumeric/source/conf.py
@@ -58,6 +58,7 @@ extensions = [
     "sphinx_copybutton",
     "sphinx_markdown_tables",
     "recommonmark",
+    "cunumeric.sphinxext.ufunc_formatter",
 ]
 
 copybutton_prompt_text = ">>> "


### PR DESCRIPTION
This PR fixes #313 

With these changes the ufunc docs render with appropriate signatures:

![image](https://user-images.githubusercontent.com/1078448/166303683-f3c0fa8b-4d18-4e23-80ba-1233b794ec6e.png)

For anyone curious: The reason the default `FunctionDocumenter` does get selected is that the `can_document_member` predicate tries to be too clever and ultimately calls
```
return inspect.isfunction(unwrap_all(obj))
``` 
The too-clever part is the `unwrap_all` which tries to see the object is a wrapper of some sort, and then make sure the thing wrapped is a function. In our case the wrapped thing is a `ufunc`. Although it is a callable object, it's not technically a function, so it gets rejected. Subesequntly the generic `DataDocumenter` for module attributes is used. This PR adds a higher priority subclass of `FunctionDocumenter` with a `can_document_member` predicate that recognizes our ufuncs. 