### PR TITLE
Use 64-bit integers for global thread ids

### DIFF
--- a/src/cunumeric/binary/binary_op.cu
+++ b/src/cunumeric/binary/binary_op.cu
@@ -27,7 +27,7 @@ template <typename Function, typename LHS, typename RHS1, typename RHS2>
 static __global__ void __launch_bounds__(THREADS_PER_BLOCK, MIN_CTAS_PER_SM)
   dense_kernel(size_t volume, Function func, LHS* out, const RHS1* in1, const RHS2* in2)
 {
-  const size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+  const size_t idx = global_tid_1d();
   if (idx >= volume) return;
   out[idx] = func(in1[idx], in2[idx]);
 }
@@ -47,7 +47,7 @@ static __global__ void __launch_bounds__(THREADS_PER_BLOCK, MIN_CTAS_PER_SM)
                  Pitches pitches,
                  Rect rect)
 {
-  const size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+  const size_t idx = global_tid_1d();
   if (idx >= volume) return;
   auto point = pitches.unflatten(idx, rect.lo);
   out[point] = func(in1[point], in2[point]);

--- a/src/cunumeric/binary/binary_red.cu
+++ b/src/cunumeric/binary/binary_red.cu
@@ -27,7 +27,7 @@ template <typename Function, typename RES, typename ARG>
 static __global__ void __launch_bounds__(THREADS_PER_BLOCK, MIN_CTAS_PER_SM)
   dense_kernel(size_t volume, Function func, RES out, const ARG* in1, const ARG* in2)
 {
-  const size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+  const size_t idx = global_tid_1d();
   if (idx >= volume) return;
   if (!func(in1[idx], in2[idx])) out <<= false;
 }
@@ -36,7 +36,7 @@ template <typename Function, typename RES, typename ReadAcc, typename Pitches, t
 static __global__ void __launch_bounds__(THREADS_PER_BLOCK, MIN_CTAS_PER_SM) generic_kernel(
   size_t volume, Function func, RES out, ReadAcc in1, ReadAcc in2, Pitches pitches, Rect rect)
 {
-  const size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+  const size_t idx = global_tid_1d();
   if (idx >= volume) return;
   auto point = pitches.unflatten(idx, rect.lo);
   if (!func(in1[point], in2[point])) out <<= false;

--- a/src/cunumeric/cuda_help.h
+++ b/src/cunumeric/cuda_help.h
@@ -72,6 +72,11 @@
 
 namespace cunumeric {
 
+__device__ inline size_t global_tid_1d()
+{
+  return static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+}
+
 struct cufftPlan {
   cufftHandle handle;
   size_t workarea_size;

--- a/src/cunumeric/index/choose.cu
+++ b/src/cunumeric/index/choose.cu
@@ -31,7 +31,7 @@ __global__ static void __launch_bounds__(THREADS_PER_BLOCK, MIN_CTAS_PER_SM)
                 const Pitches<DIM - 1> pitches,
                 int volume)
 {
-  const size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+  const size_t idx = global_tid_1d();
   if (idx >= volume) return;
   auto p = pitches.unflatten(idx, rect.lo);
   out[p] = choices[index_arr[p]][p];
@@ -42,7 +42,7 @@ template <typename VAL>
 __global__ static void __launch_bounds__(THREADS_PER_BLOCK, MIN_CTAS_PER_SM) choose_kernel_dense(
   VAL* outptr, const int64_t* indexptr, Buffer<const VAL*, 1> choices, int volume)
 {
-  const size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+  const size_t idx = global_tid_1d();
   if (idx >= volume) return;
   outptr[idx] = choices[indexptr[idx]][idx];
 }

--- a/src/cunumeric/index/repeat.cu
+++ b/src/cunumeric/index/repeat.cu
@@ -60,7 +60,7 @@ __global__ static void __launch_bounds__(THREADS_PER_BLOCK, MIN_CTAS_PER_SM)
                 const Pitches<DIM - 1> pitches,
                 const size_t volume)
 {
-  const size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+  const size_t idx = global_tid_1d();
   if (idx >= volume) return;
   auto out_p = pitches.unflatten(idx, Point<DIM>::ZEROES());
   auto in_p  = out_p;
@@ -80,7 +80,7 @@ __global__ static void __launch_bounds__(THREADS_PER_BLOCK, MIN_CTAS_PER_SM)
                 const Pitches<DIM - 1> pitches,
                 const int volume)
 {
-  const size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+  const size_t idx = global_tid_1d();
   if (idx >= volume) return;
   auto in_p  = pitches.unflatten(idx, in_lo);
   auto out_p = in_p - in_lo;

--- a/src/cunumeric/index/zip.cu
+++ b/src/cunumeric/index/zip.cu
@@ -32,7 +32,7 @@ __global__ static void __launch_bounds__(THREADS_PER_BLOCK, MIN_CTAS_PER_SM)
              DomainPoint shape,
              std::index_sequence<Is...>)
 {
-  const size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+  const size_t idx = global_tid_1d();
   if (idx >= volume) return;
   auto p = pitches.unflatten(idx, rect.lo);
   Legion::Point<N> new_point;
@@ -49,7 +49,7 @@ __global__ static void __launch_bounds__(THREADS_PER_BLOCK, MIN_CTAS_PER_SM)
                    DomainPoint shape,
                    std::index_sequence<Is...>)
 {
-  const size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+  const size_t idx = global_tid_1d();
   if (idx >= volume) return;
   Legion::Point<N> new_point;
   for (size_t i = 0; i < N; i++) { new_point[i] = compute_idx(index_arrays[i][idx], shape[i]); }
@@ -68,7 +68,7 @@ __global__ static void __launch_bounds__(THREADS_PER_BLOCK, MIN_CTAS_PER_SM)
              int64_t start_index,
              DomainPoint shape)
 {
-  const size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+  const size_t idx = global_tid_1d();
   if (idx >= volume) return;
   auto p = pitches.unflatten(idx, rect.lo);
   Legion::Point<N> new_point;

--- a/src/cunumeric/matrix/trilu.cu
+++ b/src/cunumeric/matrix/trilu.cu
@@ -33,7 +33,7 @@ static __global__ void __launch_bounds__(THREADS_PER_BLOCK, MIN_CTAS_PER_SM)
                size_t volume,
                int32_t k)
 {
-  const size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+  const size_t idx = global_tid_1d();
   if (idx >= volume) return;
 
   if (LOWER) {

--- a/src/cunumeric/nullary/fill.cu
+++ b/src/cunumeric/nullary/fill.cu
@@ -27,7 +27,7 @@ template <typename ARG, typename ReadAcc>
 static __global__ void __launch_bounds__(THREADS_PER_BLOCK, MIN_CTAS_PER_SM)
   dense_kernel(size_t volume, ARG* out, ReadAcc fill_value)
 {
-  const size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+  const size_t idx = global_tid_1d();
   if (idx >= volume) return;
   out[idx] = fill_value[0];
 }
@@ -36,7 +36,7 @@ template <typename WriteAcc, typename ReadAcc, typename Pitches, typename Rect>
 static __global__ void __launch_bounds__(THREADS_PER_BLOCK, MIN_CTAS_PER_SM)
   generic_kernel(size_t volume, WriteAcc out, ReadAcc fill_value, Pitches pitches, Rect rect)
 {
-  const size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+  const size_t idx = global_tid_1d();
   if (idx >= volume) return;
   auto point = pitches.unflatten(idx, rect.lo);
   out[point] = fill_value[0];

--- a/src/cunumeric/random/rand.cu
+++ b/src/cunumeric/random/rand.cu
@@ -27,7 +27,7 @@ template <typename WriteAcc, typename Rng, int32_t DIM>
 static __global__ void __launch_bounds__(THREADS_PER_BLOCK, MIN_CTAS_PER_SM) rand_kernel(
   size_t volume, WriteAcc out, Rng rng, Point<DIM> strides, Pitches<DIM - 1> pitches, Point<DIM> lo)
 {
-  const size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+  const size_t idx = global_tid_1d();
   if (idx >= volume) return;
   auto point    = pitches.unflatten(idx, lo);
   size_t offset = 0;

--- a/src/cunumeric/ternary/where.cu
+++ b/src/cunumeric/ternary/where.cu
@@ -27,7 +27,7 @@ template <typename VAL>
 static __global__ void __launch_bounds__(THREADS_PER_BLOCK, MIN_CTAS_PER_SM)
   dense_kernel(size_t volume, VAL* out, const bool* mask, const VAL* in1, const VAL* in2)
 {
-  const size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+  const size_t idx = global_tid_1d();
   if (idx >= volume) return;
   out[idx] = mask[idx] ? in1[idx] : in2[idx];
 }
@@ -36,7 +36,7 @@ template <typename WriteAcc, typename MaskAcc, typename ReadAcc, typename Pitche
 static __global__ void __launch_bounds__(THREADS_PER_BLOCK, MIN_CTAS_PER_SM) generic_kernel(
   size_t volume, WriteAcc out, MaskAcc mask, ReadAcc in1, ReadAcc in2, Pitches pitches, Rect rect)
 {
-  const size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+  const size_t idx = global_tid_1d();
   if (idx >= volume) return;
   auto point = pitches.unflatten(idx, rect.lo);
   out[point] = mask[point] ? in1[point] : in2[point];

--- a/src/cunumeric/transform/flip.cu
+++ b/src/cunumeric/transform/flip.cu
@@ -34,7 +34,7 @@ static __global__ void __launch_bounds__(THREADS_PER_BLOCK, MIN_CTAS_PER_SM)
               Buffer<int32_t, 1> axes,
               const uint32_t num_axes)
 {
-  const size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+  const size_t idx = global_tid_1d();
   if (idx >= volume) return;
   auto p = pitches.unflatten(idx, rect.lo);
   auto q = p;

--- a/src/cunumeric/unary/convert.cu
+++ b/src/cunumeric/unary/convert.cu
@@ -27,7 +27,7 @@ template <typename Function, typename ARG, typename RES>
 static __global__ void __launch_bounds__(THREADS_PER_BLOCK, MIN_CTAS_PER_SM)
   dense_kernel(size_t volume, Function func, RES* out, const ARG* in)
 {
-  const size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+  const size_t idx = global_tid_1d();
   if (idx >= volume) return;
   out[idx] = func(in[idx]);
 }
@@ -36,7 +36,7 @@ template <typename Function, typename ReadAcc, typename WriteAcc, typename Pitch
 static __global__ void __launch_bounds__(THREADS_PER_BLOCK, MIN_CTAS_PER_SM)
   generic_kernel(size_t volume, Function func, WriteAcc out, ReadAcc in, Pitches pitches, Rect rect)
 {
-  const size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+  const size_t idx = global_tid_1d();
   if (idx >= volume) return;
   auto point = pitches.unflatten(idx, rect.lo);
   out[point] = func(in[point]);

--- a/src/cunumeric/unary/unary_op.cu
+++ b/src/cunumeric/unary/unary_op.cu
@@ -27,7 +27,7 @@ template <typename Function, typename ARG, typename RES>
 static __global__ void __launch_bounds__(THREADS_PER_BLOCK, MIN_CTAS_PER_SM)
   dense_kernel(size_t volume, Function func, RES* out, const ARG* in)
 {
-  const size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+  const size_t idx = global_tid_1d();
   if (idx >= volume) return;
   out[idx] = func(in[idx]);
 }
@@ -36,7 +36,7 @@ template <typename Function, typename ReadAcc, typename WriteAcc, typename Pitch
 static __global__ void __launch_bounds__(THREADS_PER_BLOCK, MIN_CTAS_PER_SM)
   generic_kernel(size_t volume, Function func, WriteAcc out, ReadAcc in, Pitches pitches, Rect rect)
 {
-  const size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+  const size_t idx = global_tid_1d();
   if (idx >= volume) return;
   auto point = pitches.unflatten(idx, rect.lo);
   out[point] = func(in[point]);
@@ -46,7 +46,7 @@ template <typename VAL>
 static __global__ void __launch_bounds__(THREADS_PER_BLOCK, MIN_CTAS_PER_SM)
   dense_copy_kernel(size_t volume, VAL* out, const VAL* in)
 {
-  const size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+  const size_t idx = global_tid_1d();
   if (idx >= volume) return;
   out[idx] = in[idx];
 }
@@ -59,7 +59,7 @@ static __global__ void __launch_bounds__(THREADS_PER_BLOCK, MIN_CTAS_PER_SM)
                       Pitches<DIM - 1> pitches,
                       Rect<DIM> rect)
 {
-  const size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+  const size_t idx = global_tid_1d();
   if (idx >= volume) return;
   auto point = pitches.unflatten(idx, rect.lo);
   out[point] = in[point];
@@ -119,7 +119,7 @@ template <typename Function, typename LHS, typename RHS1, typename RHS2>
 static __global__ void __launch_bounds__(THREADS_PER_BLOCK, MIN_CTAS_PER_SM)
   dense_kernel_multiout(size_t volume, Function func, LHS* lhs, const RHS1* rhs1, RHS2* rhs2)
 {
-  const size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+  const size_t idx = global_tid_1d();
   if (idx >= volume) return;
   lhs[idx] = func(rhs1[idx], &rhs2[idx]);
 }
@@ -139,7 +139,7 @@ static __global__ void __launch_bounds__(THREADS_PER_BLOCK, MIN_CTAS_PER_SM)
                           Pitches pitches,
                           Rect rect)
 {
-  const size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+  const size_t idx = global_tid_1d();
   if (idx >= volume) return;
   auto point = pitches.unflatten(idx, rect.lo);
   lhs[point] = func(rhs1[point], rhs2.ptr(point));


### PR DESCRIPTION
All CUDA kernels were computing global thread ids incorrectly due to integer overflow with 32-bit geometry field values. This PR fixes the issue.