### PR TITLE
Remove special case handling for scalar arrays

### DIFF
--- a/cunumeric/array.py
+++ b/cunumeric/array.py
@@ -31,7 +31,8 @@ from .utils import dot_modes
 
 def add_boilerplate(*array_params: str):
     """
-    Adds required boilerplate to the wrapped cuNumeric ndarray member function.
+    Adds required boilerplate to the wrapped cunumeric.ndarray or module-level
+    function.
 
     Every time the wrapped function is called, this wrapper will:
     * Convert all specified array-like parameters, plus the special "out"

--- a/cunumeric/array.py
+++ b/cunumeric/array.py
@@ -29,7 +29,7 @@ from .runtime import runtime
 from .utils import dot_modes
 
 
-def add_boilerplate(*array_params: str, mutates_self: bool = False):
+def add_boilerplate(*array_params: str):
     """
     Adds required boilerplate to the wrapped cuNumeric ndarray member function.
 
@@ -37,11 +37,6 @@ def add_boilerplate(*array_params: str, mutates_self: bool = False):
     * Convert all specified array-like parameters, plus the special "out"
       parameter (if present), to cuNumeric ndarrays.
     * Convert the special "where" parameter (if present) to a valid predicate.
-    * Handle the case of scalar cuNumeric ndarrays, by forwarding the operation
-      to the equivalent `()`-shape numpy array.
-
-    NOTE: Assumes that no parameters are mutated besides `out`, and `self` if
-    `mutates_self` is True.
     """
     keys: Set[str] = set(array_params)
 
@@ -61,7 +56,6 @@ def add_boilerplate(*array_params: str, mutates_self: bool = False):
             if param == "where":
                 where_idx = idx
             elif param == "out":
-                assert not mutates_self
                 out_idx = idx
             elif param in keys:
                 indices.add(idx)
@@ -69,7 +63,6 @@ def add_boilerplate(*array_params: str, mutates_self: bool = False):
 
         @wraps(func)
         def wrapper(*args, **kwargs):
-            self = args[0]
             assert (where_idx is None or len(args) <= where_idx) and (
                 out_idx is None or len(args) <= out_idx
             ), "'where' and 'out' should be passed as keyword arguments"
@@ -90,51 +83,6 @@ def add_boilerplate(*array_params: str, mutates_self: bool = False):
                     kwargs[k] = convert_to_cunumeric_ndarray(v, share=True)
                 elif k in keys:
                     kwargs[k] = convert_to_cunumeric_ndarray(v)
-
-            # Handle the case where all array-like parameters are scalar, by
-            # performing the operation on the equivalent scalar numpy arrays.
-            # NOTE: This implicitly blocks on the contents of these arrays.
-            if all(
-                arg._thunk.scalar
-                for (idx, arg) in enumerate(args)
-                if (idx in indices or idx == 0) and isinstance(arg, ndarray)
-            ) and all(
-                v._thunk.scalar
-                for (k, v) in kwargs.items()
-                if (k in keys or k == "where") and isinstance(v, ndarray)
-            ):
-                out = None
-                if "out" in kwargs:
-                    out = kwargs["out"]
-                    del kwargs["out"]
-                args = tuple(
-                    arg._thunk.__numpy_array__()
-                    if (idx in indices or idx == 0)
-                    and isinstance(arg, ndarray)
-                    else arg
-                    for (idx, arg) in enumerate(args)
-                )
-                for (k, v) in kwargs.items():
-                    if (k in keys or k == "where") and isinstance(v, ndarray):
-                        kwargs[k] = v._thunk.__numpy_array__()
-                self_scalar = args[0]
-                args = args[1:]
-                res_scalar = getattr(self_scalar, func.__name__)(
-                    *args, **kwargs
-                )
-                if mutates_self:
-                    self._thunk = runtime.create_scalar(
-                        self_scalar.data,
-                        self_scalar.dtype,
-                        shape=self_scalar.shape,
-                        wrap=True,
-                    )
-                    return
-                result = convert_to_cunumeric_ndarray(res_scalar)
-                if out is not None:
-                    out._thunk.copy(result._thunk)
-                    result = out
-                return result
 
             return func(*args, **kwargs)
 
@@ -1430,7 +1378,7 @@ class ndarray:
 
     # __setattr__
 
-    @add_boilerplate("value", mutates_self=True)
+    @add_boilerplate("value")
     def __setitem__(self, key, value):
         """__setitem__(key, value, /)
 

