### PR TITLE
Fix return types for some of the unary ops

### DIFF
--- a/src/cunumeric/unary/unary_op_util.h
+++ b/src/cunumeric/unary/unary_op_util.h
@@ -202,13 +202,18 @@ struct UnaryOp<UnaryOpCode::ABSOLUTE, CODE> {
 
   UnaryOp(const std::vector<legate::Store>& args) {}
 
-  template <
-    typename _T                                                                    = T,
-    std::enable_if_t<legate::is_complex<_T>::value or
-                     (std::is_integral<_T>::value and std::is_signed<_T>::value)>* = nullptr>
+  template <typename _T = T, std::enable_if_t<legate::is_complex<_T>::value>* = nullptr>
   constexpr decltype(auto) operator()(const _T& x) const
   {
     return abs(x);
+  }
+
+  template <
+    typename _T                                                                    = T,
+    std::enable_if_t<(std::is_integral<_T>::value and std::is_signed<_T>::value)>* = nullptr>
+  constexpr _T operator()(const _T& x) const
+  {
+    return x >= 0 ? x : -x;
   }
 
   template <
@@ -222,10 +227,10 @@ struct UnaryOp<UnaryOpCode::ABSOLUTE, CODE> {
   template <
     typename _T                                                                        = T,
     std::enable_if_t<!legate::is_complex<_T>::value and !std::is_integral<_T>::value>* = nullptr>
-  constexpr decltype(auto) operator()(const _T& x) const
+  constexpr _T operator()(const _T& x) const
   {
     using std::fabs;
-    return fabs(x);
+    return static_cast<_T>(fabs(x));
   }
 };
 
@@ -889,7 +894,7 @@ struct UnaryOp<UnaryOpCode::NEGATIVE, CODE> {
 
   UnaryOp(const std::vector<legate::Store>& args) {}
 
-  constexpr decltype(auto) operator()(const T& x) const { return -x; }
+  constexpr T operator()(const T& x) const { return -x; }
 };
 
 template <legate::LegateTypeCode CODE>
@@ -1116,7 +1121,7 @@ struct UnaryOp<UnaryOpCode::SQUARE, CODE> {
 
   UnaryOp(const std::vector<legate::Store>& args) {}
 
-  constexpr decltype(auto) operator()(const T& x) const { return x * x; }
+  constexpr T operator()(const T& x) const { return x * x; }
 };
 
 template <legate::LegateTypeCode CODE>

--- a/tests/integration/test_unary_ufunc.py
+++ b/tests/integration/test_unary_ufunc.py
@@ -101,6 +101,8 @@ def test_all():
     check_ops(ops, (np.random.randn(4, 5),))
     check_ops(ops, (np.random.randn(4, 5).astype("e"),))
     check_ops(ops, (np.random.randn(4, 5).astype("f"),))
+    check_ops(ops, (np.random.randn(4, 5).astype("b"),))
+    check_ops(ops, (np.random.randn(4, 5).astype("B"),))
     check_ops(ops, (np.random.randint(1, 10, size=(4, 5)),))
     check_ops(ops, (np.random.randn(1)[0],))
 
@@ -176,9 +178,6 @@ def test_all():
     ops = [
         "ceil",
         "floor",
-        # "fmod",
-        # "frexp",
-        # "modf",
         "signbit",
         # "spacing",
         "trunc",


### PR DESCRIPTION
It turns out built-in operators don't do what I expect them to do but silently promote result types, which makes it incorrect to use `decltype(auto)` all the time. This PR is to use correct return types for the unary ops relying on the built-in and also add test cases with int8 and uint8 arrays.