### PR TITLE
Allow DeferredThunks to be created for empty arrays

### DIFF
--- a/cunumeric/array.py
+++ b/cunumeric/array.py
@@ -3432,7 +3432,7 @@ class ndarray:
                 array_types.append(array.dtype)
         return np.find_common_type(array_types, scalar_types)
 
-    def _maybe_convert(self, dtype, *hints):
+    def _maybe_convert(self, dtype, hints):
         if self.dtype == dtype:
             return self
         copy = ndarray(shape=self.shape, dtype=dtype, inputs=hints)

--- a/cunumeric/runtime.py
+++ b/cunumeric/runtime.py
@@ -407,10 +407,6 @@ class Runtime(object):
             # Don't store this one in the ptr_to_thunk as we only want to
             # store the root ones
             return parent_thunk.get_item(key)
-        elif array.size == 0:
-            # We always store completely empty arrays with eager thunks
-            assert not defer
-            return EagerArray(self, array)
         # Once it's a normal numpy array we can make it into one of our arrays
         # Check to see if it is a type that we support for doing deferred
         # execution and big enough to be worth off-loading onto Legion
@@ -473,7 +469,7 @@ class Runtime(object):
 
     def is_eager_shape(self, shape):
         volume = calculate_volume(shape)
-        # Empty arrays are ALWAYS eager
+        # Newly created empty arrays are ALWAYS eager
         if volume == 0:
             return True
         # If we're testing then the answer is always no


### PR DESCRIPTION
We need to allow `find_or_create_array_thunk` to create `DeferredThunk`s for empty arrays as well. Consider this example:

```
x = cn.nonzero([0,0,0])[0]  # creates a deferred empty ndarray
y = cn.ones((0,))  # creates an eager empty ndarray
x + y
```

Here `DeferredThunk.binary_op` will try to convert all its arguments to `DeferredArray`s, and that will end up calling `find_or_create_array_thunk` on `y`.

This PR also fixes a typo discovered while fixing this.