### PR TITLE
Implement __array_function__ and __array_ufunc__

### DIFF
--- a/cunumeric/array.py
+++ b/cunumeric/array.py
@@ -279,6 +279,9 @@ class ndarray:
         # For now we will just assume that at the very least we can convert
         # any such object to a baseline NumPy array using `np.array`, and
         # consume that.
+
+        # TODO: We could check at this point that our implementation supports
+        # all the provided arguments, and fall back to NumPy if not.
         return cn_func(*args, **kwargs)
 
     def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):

--- a/cunumeric/array.py
+++ b/cunumeric/array.py
@@ -304,8 +304,10 @@ class ndarray:
         # We cannot handle this ufunc call, so we will fall back to NumPy.
         # Ideally we would be able to skip the __array_ufunc__ dispatch, and
         # let NumPy convert our arrays automatically by calling our __array__
-        # method. Unfortunately there is no easy way to skip the dispatch
-        # mechnanism, therefore the best we can do is manually convert all
+        # method, similar to what we are doing for __array_function__ in
+        # coverage.py, by going through the _implementation field.
+        # Unfortunately, there is no easy way to skip the dispatch mechnanism
+        # for ufuncs, therefore the best we can do is manually convert all
         # cuNumeric arrays into NumPy arrays and try the call again.
         # One would expect NumPy to do exactly this if all __array_ufunc__
         # implementations return `NotImplemented` for a particular call, but

--- a/cunumeric/coverage.py
+++ b/cunumeric/coverage.py
@@ -122,6 +122,15 @@ def unimplemented(
 ) -> CuWrapped:
     name = f"{prefix}.{name}"
 
+    # Skip over NumPy's __array_function__ dispatch wrapper, if present.
+    # Say we're dealing with a call to `cunumeric.foo`, and are trying to fall
+    # back to `numpy.foo`. If we didn't skip the __array_function__ wrapper of
+    # `numpy.foo`, then NumPy would ask `cunumeric.ndarray.__array_function__`
+    # to handle the call to `numpy.foo`, then
+    # `cunumeric.ndarray.__array_function__` would call `cunumeric.foo`, and we
+    # would end up here again, thus creating infinite recursion.
+    func = getattr(func, "_implementation", func)
+
     wrapper: CuWrapped
 
     if reporting:

--- a/cunumeric/coverage.py
+++ b/cunumeric/coverage.py
@@ -122,13 +122,18 @@ def unimplemented(
 ) -> CuWrapped:
     name = f"{prefix}.{name}"
 
-    # Skip over NumPy's __array_function__ dispatch wrapper, if present.
-    # Say we're dealing with a call to `cunumeric.foo`, and are trying to fall
-    # back to `numpy.foo`. If we didn't skip the __array_function__ wrapper of
-    # `numpy.foo`, then NumPy would ask `cunumeric.ndarray.__array_function__`
-    # to handle the call to `numpy.foo`, then
-    # `cunumeric.ndarray.__array_function__` would call `cunumeric.foo`, and we
-    # would end up here again, thus creating infinite recursion.
+    # Skip over NumPy's `__array_function__` dispatch wrapper, if present.
+    # NumPy adds `__array_function__` dispatch logic through decorators, but
+    # still makes the underlying code (which converts all array-like arguments
+    # to `numpy.ndarray` through `__array__`) available in the
+    # `_implementation` field.
+    # We have to skip the dispatch wrapper, otherwise we will trigger an
+    # infinite loop. Say we're dealing with a call to `cunumeric.foo`, and are
+    # trying to fall back to `numpy.foo`. If we didn't skip the dispatch
+    # wrapper of `numpy.foo`, then NumPy would ask
+    # `cunumeric.ndarray.__array_function__` to handle the call to `numpy.foo`,
+    # then `cunumeric.ndarray.__array_function__` would call `cunumeric.foo`,
+    # and we would end up here again.
     func = getattr(func, "_implementation", func)
 
     wrapper: CuWrapped

--- a/tests/integration/test_array_dunders.py
+++ b/tests/integration/test_array_dunders.py
@@ -1,0 +1,83 @@
+# Copyright 2022 NVIDIA Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import numpy as np
+import pytest
+
+import cunumeric as cn
+
+
+def test_array_dunders():
+    np_arr = np.eye(4)
+    np_vec = np.arange(4).astype(np.float64)
+    cn_arr = cn.array(np_arr)
+    cn_vec = cn.array(np_vec)
+    indices = [0, 3, 1, 2]
+
+    # module-level functions
+
+    np_res = np.dot(np_arr, np_vec)
+    cn_res = np.dot(cn_arr, cn_vec)
+    assert np.array_equal(np_res, cn_res)
+    assert isinstance(cn_res, cn.ndarray)  # implemented
+
+    np_res = np.linalg.solve(np_arr, np_vec)
+    cn_res = np.linalg.solve(cn_arr, cn_vec)
+    assert np.array_equal(np_res, cn_res)
+    assert isinstance(cn_res, np.ndarray)  # unimplemented
+
+    # ufunc invoked indirectly, through __op__ array method
+
+    assert np.array_equal(cn_vec + cn_vec, np_vec + np_vec)
+    assert isinstance(cn_vec + np_vec, cn.ndarray)
+    assert isinstance(np_vec + cn_vec, cn.ndarray)
+
+    # ufunc invoked directly, on NumPy ufunc object
+
+    np_res = np.add(np_vec, np_vec)
+    cn_res = np.add(cn_vec, cn_vec)
+    assert np.array_equal(np_res, cn_res)
+    assert isinstance(cn_res, cn.ndarray)  # implemented
+
+    np_res = np.add.reduce(np_vec)
+    cn_res = np.add.reduce(cn_vec)
+    assert np.array_equal(np_res, cn_res)
+    assert isinstance(cn_res, cn.ndarray)  # implemented
+
+    np_res = np.add.accumulate(np_vec)
+    cn_res = np.add.accumulate(cn_vec)
+    assert np.array_equal(np_res, cn_res)
+    assert isinstance(cn_res, np.ndarray)  # unimplemented
+
+    np_res = np.add.reduceat(np_vec, indices)
+    cn_res = np.add.reduceat(cn_vec, indices)
+    assert np.array_equal(np_res, cn_res)
+    assert isinstance(cn_res, np.ndarray)  # unimplemented
+
+    np_res = np.add.outer(np_vec, np_vec)
+    cn_res = np.add.outer(cn_vec, cn_vec)
+    assert np.array_equal(np_res, cn_res)
+    assert isinstance(cn_res, np.ndarray)  # unimplemented
+
+    np.add.at(np_vec, indices, np_vec)
+    np.add.at(cn_vec, indices, cn_vec)
+    assert np.array_equal(np_vec, cn_vec)
+    assert isinstance(cn_vec, cn.ndarray)
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main(sys.argv))