--- a/cunumeric/module.py
+++ b/cunumeric/module.py
@@ -52,11 +52,6 @@ def add_boilerplate(*array_params: str):
     * Convert all specified array-like parameters, plus the special "out"
       parameter (if present), to cuNumeric ndarrays.
     * Convert the special "where" parameter (if present) to a valid predicate.
-    * Handle the case of scalar cuNumeric ndarrays, by forwarding the operation
-      to the equivalent `()`-shape numpy array (if the operation exists on base
-      numpy).
-
-    NOTE: Assumes that no parameters are mutated besides `out`.
     """
     keys: Set[str] = set(array_params)
 
@@ -103,44 +98,6 @@ def add_boilerplate(*array_params: str):
                     kwargs[k] = convert_to_cunumeric_ndarray(v, share=True)
                 elif k in keys:
                     kwargs[k] = convert_to_cunumeric_ndarray(v)
-
-            # Handle the case where all array-like parameters are scalar, by
-            # performing the operation on the equivalent scalar numpy arrays.
-            # NOTE: This implicitly blocks on the contents of these arrays.
-            if (
-                hasattr(np, func.__name__)
-                and _builtin_all(
-                    isinstance(args[idx], ndarray) and args[idx]._thunk.scalar
-                    for idx in indices
-                )
-                and _builtin_all(
-                    isinstance(v, ndarray) and v._thunk.scalar
-                    for v in (kwargs.get("where", None),)
-                )
-            ):
-                out = None
-                if "out" in kwargs:
-                    out = kwargs["out"]
-                    del kwargs["out"]
-                args = tuple(
-                    arg._thunk.__numpy_array__()
-                    if (idx in indices) and isinstance(arg, ndarray)
-                    else arg
-                    for (idx, arg) in enumerate(args)
-                )
-                for (k, v) in kwargs.items():
-                    if (k in keys or k == "where") and isinstance(v, ndarray):
-                        kwargs[k] = v._thunk.__numpy_array__()
-                result = convert_to_cunumeric_ndarray(
-                    getattr(np, func.__name__)(*args, **kwargs)
-                )
-                if out is not None:
-                    if out._thunk.dtype != result._thunk.dtype:
-                        out._thunk.convert(result._thunk, warn=False)
-                    else:
-                        out._thunk.copy(result._thunk)
-                    result = out
-                return result
 
             return func(*args, **kwargs)
 

--- a/cunumeric/module.py
+++ b/cunumeric/module.py
@@ -16,10 +16,7 @@
 import math
 import re
 from collections import Counter
-from functools import wraps
-from inspect import signature
 from itertools import chain
-from typing import Optional, Set
 
 import numpy as np
 import opt_einsum as oe
@@ -27,11 +24,7 @@ from cunumeric._ufunc.comparison import maximum, minimum
 from cunumeric._ufunc.floating import floor
 from cunumeric._ufunc.math import add, multiply
 
-from .array import (
-    convert_to_cunumeric_ndarray,
-    convert_to_predicate_ndarray,
-    ndarray,
-)
+from .array import add_boilerplate, convert_to_cunumeric_ndarray, ndarray
 from .config import BinaryOpCode, UnaryRedCode
 from .runtime import runtime
 from .utils import inner_modes, matmul_modes, tensordot_modes
@@ -42,68 +35,6 @@ _builtin_any = any
 _builtin_max = max
 _builtin_min = min
 _builtin_sum = sum
-
-
-def add_boilerplate(*array_params: str):
-    """
-    Adds required boilerplate to the wrapped module-level ndarray function.
-
-    Every time the wrapped function is called, this wrapper will:
-    * Convert all specified array-like parameters, plus the special "out"
-      parameter (if present), to cuNumeric ndarrays.
-    * Convert the special "where" parameter (if present) to a valid predicate.
-    """
-    keys: Set[str] = set(array_params)
-
-    def decorator(func):
-        assert not hasattr(
-            func, "__wrapped__"
-        ), "this decorator must be the innermost"
-
-        # For each parameter specified by name, also consider the case where
-        # it's passed as a positional parameter.
-        indices: Set[int] = set()
-        all_formals: Set[str] = set()
-        where_idx: Optional[int] = None
-        out_idx: Optional[int] = None
-        for (idx, param) in enumerate(signature(func).parameters):
-            all_formals.add(param)
-            if param == "where":
-                where_idx = idx
-            elif param == "out":
-                out_idx = idx
-            elif param in keys:
-                indices.add(idx)
-        assert len(keys - all_formals) == 0, "unkonwn parameter(s)"
-
-        @wraps(func)
-        def wrapper(*args, **kwargs):
-            assert (where_idx is None or len(args) <= where_idx) and (
-                out_idx is None or len(args) <= out_idx
-            ), "'where' and 'out' should be passed as keyword arguments"
-
-            # Convert relevant arguments to cuNumeric ndarrays
-            args = tuple(
-                convert_to_cunumeric_ndarray(arg)
-                if idx in indices and arg is not None
-                else arg
-                for (idx, arg) in enumerate(args)
-            )
-            for (k, v) in kwargs.items():
-                if v is None:
-                    continue
-                elif k == "where":
-                    kwargs[k] = convert_to_predicate_ndarray(v)
-                elif k == "out":
-                    kwargs[k] = convert_to_cunumeric_ndarray(v, share=True)
-                elif k in keys:
-                    kwargs[k] = convert_to_cunumeric_ndarray(v)
-
-            return func(*args, **kwargs)
-
-        return wrapper
-
-    return decorator
 
 
 #########################

--- a/src/cunumeric/unary/unary_red_template.inl
+++ b/src/cunumeric/unary/unary_red_template.inl
@@ -98,12 +98,14 @@ struct UnaryRedDispatch {
   template <UnaryRedCode OP_CODE, std::enable_if_t<!is_arg_reduce<OP_CODE>::value>* = nullptr>
   void operator()(UnaryRedArgs& args) const
   {
-    return double_dispatch(args.rhs.dim(), args.rhs.code(), UnaryRedImpl<KIND, OP_CODE>{}, args);
+    auto dim = std::max(1, args.rhs.dim());
+    return double_dispatch(dim, args.rhs.code(), UnaryRedImpl<KIND, OP_CODE>{}, args);
   }
   template <UnaryRedCode OP_CODE, std::enable_if_t<is_arg_reduce<OP_CODE>::value>* = nullptr>
   void operator()(UnaryRedArgs& args) const
   {
-    return double_dispatch(args.rhs.dim(), args.rhs.code(), ArgRedImpl<KIND, OP_CODE>{}, args);
+    auto dim = std::max(1, args.rhs.dim());
+    return double_dispatch(dim, args.rhs.code(), ArgRedImpl<KIND, OP_CODE>{}, args);
   }
 };
 

--- a/tests/integration/test_view.py
+++ b/tests/integration/test_view.py
@@ -38,6 +38,16 @@ def test_basic():
     y = x[2:, 2:]
     assert np.array_equal(ynp, y)
 
+    # views over scalar values are writable
+    x = num.ones((1,))
+    y = x.reshape((1, 1))
+    y[:] = 2
+    assert np.array_equal(x, [2])
+    assert np.array_equal(y, [[2]])
+    y[:] = 3
+    assert np.array_equal(x, [3])
+    assert np.array_equal(y, [[3]])
+
 
 if __name__ == "__main__":
     import sys


### PR DESCRIPTION
This code is not compatible with functions that return views. For example, consider what happens when we fall back to NumPy arrays in this example:

```
x = cn.ones((1,))
y = x.reshape((1, 1))
y[:] = 2
```

The fallback code will execute the `reshape` operation onto a freshly allocated NumPy array mirroring `x`, and therefore `y` will not be a view over the same memory as `x`.

Instead of removing this path altogether we could just allow/block functions that cannot/might create views, but we had already been considering removing this path anyway, because it introduces blocking. @magnatelee do you have a preference on how to handle this?