### PR TITLE
Use legate.core arg parsing

### DIFF
--- a/cunumeric/coverage.py
+++ b/cunumeric/coverage.py
@@ -87,7 +87,9 @@ def implemented(
 
         @wraps(func)
         def wrapper(*args: Any, **kwargs: Any) -> Any:
-            location = find_last_user_frames(not runtime.report_dump_callstack)
+            location = find_last_user_frames(
+                not runtime.args.report_dump_callstack
+            )
             runtime.record_api_call(
                 name=name,
                 location=location,
@@ -117,7 +119,9 @@ def unimplemented(
 
         @wraps(func)
         def wrapper(*args: Any, **kwargs: Any) -> Any:
-            location = find_last_user_frames(not runtime.report_dump_callstack)
+            location = find_last_user_frames(
+                not runtime.args.report_dump_callstack
+            )
             runtime.record_api_call(
                 name=name,
                 location=location,
@@ -171,7 +175,7 @@ def clone_module(
         omit_types=(ModuleType,),
     )
 
-    reporting = runtime.report_coverage
+    reporting = runtime.args.report_coverage
 
     from ._ufunc.ufunc import ufunc as lgufunc
 
@@ -221,7 +225,7 @@ def clone_class(origin_class: type) -> Callable[[type], type]:
             omit_names=set(cls.__dict__).union(NDARRAY_INTERNAL),
         )
 
-        reporting = runtime.report_coverage
+        reporting = runtime.args.report_coverage
 
         for attr, value in cls.__dict__.items():
             if should_wrap(value):

--- a/cunumeric/linalg/cholesky.py
+++ b/cunumeric/linalg/cholesky.py
@@ -100,7 +100,7 @@ MIN_CHOLESKY_MATRIX_SIZE = 8192
 
 # TODO: We need a better cost model
 def choose_color_shape(runtime, shape):
-    if runtime.test_mode:
+    if runtime.args.test_mode:
         num_tiles = runtime.num_procs * 2
         return (num_tiles, num_tiles)
     else:

--- a/cunumeric/runtime.py
+++ b/cunumeric/runtime.py
@@ -58,23 +58,48 @@ _supported_dtypes = {
 
 ARGS = [
     Argument(
-        "test", ArgSpec(action="store_true", default=False, dest="test_mode")
+        "test",
+        ArgSpec(
+            action="store_true",
+            default=False,
+            dest="test_mode",
+            help="Enable test mode. In test mode, all cuNumeric ndarrays are managed by the distributed runtime and the NumPy fallback for small arrays is turned off.",  # noqa E501
+        ),
     ),
     Argument(
         "preload-cudalibs",
-        ArgSpec(action="store_true", default=False, dest="preload_cudalibs"),
+        ArgSpec(
+            action="store_true",
+            default=False,
+            dest="preload_cudalibs",
+            help="Preload and initialize handles of all CUDA libraries (cuBLAS, cuSOLVER, etc.) used in cuNumericLoad CUDA libs early",  # noqa E501
+        ),
     ),
     Argument(
-        "warn", ArgSpec(action="store_true", default=False, dest="warning")
+        "warn",
+        ArgSpec(
+            action="store_true",
+            default=False,
+            dest="warning",
+            help="Turn on warnings",
+        ),
     ),
     Argument(
         "report:coverage",
-        ArgSpec(action="store_true", default=False, dest="report_coverage"),
+        ArgSpec(
+            action="store_true",
+            default=False,
+            dest="report_coverage",
+            help="Print an overall percentage of cunumeric coverage",
+        ),
     ),
     Argument(
         "report:dump-callstack",
         ArgSpec(
-            action="store_true", default=False, dest="report_dump_callstack"
+            action="store_true",
+            default=False,
+            dest="report_dump_callstack",
+            help="Print an overall percentage of cunumeric coverage with call stack details",  # noqa E501
         ),
     ),
     Argument(
@@ -85,6 +110,7 @@ ARGS = [
             nargs=1,
             default=None,
             dest="report_dump_csv",
+            help="Save a coverage report to a specified CSV file",
         ),
     ),
 ]
@@ -210,7 +236,7 @@ class Runtime(object):
         assert not self.destroyed
         if self.num_gpus > 0:
             self._unload_cudalibs()
-        if self.args.report_coverage:
+        if hasattr(self, "args") and self.args.report_coverage:
             self._report_coverage()
         self.destroyed = True
 

--- a/tests/unit/cunumeric/test_coverage.py
+++ b/tests/unit/cunumeric/test_coverage.py
@@ -319,9 +319,9 @@ attr2 = 30
 
 
 class Test_clone_module:
-    @patch.object(cunumeric.runtime, "report_coverage", True)
+    @patch.object(cunumeric.runtime.args, "report_coverage", True)
     def test_report_coverage_True(self) -> None:
-        assert cunumeric.runtime.report_coverage
+        assert cunumeric.runtime.args.report_coverage
 
         _Dest = ModuleType("dest")
         exec(_DestCode, _Dest.__dict__)
@@ -342,9 +342,9 @@ class Test_clone_module:
         assert _Dest.function2.__wrapped__
         assert _Dest.function2._cunumeric.implemented
 
-    @patch.object(cunumeric.runtime, "report_coverage", False)
+    @patch.object(cunumeric.runtime.args, "report_coverage", False)
     def test_report_coverage_False(self) -> None:
-        assert not cunumeric.runtime.report_coverage
+        assert not cunumeric.runtime.args.report_coverage
 
         _Dest = ModuleType("dest")
         exec(_DestCode, _Dest.__dict__)
@@ -402,9 +402,9 @@ class _OriginClass:
 
 
 class Test_clone_class:
-    @patch.object(cunumeric.runtime, "report_coverage", True)
+    @patch.object(cunumeric.runtime.args, "report_coverage", True)
     def test_report_coverage_True(self) -> None:
-        assert cunumeric.runtime.report_coverage
+        assert cunumeric.runtime.args.report_coverage
 
         @m.clone_class(_OriginClass)
         class _Dest:
@@ -425,9 +425,9 @@ class Test_clone_class:
         assert _Dest.method2.__wrapped__
         assert _Dest.method2._cunumeric.implemented
 
-    @patch.object(cunumeric.runtime, "report_coverage", False)
+    @patch.object(cunumeric.runtime.args, "report_coverage", False)
     def test_report_coverage_False(self) -> None:
-        assert not cunumeric.runtime.report_coverage
+        assert not cunumeric.runtime.args.report_coverage
 
         @m.clone_class(_OriginClass)
         class _Dest:


### PR DESCRIPTION
This PR builds on https://github.com/nv-legate/legate.core/pull/232 to apply centralized argument parsing to `cunumeric`.

Questions:

* Is moving command line configs to `runtime.args` acceptable, or is there a better name (runtime.config)?