--- a/tests/integration/test_array_dunders.py
+++ b/tests/integration/test_array_dunders.py
@@ -18,63 +18,75 @@ import pytest
 
 import cunumeric as cn
 
+np_arr = np.eye(4)
+np_vec = np.arange(4).astype(np.float64)
+cn_arr = cn.array(np_arr)
+cn_vec = cn.array(np_vec)
+indices = [0, 3, 1, 2]
 
-def test_array_dunders():
-    np_arr = np.eye(4)
-    np_vec = np.arange(4).astype(np.float64)
-    cn_arr = cn.array(np_arr)
-    cn_vec = cn.array(np_vec)
-    indices = [0, 3, 1, 2]
 
-    # module-level functions
-
+def test_array_function_implemented():
     np_res = np.dot(np_arr, np_vec)
     cn_res = np.dot(cn_arr, cn_vec)
     assert np.array_equal(np_res, cn_res)
     assert isinstance(cn_res, cn.ndarray)  # implemented
 
+
+def test_array_function_unimplemented():
     np_res = np.linalg.solve(np_arr, np_vec)
     cn_res = np.linalg.solve(cn_arr, cn_vec)
     assert np.array_equal(np_res, cn_res)
     assert isinstance(cn_res, np.ndarray)  # unimplemented
 
-    # ufunc invoked indirectly, through __op__ array method
 
+def test_array_ufunc_through_array_op():
     assert np.array_equal(cn_vec + cn_vec, np_vec + np_vec)
     assert isinstance(cn_vec + np_vec, cn.ndarray)
     assert isinstance(np_vec + cn_vec, cn.ndarray)
 
-    # ufunc invoked directly, on NumPy ufunc object
 
+def test_array_ufunc_call():
     np_res = np.add(np_vec, np_vec)
     cn_res = np.add(cn_vec, cn_vec)
     assert np.array_equal(np_res, cn_res)
     assert isinstance(cn_res, cn.ndarray)  # implemented
 
+
+def test_array_ufunc_reduce():
     np_res = np.add.reduce(np_vec)
     cn_res = np.add.reduce(cn_vec)
     assert np.array_equal(np_res, cn_res)
     assert isinstance(cn_res, cn.ndarray)  # implemented
 
+
+def test_array_ufunc_accumulate():
     np_res = np.add.accumulate(np_vec)
     cn_res = np.add.accumulate(cn_vec)
     assert np.array_equal(np_res, cn_res)
     assert isinstance(cn_res, np.ndarray)  # unimplemented
 
+
+def test_array_ufunc_reduceat():
     np_res = np.add.reduceat(np_vec, indices)
     cn_res = np.add.reduceat(cn_vec, indices)
     assert np.array_equal(np_res, cn_res)
     assert isinstance(cn_res, np.ndarray)  # unimplemented
 
+
+def test_array_ufunc_outer():
     np_res = np.add.outer(np_vec, np_vec)
     cn_res = np.add.outer(cn_vec, cn_vec)
     assert np.array_equal(np_res, cn_res)
     assert isinstance(cn_res, np.ndarray)  # unimplemented
 
-    np.add.at(np_vec, indices, np_vec)
-    np.add.at(cn_vec, indices, cn_vec)
-    assert np.array_equal(np_vec, cn_vec)
-    assert isinstance(cn_vec, cn.ndarray)
+
+def test_array_ufunc_at():
+    np_res = np.full((4,), 42)
+    cn_res = cn.full((4,), 42)
+    np.add.at(np_res, indices, np_vec)
+    np.add.at(cn_res, indices, cn_vec)
+    assert np.array_equal(np_res, cn_res)
+    assert isinstance(cn_res, cn.ndarray)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I originally had higher hopes about this feature. I was hoping we could reuse some generic code in NumPy, like `np.multi_dot` and `np.matrix_power`, by convincing NumPy to just use our array objects without converting back to `np.ndarray`, which should fundamentally be possible, since we implement the same interface. See https://github.com/manopapad/cunumeric/commit/bd833be0a2d32a6ef40eda354e6f4b228e2db08a if you're curious on why I couldn't make this work.

Note that some of the code in `__array_ufunc__` would ideally go into a `coverage.py` wrapper, but I will need some advice on how to do that, as it will affect the coverage reporting (I would want to separate out each ufunc `foo` into multiple functions, like `foo.reduce` and `foo.accumulate`).