### PR TITLE
First pass mypy typing 

### DIFF
--- a/cunumeric/__init__.py
+++ b/cunumeric/__init__.py
@@ -22,6 +22,7 @@ with GPU acceleration.
 
 :meta private:
 """
+from __future__ import annotations
 
 import numpy as _np
 

--- a/cunumeric/_sphinxext/__init__.py
+++ b/cunumeric/_sphinxext/__init__.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from __future__ import annotations
 
 from typing import TypedDict
 

--- a/cunumeric/_sphinxext/_comparison_config.py
+++ b/cunumeric/_sphinxext/_comparison_config.py
@@ -73,8 +73,8 @@ MISSING_NP_REFS = {
 class SectionConfig:
     title: str
     attr: str | None
-    types: tuple(type) | None = None
-    names: tuple(str) | None = None
+    types: tuple[type, ...] | None = None
+    names: tuple[str, ...] | None = None
 
 
 FUNCTIONS = (FunctionType, BuiltinFunctionType)

--- a/cunumeric/_sphinxext/_cunumeric_directive.py
+++ b/cunumeric/_sphinxext/_cunumeric_directive.py
@@ -21,7 +21,7 @@ from sphinx.util.nodes import nested_parse_with_titles
 
 
 class CunumericDirective(SphinxDirective):
-    def parse(self, rst_text, annotation):
+    def parse(self, rst_text: str, annotation: str) -> nodes.Node:
         result = ViewList()
         for line in rst_text.split("\n"):
             result.append(line, annotation)

--- a/cunumeric/_sphinxext/comparison_table.py
+++ b/cunumeric/_sphinxext/comparison_table.py
@@ -14,10 +14,12 @@
 #
 from __future__ import annotations
 
+from docutils import nodes
 from docutils.parsers.rst.directives import choice
+from sphinx.application import Sphinx
 from sphinx.util.logging import getLogger
 
-from . import PARALLEL_SAFE
+from . import PARALLEL_SAFE, SphinxParallelSpec
 from ._comparison_config import GROUPED_CONFIGS, NUMPY_CONFIGS
 from ._comparison_util import generate_section
 from ._cunumeric_directive import CunumericDirective
@@ -36,7 +38,7 @@ class ComparisonTable(CunumericDirective):
         "sections": lambda x: choice(x, ("numpy", "grouped")),
     }
 
-    def run(self):
+    def run(self) -> nodes.Node:
         if self.options.get("sections", "numpy") == "numpy":
             section_configs = NUMPY_CONFIGS
         else:
@@ -50,6 +52,6 @@ class ComparisonTable(CunumericDirective):
         return self.parse(rst_text, "<comparison-table>")
 
 
-def setup(app):
+def setup(app: Sphinx) -> SphinxParallelSpec:
     app.add_directive_to_domain("py", "comparison-table", ComparisonTable)
     return PARALLEL_SAFE

--- a/cunumeric/_sphinxext/ufunc_formatter.py
+++ b/cunumeric/_sphinxext/ufunc_formatter.py
@@ -12,12 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from __future__ import annotations
 
+from typing import Any
+
+from sphinx.application import Sphinx
 from sphinx.ext.autodoc import FunctionDocumenter
 
 from cunumeric import ufunc
 
-from . import PARALLEL_SAFE
+from . import PARALLEL_SAFE, SphinxParallelSpec
 
 
 class UfuncDocumenter(FunctionDocumenter):
@@ -26,10 +30,12 @@ class UfuncDocumenter(FunctionDocumenter):
     priority = 20
 
     @classmethod
-    def can_document_member(cls, member, membername, isattr, parent):
+    def can_document_member(
+        cls, member: Any, membername: str, isattr: bool, parent: Any
+    ) -> bool:
         return isinstance(getattr(member, "__wrapped__", None), ufunc)
 
 
-def setup(app):
+def setup(app: Sphinx) -> SphinxParallelSpec:
     app.add_autodocumenter(UfuncDocumenter)
     return PARALLEL_SAFE

--- a/cunumeric/_ufunc/__init__.py
+++ b/cunumeric/_ufunc/__init__.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from __future__ import annotations
 
 from .bit_twiddling import *
 from .comparison import *

--- a/cunumeric/_ufunc/bit_twiddling.py
+++ b/cunumeric/_ufunc/bit_twiddling.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from __future__ import annotations
 
 from cunumeric.config import BinaryOpCode, UnaryOpCode
 

--- a/cunumeric/_ufunc/comparison.py
+++ b/cunumeric/_ufunc/comparison.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from __future__ import annotations
 
 from cunumeric.config import BinaryOpCode, UnaryOpCode, UnaryRedCode
 

--- a/cunumeric/_ufunc/floating.py
+++ b/cunumeric/_ufunc/floating.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from __future__ import annotations
 
 from cunumeric.config import BinaryOpCode, UnaryOpCode
 

--- a/cunumeric/_ufunc/math.py
+++ b/cunumeric/_ufunc/math.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from __future__ import annotations
 
 from cunumeric.config import BinaryOpCode, UnaryOpCode, UnaryRedCode
 

--- a/cunumeric/_ufunc/trigonometric.py
+++ b/cunumeric/_ufunc/trigonometric.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from __future__ import annotations
 
 from cunumeric.config import BinaryOpCode, UnaryOpCode
 

--- a/cunumeric/_ufunc/ufunc.py
+++ b/cunumeric/_ufunc/ufunc.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from __future__ import annotations
 
 import numpy as np
 

--- a/cunumeric/_ufunc/ufunc.py
+++ b/cunumeric/_ufunc/ufunc.py
@@ -14,9 +14,19 @@
 #
 from __future__ import annotations
 
+from typing import TYPE_CHECKING, Any, Literal, Sequence, Union
+
 import numpy as np
 
 from ..array import convert_to_cunumeric_ndarray, ndarray
+from ..config import BinaryOpCode, UnaryOpCode, UnaryRedCode
+
+if TYPE_CHECKING:
+    import numpy.typing as npt
+
+CastingKind = Union[
+    Literal["no", "equiv", "safe", "same_kind", "unsafe"], None
+]
 
 _UNARY_DOCSTRING_TEMPLATE = """{}
 
@@ -155,52 +165,51 @@ all_but_boolean = integer_dtypes + float_and_complex
 all_dtypes = ["?"] + all_but_boolean
 
 
-def predicate_types_of(dtypes):
+def predicate_types_of(dtypes: Sequence[str]) -> list[str]:
     return [ty + "?" for ty in dtypes]
 
 
-def relation_types_of(dtypes):
+def relation_types_of(dtypes: Sequence[str]) -> list[str]:
     return [ty * 2 + "?" for ty in dtypes]
 
 
-def to_dtypes(chars):
+def to_dtypes(chars: str) -> tuple[np.dtype[Any], ...]:
     return tuple(np.dtype(char) for char in chars)
 
 
 class ufunc:
-    def __init__(self, name, doc, types):
+    def __init__(self, name: str, doc: str, types: dict[Any, str]) -> None:
         self._name = name
         self._types = types
         self.__doc__ = doc
-        self._nin = None
-        self._nout = None
-        for in_ty, out_ty in self._types.items():
-            self._nin = len(in_ty)
-            self._nout = len(out_ty)
-            break
-        assert self._nin is not None
-        assert self._nout is not None
+
+        assert len(self._types)
+        in_ty, out_ty = next(iter(self._types.items()))
+        self._nin = len(in_ty)
+        self._nout = len(out_ty)
 
     @property
-    def nin(self):
+    def nin(self) -> int:
         return self._nin
 
     @property
-    def nout(self):
+    def nout(self) -> int:
         return self._nout
 
     @property
-    def types(self):
+    def types(self) -> list[str]:
         return [
             f"{''.join(in_tys)}->{''.join(out_tys)}"
             for in_tys, out_tys in self._types.items()
         ]
 
     @property
-    def ntypes(self):
+    def ntypes(self) -> int:
         return len(self._types)
 
-    def _maybe_cast_input(self, arr, to_dtype, casting):
+    def _maybe_cast_input(
+        self, arr: ndarray, to_dtype: np.dtype[Any], casting: CastingKind
+    ) -> ndarray:
         if arr.dtype == to_dtype:
             return arr
 
@@ -212,7 +221,14 @@ class ufunc:
 
         return arr.astype(to_dtype)
 
-    def _maybe_create_result(self, out, out_shape, res_dtype, casting, inputs):
+    def _maybe_create_result(
+        self,
+        out: Union[ndarray, None],
+        out_shape: tuple[int, ...],
+        res_dtype: np.dtype[Any],
+        casting: CastingKind,
+        inputs: Union[tuple[ndarray, bool], tuple[ndarray, ndarray, bool]],
+    ) -> ndarray:
         if out is None:
             return ndarray(shape=out_shape, dtype=res_dtype, inputs=inputs)
         elif out.dtype != res_dtype:
@@ -227,25 +243,34 @@ class ufunc:
             return out
 
     @staticmethod
-    def _maybe_cast_output(out, result):
+    def _maybe_cast_output(
+        out: Union[ndarray, None], result: ndarray
+    ) -> ndarray:
         if out is None or out is result:
             return result
-        else:
-            out._thunk.convert(result._thunk, warn=False)
-            return out
+        out._thunk.convert(result._thunk, warn=False)
+        return out
 
     @staticmethod
-    def _maybe_convert_output_to_cunumeric_ndarray(out):
+    def _maybe_convert_output_to_cunumeric_ndarray(
+        out: Union[ndarray, npt.NDArray[Any], None]
+    ) -> Union[ndarray, None]:
         if out is None:
             return None
-        elif isinstance(out, ndarray):
+        if isinstance(out, ndarray):
             return out
-        elif isinstance(out, np.ndarray):
+        if isinstance(out, np.ndarray):
             return convert_to_cunumeric_ndarray(out, share=True)
-        else:
-            raise TypeError("return arrays must be of ArrayType")
+        raise TypeError("return arrays must be of ArrayType")
 
-    def _prepare_operands(self, *args, out=None, where=True):
+    def _prepare_operands(
+        self, *args: Any, out: Union[ndarray, None], where: bool = True
+    ) -> tuple[
+        Sequence[ndarray],
+        Sequence[Union[ndarray, None]],
+        tuple[int, ...],
+        bool,
+    ]:
         max_nargs = self.nin + self.nout
         if len(args) < self.nin or len(args) > max_nargs:
             raise TypeError(
@@ -263,16 +288,17 @@ class ufunc:
                     "cannot specify 'out' as both a positional and keyword "
                     "argument"
                 )
-            out = args[self.nin :]
+            computed_out = args[self.nin :]
             # Missing outputs are treated as Nones
-            out = out + (None,) * (self.nout - len(out))
+            computed_out += (None,) * (self.nout - len(computed_out))
         elif out is None:
-            out = (None,) * self.nout
+            computed_out = (None,) * self.nout
         elif not isinstance(out, tuple):
-            out = (out,)
+            computed_out = (out,)
 
         outputs = tuple(
-            self._maybe_convert_output_to_cunumeric_ndarray(arr) for arr in out
+            self._maybe_convert_output_to_cunumeric_ndarray(arr)
+            for arr in computed_out
         )
 
         if self.nout != len(outputs):
@@ -302,18 +328,27 @@ class ufunc:
 
         return inputs, outputs, out_shape, where
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"<ufunc {self._name}>"
 
 
 class unary_ufunc(ufunc):
-    def __init__(self, name, doc, op_code, types, overrides):
+    def __init__(
+        self,
+        name: str,
+        doc: str,
+        op_code: UnaryOpCode,
+        types: dict[str, str],
+        overrides: dict[str, UnaryOpCode],
+    ) -> None:
         super().__init__(name, doc, types)
         self._op_code = op_code
-        self._resolution_cache = {}
+        self._resolution_cache: dict[np.dtype[Any], np.dtype[Any]] = {}
         self._overrides = overrides
 
-    def _resolve_dtype(self, arr, precision_fixed):
+    def _resolve_dtype(
+        self, arr: ndarray, precision_fixed: bool
+    ) -> tuple[ndarray, np.dtype[Any]]:
         if arr.dtype.char in self._types:
             return arr, np.dtype(self._types[arr.dtype.char])
 
@@ -343,14 +378,14 @@ class unary_ufunc(ufunc):
 
     def __call__(
         self,
-        *args,
-        out=None,
-        where=True,
-        casting="same_kind",
-        order="K",
-        dtype=None,
-        **kwargs,
-    ):
+        *args: Any,
+        out: Union[ndarray, None] = None,
+        where: bool = True,
+        casting: CastingKind = "same_kind",
+        order: str = "K",
+        dtype: Union[np.dtype[Any], None] = None,
+        **kwargs: Any,
+    ) -> ndarray:
         (x,), (out,), out_shape, where = self._prepare_operands(
             *args, out=out, where=where
         )
@@ -380,12 +415,16 @@ class unary_ufunc(ufunc):
 
 
 class multiout_unary_ufunc(ufunc):
-    def __init__(self, name, doc, op_code, types):
+    def __init__(
+        self, name: str, doc: str, op_code: UnaryOpCode, types: dict[Any, Any]
+    ) -> None:
         super().__init__(name, doc, types)
         self._op_code = op_code
-        self._resolution_cache = {}
+        self._resolution_cache: dict[np.dtype[Any], np.dtype[Any]] = {}
 
-    def _resolve_dtype(self, arr, precision_fixed):
+    def _resolve_dtype(
+        self, arr: ndarray, precision_fixed: bool
+    ) -> tuple[ndarray, tuple[np.dtype[Any], ...]]:
         if arr.dtype.char in self._types:
             return arr, to_dtypes(self._types[arr.dtype.char])
 
@@ -415,14 +454,14 @@ class multiout_unary_ufunc(ufunc):
 
     def __call__(
         self,
-        *args,
-        out=None,
-        where=True,
-        casting="same_kind",
-        order="K",
-        dtype=None,
-        **kwargs,
-    ):
+        *args: Any,
+        out: Union[ndarray, None] = None,
+        where: bool = True,
+        casting: CastingKind = "same_kind",
+        order: str = "K",
+        dtype: Union[np.dtype[Any], None] = None,
+        **kwargs: Any,
+    ) -> tuple[ndarray, ...]:
         (x,), outs, out_shape, where = self._prepare_operands(
             *args, out=out, where=where
         )
@@ -461,16 +500,26 @@ class multiout_unary_ufunc(ufunc):
 
 class binary_ufunc(ufunc):
     def __init__(
-        self, name, doc, op_code, types, red_code=None, use_common_type=True
-    ):
+        self,
+        name: str,
+        doc: str,
+        op_code: BinaryOpCode,
+        types: dict[tuple[str, str], str],
+        red_code: Union[UnaryRedCode, None] = None,
+        use_common_type: bool = True,
+    ) -> None:
         super().__init__(name, doc, types)
         self._op_code = op_code
-        self._resolution_cache = {}
+        self._resolution_cache: dict[
+            tuple[str, ...], tuple[np.dtype[Any], ...]
+        ] = {}
         self._red_code = red_code
         self._use_common_type = use_common_type
 
     @staticmethod
-    def _find_common_type(arrs, orig_args):
+    def _find_common_type(
+        arrs: Sequence[ndarray], orig_args: Sequence[Any]
+    ) -> np.dtype[Any]:
         # FIXME: The following is a miserable attempt to implement type
         # coercion rules that try to match NumPy's rules for a subset of cases;
         # for the others, cuNumeric computes a type different from what
@@ -499,7 +548,15 @@ class binary_ufunc(ufunc):
 
         return np.find_common_type(array_types, scalar_types)
 
-    def _resolve_dtype(self, arrs, orig_args, casting, precision_fixed):
+    def _resolve_dtype(
+        self,
+        arrs: Sequence[ndarray],
+        orig_args: Sequence[np.dtype[Any]],
+        casting: CastingKind,
+        precision_fixed: bool,
+    ) -> tuple[Sequence[ndarray], np.dtype[Any]]:
+        to_dtypes: tuple[np.dtype[Any], ...]
+        key: tuple[str, ...]
         if self._use_common_type:
             common_dtype = self._find_common_type(arrs, orig_args)
             to_dtypes = (common_dtype, common_dtype)
@@ -557,14 +614,14 @@ class binary_ufunc(ufunc):
 
     def __call__(
         self,
-        *args,
-        out=None,
-        where=True,
-        casting="same_kind",
-        order="K",
-        dtype=None,
-        **kwargs,
-    ):
+        *args: Any,
+        out: Union[ndarray, None] = None,
+        where: bool = True,
+        casting: CastingKind = "same_kind",
+        order: str = "K",
+        dtype: Union[np.dtype[Any], None] = None,
+        **kwargs: Any,
+    ) -> ndarray:
         arrs, (out,), out_shape, where = self._prepare_operands(
             *args, out=out, where=where
         )
@@ -598,14 +655,14 @@ class binary_ufunc(ufunc):
 
     def reduce(
         self,
-        array,
-        axis=0,
-        dtype=None,
-        out=None,
-        keepdims=False,
-        initial=None,
-        where=True,
-    ):
+        array: ndarray,
+        axis: Union[int, tuple[int, ...], None] = 0,
+        dtype: Union[np.dtype[Any], None] = None,
+        out: Union[ndarray, None] = None,
+        keepdims: bool = False,
+        initial: Union[Any, None] = None,
+        where: bool = True,
+    ) -> ndarray:
         """
         reduce(array, axis=0, dtype=None, out=None, keepdims=False, initial=<no
         value>, where=True)
@@ -686,46 +743,57 @@ class binary_ufunc(ufunc):
         )
 
 
-def _parse_unary_ufunc_type(ty):
+def _parse_unary_ufunc_type(ty: str) -> tuple[str, str]:
     if len(ty) == 1:
         return (ty, ty)
-    else:
-        return (ty[0], ty[1:])
+    return (ty[0], ty[1:])
 
 
-def create_unary_ufunc(summary, name, op_code, types, overrides={}):
+def create_unary_ufunc(
+    summary: str,
+    name: str,
+    op_code: UnaryOpCode,
+    types: Sequence[str],
+    overrides: dict[str, UnaryOpCode] = {},
+) -> unary_ufunc:
     doc = _UNARY_DOCSTRING_TEMPLATE.format(summary, name)
-    types = dict(_parse_unary_ufunc_type(ty) for ty in types)
-    return unary_ufunc(name, doc, op_code, types, overrides)
+    types_dict = dict(_parse_unary_ufunc_type(ty) for ty in types)
+    return unary_ufunc(name, doc, op_code, types_dict, overrides)
 
 
-def create_multiout_unary_ufunc(summary, name, op_code, types):
+def create_multiout_unary_ufunc(
+    summary: str, name: str, op_code: UnaryOpCode, types: Sequence[str]
+) -> multiout_unary_ufunc:
     doc = _MULTIOUT_UNARY_DOCSTRING_TEMPLATE.format(summary, name)
-    types = dict(_parse_unary_ufunc_type(ty) for ty in types)
-    return multiout_unary_ufunc(name, doc, op_code, types)
+    types_dict = dict(_parse_unary_ufunc_type(ty) for ty in types)
+    return multiout_unary_ufunc(name, doc, op_code, types_dict)
 
 
-def _parse_binary_ufunc_type(ty):
+def _parse_binary_ufunc_type(ty: str) -> tuple[tuple[str, str], str]:
     if len(ty) == 1:
         return ((ty, ty), ty)
-    else:
-        if len(ty) != 3:
-            raise NotImplementedError(
-                "Binary ufunc must have two inputs and one output"
-            )
+    if len(ty) == 3:
         return ((ty[0], ty[1]), ty[2])
+    raise NotImplementedError(
+        "Binary ufunc must have two inputs and one output"
+    )
 
 
 def create_binary_ufunc(
-    summary, name, op_code, types, red_code=None, use_common_type=True
-):
+    summary: str,
+    name: str,
+    op_code: BinaryOpCode,
+    types: Sequence[str],
+    red_code: Union[UnaryRedCode, None] = None,
+    use_common_type: bool = True,
+) -> binary_ufunc:
     doc = _BINARY_DOCSTRING_TEMPLATE.format(summary, name)
-    types = dict(_parse_binary_ufunc_type(ty) for ty in types)
+    types_dict = dict(_parse_binary_ufunc_type(ty) for ty in types)
     return binary_ufunc(
         name,
         doc,
         op_code,
-        types,
+        types_dict,
         red_code=red_code,
         use_common_type=use_common_type,
     )

--- a/cunumeric/_ufunc/ufunc.py
+++ b/cunumeric/_ufunc/ufunc.py
@@ -14,7 +14,7 @@
 #
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Literal, Sequence, Union
+from typing import TYPE_CHECKING, Any, Dict, Literal, Sequence, Union
 
 import numpy as np
 
@@ -178,15 +178,14 @@ def to_dtypes(chars: str) -> tuple[np.dtype[Any], ...]:
 
 
 class ufunc:
-    def __init__(self, name: str, doc: str, types: dict[Any, str]) -> None:
-        self._name = name
-        self._types = types
-        self.__doc__ = doc
 
-        assert len(self._types)
-        in_ty, out_ty = next(iter(self._types.items()))
-        self._nin = len(in_ty)
-        self._nout = len(out_ty)
+    _types: Dict[Any, str]
+    _nin: int
+    _nout: int
+
+    def __init__(self, name: str, doc: str) -> None:
+        self._name = name
+        self.__doc__ = doc
 
     @property
     def nin(self) -> int:
@@ -341,7 +340,14 @@ class unary_ufunc(ufunc):
         types: dict[str, str],
         overrides: dict[str, UnaryOpCode],
     ) -> None:
-        super().__init__(name, doc, types)
+        super().__init__(name, doc)
+
+        self._types = types
+        assert len(self._types)
+        in_ty, out_ty = next(iter(self._types.items()))
+        self._nin = len(in_ty)
+        self._nout = len(out_ty)
+
         self._op_code = op_code
         self._resolution_cache: dict[np.dtype[Any], np.dtype[Any]] = {}
         self._overrides = overrides
@@ -418,7 +424,14 @@ class multiout_unary_ufunc(ufunc):
     def __init__(
         self, name: str, doc: str, op_code: UnaryOpCode, types: dict[Any, Any]
     ) -> None:
-        super().__init__(name, doc, types)
+        super().__init__(name, doc)
+
+        self._types = types
+        assert len(self._types)
+        in_ty, out_ty = next(iter(self._types.items()))
+        self._nin = len(in_ty)
+        self._nout = len(out_ty)
+
         self._op_code = op_code
         self._resolution_cache: dict[np.dtype[Any], np.dtype[Any]] = {}
 
@@ -508,7 +521,14 @@ class binary_ufunc(ufunc):
         red_code: Union[UnaryRedCode, None] = None,
         use_common_type: bool = True,
     ) -> None:
-        super().__init__(name, doc, types)
+        super().__init__(name, doc)
+
+        self._types = types
+        assert len(self._types)
+        in_ty, out_ty = next(iter(self._types.items()))
+        self._nin = len(in_ty)
+        self._nout = len(out_ty)
+
         self._op_code = op_code
         self._resolution_cache: dict[
             tuple[str, ...], tuple[np.dtype[Any], ...]

--- a/cunumeric/_ufunc/ufunc.py
+++ b/cunumeric/_ufunc/ufunc.py
@@ -226,7 +226,7 @@ class ufunc:
         out_shape: tuple[int, ...],
         res_dtype: np.dtype[Any],
         casting: CastingKind,
-        inputs: Union[tuple[ndarray, bool], tuple[ndarray, ndarray, bool]],
+        inputs: tuple[ndarray, ...],
     ) -> ndarray:
         if out is None:
             return ndarray(shape=out_shape, dtype=res_dtype, inputs=inputs)
@@ -411,7 +411,7 @@ class unary_ufunc(ufunc):
         x, res_dtype = self._resolve_dtype(x, precision_fixed)
 
         result = self._maybe_create_result(
-            out, out_shape, res_dtype, casting, (x, where)
+            out, out_shape, res_dtype, casting, (x,)
         )
 
         op_code = self._overrides.get(x.dtype.char, self._op_code)
@@ -494,9 +494,7 @@ class multiout_unary_ufunc(ufunc):
         x, res_dtypes = self._resolve_dtype(x, precision_fixed)
 
         results = tuple(
-            self._maybe_create_result(
-                out, out_shape, res_dtype, casting, (x, where)
-            )
+            self._maybe_create_result(out, out_shape, res_dtype, casting, (x,))
             for out, res_dtype in zip(outs, res_dtypes)
         )
 
@@ -674,7 +672,7 @@ class binary_ufunc(ufunc):
 
         x1, x2 = arrs
         result = self._maybe_create_result(
-            out, out_shape, res_dtype, casting, (x1, x2, where)
+            out, out_shape, res_dtype, casting, (x1, x2)
         )
         result._thunk.binary_op(self._op_code, x1._thunk, x2._thunk, where, ())
 

--- a/cunumeric/array.py
+++ b/cunumeric/array.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from __future__ import annotations
 
 from collections.abc import Iterable
 from functools import reduce, wraps
@@ -143,7 +144,7 @@ class ndarray:
         order=None,
         thunk=None,
         inputs=None,
-    ):
+    ) -> None:
         # `inputs` being a cuNumeric ndarray is definitely a bug
         assert not isinstance(inputs, ndarray)
         if thunk is None:

--- a/cunumeric/array.py
+++ b/cunumeric/array.py
@@ -2065,7 +2065,7 @@ class ndarray:
         """
         return self.conj()
 
-    def copy(self, order="C"):
+    def copy(self, order="C") -> ndarray:
         """copy()
 
         Get a copy of the iterator as a 1-D array.
@@ -2277,7 +2277,7 @@ class ndarray:
         return res
 
     @add_boilerplate("rhs")
-    def dot(self, rhs, out=None):
+    def dot(self, rhs, out=None) -> ndarray:
         """a.dot(rhs, out=None)
 
         Return the dot product of this array with ``rhs``.
@@ -2857,7 +2857,7 @@ class ndarray:
             where=where,
         )
 
-    def ravel(self, order="C"):
+    def ravel(self, order="C") -> ndarray:
         """a.ravel(order="C")
 
         Return a flattened array.
@@ -2876,7 +2876,7 @@ class ndarray:
         """
         return self.reshape(-1, order=order)
 
-    def reshape(self, shape, order="C"):
+    def reshape(self, shape, order="C") -> ndarray:
         """a.reshape(shape, order='C')
 
         Returns an array containing the same data with a new shape.

--- a/cunumeric/array.py
+++ b/cunumeric/array.py
@@ -93,7 +93,7 @@ def add_boilerplate(*array_params: str):
     return decorator
 
 
-def convert_to_cunumeric_ndarray(obj, share=False):
+def convert_to_cunumeric_ndarray(obj, share: bool = False) -> ndarray:
     # If this is an instance of one of our ndarrays then we're done
     if isinstance(obj, ndarray):
         return obj
@@ -1676,7 +1676,7 @@ class ndarray:
 
     def astype(
         self, dtype, order="C", casting="unsafe", subok=True, copy=True
-    ):
+    ) -> ndarray:
         """a.astype(dtype, order='C', casting='unsafe', subok=True, copy=True)
 
         Copy of the array, cast to a specified type.
@@ -3545,7 +3545,7 @@ class ndarray:
         args=None,
         initial=None,
         where=True,
-    ):
+    ) -> ndarray:
         # When 'res_dtype' is not None, the input and output of the reduction
         # have different types. Such reduction operators don't take a dtype of
         # the accumulator

--- a/cunumeric/array.py
+++ b/cunumeric/array.py
@@ -17,10 +17,11 @@ from __future__ import annotations
 from collections.abc import Iterable
 from functools import reduce, wraps
 from inspect import signature
-from typing import Optional, Set, Tuple
+from typing import Callable, Optional, Set, Tuple, TypeVar
 
 import numpy as np
 import pyarrow
+from typing_extensions import ParamSpec
 
 from legate.core import Array
 
@@ -29,8 +30,13 @@ from .coverage import clone_class
 from .runtime import runtime
 from .utils import dot_modes
 
+R = TypeVar("R")
+P = ParamSpec("P")
 
-def add_boilerplate(*array_params: str):
+
+def add_boilerplate(
+    *array_params: str,
+) -> Callable[[Callable[P, R]], Callable[P, R]]:
     """
     Adds required boilerplate to the wrapped cunumeric.ndarray or module-level
     function.
@@ -2019,7 +2025,7 @@ class ndarray:
             UnaryOpCode.CLIP, self, dst=out, extra_args=args
         )
 
-    def conj(self):
+    def conj(self) -> ndarray:
         """a.conj()
 
         Complex-conjugate all elements.
@@ -2041,7 +2047,7 @@ class ndarray:
         else:
             return self
 
-    def conjugate(self):
+    def conjugate(self) -> ndarray:
         """a.conjugate()
 
         Return the complex conjugate, element-wise.
@@ -2363,7 +2369,7 @@ class ndarray:
                 fft_s[ax] = s[idx]
         return np.asarray(fft_axes), np.asarray(fft_s)
 
-    def fft(self, s, axes, kind, direction, norm):
+    def fft(self, s, axes, kind, direction, norm) -> ndarray:
         """a.fft(s, axes, kind, direction, norm)
 
         Return the ``kind`` ``direction`` FFT of this array

--- a/cunumeric/config.py
+++ b/cunumeric/config.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import os
 from enum import IntEnum, unique
+from typing import Any, Union
 
 import numpy as np
 
@@ -363,7 +364,7 @@ FFT_Z2D = _FFTType(
 
 class FFTCode:
     @staticmethod
-    def real_to_complex_code(dtype):
+    def real_to_complex_code(dtype: np.dtype[Any]) -> _FFTType:
         if dtype == np.float64:
             return FFT_D2Z
         elif dtype == np.float32:
@@ -377,7 +378,7 @@ class FFTCode:
             )
 
     @staticmethod
-    def complex_to_real_code(dtype):
+    def complex_to_real_code(dtype: np.dtype[Any]) -> _FFTType:
         if dtype == np.complex128:
             return FFT_Z2D
         elif dtype == np.complex64:
@@ -404,7 +405,7 @@ class FFTNormalization(IntEnum):
     ORTHOGONAL = 3
 
     @staticmethod
-    def from_string(in_string):
+    def from_string(in_string: str) -> Union[FFTNormalization, None]:
         if in_string == "forward":
             return FFTNormalization.FORWARD
         elif in_string == "ortho":
@@ -415,7 +416,7 @@ class FFTNormalization(IntEnum):
             return None
 
     @staticmethod
-    def reverse(in_string):
+    def reverse(in_string: Union[str, None]) -> str:
         if in_string == "forward":
             return "backward"
         elif in_string == "backward" or in_string is None:

--- a/cunumeric/config.py
+++ b/cunumeric/config.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from __future__ import annotations
 
 import os
 from enum import IntEnum, unique

--- a/cunumeric/deferred.py
+++ b/cunumeric/deferred.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from __future__ import annotations
 
 import weakref
 from collections import Counter

--- a/cunumeric/eager.py
+++ b/cunumeric/eager.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from __future__ import annotations
 
 import numpy as np
 

--- a/cunumeric/fft/__init__.py
+++ b/cunumeric/fft/__init__.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from __future__ import annotations
 
 import numpy.fft as _npfft
 from cunumeric.fft.fft import *

--- a/cunumeric/fft/fft.py
+++ b/cunumeric/fft/fft.py
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
+from __future__ import annotations
 
 import numpy as np
 from cunumeric.config import (

--- a/cunumeric/fft/fft.py
+++ b/cunumeric/fft/fft.py
@@ -14,6 +14,8 @@
 #
 from __future__ import annotations
 
+from typing import TYPE_CHECKING, Sequence, Union
+
 import numpy as np
 from cunumeric.config import (
     FFT_C2C,
@@ -24,8 +26,16 @@ from cunumeric.config import (
 )
 from cunumeric.module import add_boilerplate
 
+if TYPE_CHECKING:
+    from ..array import ndarray
 
-def _sanitize_user_axes(a, s, axes, is_c2r=False):
+
+def _sanitize_user_axes(
+    a: ndarray,
+    s: Union[Sequence[int], None],
+    axes: Union[Sequence[int], None],
+    is_c2r: bool = False,
+) -> tuple[list[int], Sequence[int]]:
     if s is None:
         user_shape = False
         if axes is None:
@@ -42,7 +52,7 @@ def _sanitize_user_axes(a, s, axes, is_c2r=False):
     return s, axes
 
 
-def _operate_by_axes(a, axes):
+def _operate_by_axes(a: ndarray, axes: Sequence[int]) -> bool:
     return (
         len(axes) != len(set(axes))
         or len(axes) != a.ndim
@@ -51,7 +61,12 @@ def _operate_by_axes(a, axes):
 
 
 @add_boilerplate("a")
-def fft(a, n=None, axis=-1, norm=None):
+def fft(
+    a: ndarray,
+    n: Union[int, None] = None,
+    axis: int = -1,
+    norm: Union[str, None] = None,
+) -> ndarray:
     """
     Compute the one-dimensional discrete Fourier Transform.
 
@@ -101,7 +116,12 @@ def fft(a, n=None, axis=-1, norm=None):
 
 
 @add_boilerplate("a")
-def fft2(a, s=None, axes=(-2, -1), norm=None):
+def fft2(
+    a: ndarray,
+    s: Union[Sequence[int], None] = None,
+    axes: Sequence[int] = (-2, -1),
+    norm: Union[str, None] = None,
+) -> ndarray:
     """
     Compute the 2-dimensional discrete Fourier Transform.
 
@@ -153,7 +173,12 @@ def fft2(a, s=None, axes=(-2, -1), norm=None):
 
 
 @add_boilerplate("a")
-def fftn(a, s=None, axes=None, norm=None):
+def fftn(
+    a: ndarray,
+    s: Union[Sequence[int], None] = None,
+    axes: Union[Sequence[int], None] = None,
+    norm: Union[str, None] = None,
+) -> ndarray:
     """
     Compute the N-dimensional discrete Fourier Transform.
 
@@ -223,7 +248,12 @@ def fftn(a, s=None, axes=None, norm=None):
 
 
 @add_boilerplate("a")
-def ifft(a, n=None, axis=-1, norm=None):
+def ifft(
+    a: ndarray,
+    n: Union[int, None] = None,
+    axis: int = -1,
+    norm: Union[str, None] = None,
+) -> ndarray:
     """
     Compute the one-dimensional inverse discrete Fourier Transform.
 
@@ -283,12 +313,17 @@ def ifft(a, n=None, axis=-1, norm=None):
     Single GPU
     """
     s = (n,) if n is not None else None
-    axis = (axis,) if axis is not None else None
-    return ifftn(a=a, s=s, axes=axis, norm=norm)
+    computed_axis = (axis,) if axis is not None else None
+    return ifftn(a=a, s=s, axes=computed_axis, norm=norm)
 
 
 @add_boilerplate("a")
-def ifft2(a, s=None, axes=(-2, -1), norm=None):
+def ifft2(
+    a: ndarray,
+    s: Union[Sequence[int], None] = None,
+    axes: Sequence[int] = (-2, -1),
+    norm: Union[str, None] = None,
+) -> ndarray:
     """
     Compute the 2-dimensional inverse discrete Fourier Transform.
 
@@ -347,7 +382,12 @@ def ifft2(a, s=None, axes=(-2, -1), norm=None):
 
 
 @add_boilerplate("a")
-def ifftn(a, s=None, axes=None, norm=None):
+def ifftn(
+    a: ndarray,
+    s: Union[Sequence[int], None] = None,
+    axes: Union[Sequence[int], None] = None,
+    norm: Union[str, None] = None,
+) -> ndarray:
     """
     Compute the N-dimensional inverse discrete Fourier Transform.
 
@@ -427,7 +467,12 @@ def ifftn(a, s=None, axes=None, norm=None):
 
 
 @add_boilerplate("a")
-def rfft(a, n=None, axis=-1, norm=None):
+def rfft(
+    a: ndarray,
+    n: Union[int, None] = None,
+    axis: int = -1,
+    norm: Union[str, None] = None,
+) -> ndarray:
     """
     Compute the one-dimensional discrete Fourier Transform for real input.
 
@@ -474,12 +519,17 @@ def rfft(a, n=None, axis=-1, norm=None):
     Single GPU
     """
     s = (n,) if n is not None else None
-    axis = (axis,) if axis is not None else None
-    return rfftn(a=a, s=s, axes=axis, norm=norm)
+    computed_axis = (axis,) if axis is not None else None
+    return rfftn(a=a, s=s, axes=computed_axis, norm=norm)
 
 
 @add_boilerplate("a")
-def rfft2(a, s=None, axes=(-2, -1), norm=None):
+def rfft2(
+    a: ndarray,
+    s: Union[Sequence[int], None] = None,
+    axes: Sequence[int] = (-2, -1),
+    norm: Union[str, None] = None,
+) -> ndarray:
     """
     Compute the 2-dimensional FFT of a real array.
 
@@ -518,7 +568,12 @@ def rfft2(a, s=None, axes=(-2, -1), norm=None):
 
 
 @add_boilerplate("a")
-def rfftn(a, s=None, axes=None, norm=None):
+def rfftn(
+    a: ndarray,
+    s: Union[Sequence[int], None] = None,
+    axes: Union[Sequence[int], None] = None,
+    norm: Union[str, None] = None,
+) -> ndarray:
     """
     Compute the N-dimensional discrete Fourier Transform for real input.
 
@@ -609,7 +664,12 @@ def rfftn(a, s=None, axes=None, norm=None):
 
 
 @add_boilerplate("a")
-def irfft(a, n=None, axis=-1, norm=None):
+def irfft(
+    a: ndarray,
+    n: Union[int, None] = None,
+    axis: int = -1,
+    norm: Union[str, None] = None,
+) -> ndarray:
     """
     Computes the inverse of `rfft`.
 
@@ -666,12 +726,17 @@ def irfft(a, n=None, axis=-1, norm=None):
     Single GPU
     """
     s = (n,) if n is not None else None
-    axis = (axis,) if axis is not None else None
-    return irfftn(a=a, s=s, axes=axis, norm=norm)
+    computed_axis = (axis,) if axis is not None else None
+    return irfftn(a=a, s=s, axes=computed_axis, norm=norm)
 
 
 @add_boilerplate("a")
-def irfft2(a, s=None, axes=(-2, -1), norm=None):
+def irfft2(
+    a: ndarray,
+    s: Union[Sequence[int], None] = None,
+    axes: Sequence[int] = (-2, -1),
+    norm: Union[str, None] = None,
+) -> ndarray:
     """
     Computes the inverse of `rfft2`.
 
@@ -712,7 +777,12 @@ def irfft2(a, s=None, axes=(-2, -1), norm=None):
 
 
 @add_boilerplate("a")
-def irfftn(a, s=None, axes=None, norm=None):
+def irfftn(
+    a: ndarray,
+    s: Union[Sequence[int], None] = None,
+    axes: Union[Sequence[int], None] = None,
+    norm: Union[str, None] = None,
+) -> ndarray:
     """
     Computes the inverse of `rfftn`.
 
@@ -816,7 +886,12 @@ def irfftn(a, s=None, axes=None, norm=None):
 
 
 @add_boilerplate("a")
-def hfft(a, n=None, axis=-1, norm=None):
+def hfft(
+    a: ndarray,
+    n: Union[int, None] = None,
+    axis: int = -1,
+    norm: Union[str, None] = None,
+) -> ndarray:
     """
     Compute the FFT of a signal that has Hermitian symmetry, i.e., a real
     spectrum.
@@ -862,17 +937,25 @@ def hfft(a, n=None, axis=-1, norm=None):
     Single GPU
     """
     s = (n,) if n is not None else None
-    axis = (axis,) if axis is not None else None
+    computed_axis = (axis,) if axis is not None else None
     # Add checks to ensure input is hermitian?
     # Essentially a C2R FFT, with reverse sign
     # (forward transform, forward norm)
     return irfftn(
-        a=a.conjugate(), s=s, axes=axis, norm=FFTNormalization.reverse(norm)
+        a=a.conjugate(),
+        s=s,
+        axes=computed_axis,
+        norm=FFTNormalization.reverse(norm),
     )
 
 
 @add_boilerplate("a")
-def ihfft(a, n=None, axis=-1, norm=None):
+def ihfft(
+    a: ndarray,
+    n: Union[int, None] = None,
+    axis: int = -1,
+    norm: Union[str, None] = None,
+) -> ndarray:
     """
     Compute the inverse FFT of a signal that has Hermitian symmetry.
 
@@ -910,10 +993,10 @@ def ihfft(a, n=None, axis=-1, norm=None):
     Single GPU
     """
     s = (n,) if n is not None else None
-    axis = (axis,) if axis is not None else None
+    computed_axis = (axis,) if axis is not None else None
     # Add checks to ensure input is hermitian?
     # Essentially a R2C FFT, with reverse sign
     # (inverse transform, inverse norm)
     return rfftn(
-        a=a, s=s, axes=axis, norm=FFTNormalization.reverse(norm)
+        a=a, s=s, axes=computed_axis, norm=FFTNormalization.reverse(norm)
     ).conjugate()

--- a/cunumeric/linalg/__init__.py
+++ b/cunumeric/linalg/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
+from __future__ import annotations
 
 import numpy.linalg as _nplinalg
 

--- a/cunumeric/linalg/cholesky.py
+++ b/cunumeric/linalg/cholesky.py
@@ -19,10 +19,10 @@ from typing import TYPE_CHECKING, cast
 from cunumeric.config import CuNumericOpCode
 
 from legate.core import Rect, types as ty
+from legate.core.operation import ManualTask
 
 if TYPE_CHECKING:
     from legate.core.context import Context
-    from legate.core.operation import ManualTask
     from legate.core.shape import Shape
     from legate.core.store import StorePartition
 

--- a/cunumeric/linalg/cholesky.py
+++ b/cunumeric/linalg/cholesky.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
+from __future__ import annotations
 
 from cunumeric.config import CuNumericOpCode
 

--- a/cunumeric/linalg/cholesky.py
+++ b/cunumeric/linalg/cholesky.py
@@ -20,12 +20,12 @@ from cunumeric.config import CuNumericOpCode
 
 from legate.core import Rect, types as ty
 from legate.core.operation import ManualTask
+from legate.core.shape import Shape
 
 from .exception import LinAlgError
 
 if TYPE_CHECKING:
     from legate.core.context import Context
-    from legate.core.shape import Shape
     from legate.core.store import Store, StorePartition
 
     from ..deferred import DeferredArray
@@ -165,16 +165,16 @@ MIN_CHOLESKY_MATRIX_SIZE = 8192
 
 
 # TODO: We need a better cost model
-def choose_color_shape(runtime: Runtime, shape: Shape) -> tuple[int, int]:
+def choose_color_shape(runtime: Runtime, shape: Shape) -> Shape:
     if runtime.args.test_mode:
         num_tiles = runtime.num_procs * 2
-        return (num_tiles, num_tiles)
+        return Shape((num_tiles, num_tiles))
 
     extent = shape[0]
     # If there's only one processor or the matrix is too small,
     # don't even bother to partition it at all
     if runtime.num_procs == 1 or extent <= MIN_CHOLESKY_MATRIX_SIZE:
-        return (1, 1)
+        return Shape((1, 1))
 
     # If the matrix is big enough to warrant partitioning,
     # pick the granularity that the tile size is greater than a threshold
@@ -186,7 +186,7 @@ def choose_color_shape(runtime: Runtime, shape: Shape) -> tuple[int, int]:
     ):
         num_tiles *= 2
 
-    return (num_tiles, num_tiles)
+    return Shape((num_tiles, num_tiles))
 
 
 def tril_single(context: Context, output: Store) -> None:

--- a/cunumeric/linalg/linalg.py
+++ b/cunumeric/linalg/linalg.py
@@ -14,15 +14,22 @@
 #
 from __future__ import annotations
 
+from typing import TYPE_CHECKING, Any, Sequence, Union
+
 import numpy as np
 from cunumeric._ufunc.math import add, sqrt as _sqrt
 from cunumeric.array import add_boilerplate, convert_to_cunumeric_ndarray
 from cunumeric.module import dot, empty_like, eye, matmul, ndarray
-from numpy.core.multiarray import normalize_axis_index
+from numpy.core.multiarray import (  # type: ignore [attr-defined]
+    normalize_axis_index,
+)
+
+if TYPE_CHECKING:
+    import numpy.typing as npt
 
 
 @add_boilerplate("a")
-def cholesky(a):
+def cholesky(a: ndarray) -> ndarray:
     """
     Cholesky decomposition.
 
@@ -76,7 +83,7 @@ def cholesky(a):
 
 # This implementation is adapted closely from NumPy
 @add_boilerplate("a")
-def matrix_power(a, n):
+def matrix_power(a: ndarray, n: int) -> Union[ndarray, None]:
     """
     Raise a square matrix to the (integer) power `n`.
     For positive integers `n`, the power is computed by repeated matrix
@@ -152,7 +159,9 @@ def matrix_power(a, n):
 
 
 # This implementation is adapted closely from NumPy
-def multi_dot(arrays, *, out=None):
+def multi_dot(
+    arrays: Sequence[ndarray], *, out: Union[ndarray, None] = None
+) -> ndarray:
     """
     Compute the dot product of two or more arrays in a single function call,
     while automatically selecting the fastest evaluation order.
@@ -227,7 +236,9 @@ def multi_dot(arrays, *, out=None):
         return result
 
 
-def _multi_dot_three(A, B, C, out=None):
+def _multi_dot_three(
+    A: ndarray, B: ndarray, C: ndarray, out: Union[ndarray, None] = None
+) -> ndarray:
     """
     Find the best order for three arrays and do the multiplication.
     """
@@ -244,7 +255,12 @@ def _multi_dot_three(A, B, C, out=None):
         return dot(A, dot(B, C), out=out)
 
 
-def _multi_dot_matrix_chain_order(arrays, return_costs=False):
+def _multi_dot_matrix_chain_order(
+    arrays: Sequence[ndarray], return_costs: bool = False
+) -> Union[
+    npt.NDArray[np.int64],
+    tuple[npt.NDArray[np.int64], npt.NDArray[np.float64]],
+]:
     """
     Return a `np.array` that encodes the optimal order of mutiplications.
     The optimal order array is then used by `_multi_dot()` to do the
@@ -280,7 +296,13 @@ def _multi_dot_matrix_chain_order(arrays, return_costs=False):
     return (s, m) if return_costs else s
 
 
-def _multi_dot(arrays, order, i, j, out=None):
+def _multi_dot(
+    arrays: Sequence[ndarray],
+    order: Any,
+    i: int,
+    j: int,
+    out: Union[ndarray, None] = None,
+) -> ndarray:
     """Actually do the multiplication with the given order."""
     if i == j:
         # the initial call with non-None out should never get here
@@ -297,7 +319,12 @@ def _multi_dot(arrays, order, i, j, out=None):
 
 # This implementation is adapted closely from NumPy
 @add_boilerplate("x")
-def norm(x, ord=None, axis=None, keepdims=False):
+def norm(
+    x: ndarray,
+    ord: Union[str, int, float, None] = None,
+    axis: Union[int, tuple[int, int], None] = None,
+    keepdims: bool = False,
+) -> Union[float, ndarray]:
     """
     Matrix or vector norm.
 
@@ -402,31 +429,35 @@ def norm(x, ord=None, axis=None, keepdims=False):
     # Normalize the `axis` argument to a tuple.
     nd = x.ndim
     if axis is None:
-        axis = tuple(range(nd))
+        computed_axis = tuple(range(nd))
     else:
         if not isinstance(axis, tuple):
-            axis = (axis,)
-        for ax in axis:
+            computed_axis = (axis,)
+        for ax in computed_axis:
             if not isinstance(ax, int):
                 raise TypeError(
                     "`axis` must be None, an integer or a tuple of integers"
                 )
 
-    if len(axis) == 1:
+    if len(computed_axis) == 1:
         if ord == np.inf:
-            return abs(x).max(axis=axis, keepdims=keepdims)
+            return abs(x).max(axis=computed_axis, keepdims=keepdims)
         elif ord == -np.inf:
-            return abs(x).min(axis=axis, keepdims=keepdims)
+            return abs(x).min(axis=computed_axis, keepdims=keepdims)
         elif ord == 0:
             # Zero norm
-            return (x != 0).astype(np.int64).sum(axis=axis, keepdims=keepdims)
+            return (
+                (x != 0)
+                .astype(np.int64)
+                .sum(axis=computed_axis, keepdims=keepdims)
+            )
         elif ord == 1:
             # special case for speedup
-            return add.reduce(abs(x), axis=axis, keepdims=keepdims)
+            return add.reduce(abs(x), axis=computed_axis, keepdims=keepdims)
         elif ord is None or ord == 2:
             # special case for speedup
             s = (x.conj() * x).real
-            return _sqrt(add.reduce(s, axis=axis, keepdims=keepdims))
+            return _sqrt(add.reduce(s, axis=computed_axis, keepdims=keepdims))
         # None of the str-type keywords for ord ("fro", "nuc")
         # are valid for vectors
         elif isinstance(ord, str):
@@ -434,11 +465,11 @@ def norm(x, ord=None, axis=None, keepdims=False):
         else:
             absx = abs(x)
             absx **= ord
-            ret = add.reduce(absx, axis=axis, keepdims=keepdims)
+            ret = add.reduce(absx, axis=computed_axis, keepdims=keepdims)
             ret **= 1 / ord
             return ret
-    elif len(axis) == 2:
-        row_axis, col_axis = axis
+    elif len(computed_axis) == 2:
+        row_axis, col_axis = computed_axis
         row_axis = normalize_axis_index(row_axis, nd)
         col_axis = normalize_axis_index(col_axis, nd)
         if row_axis == col_axis:
@@ -474,15 +505,15 @@ def norm(x, ord=None, axis=None, keepdims=False):
             raise ValueError("Invalid norm order for matrices")
         if keepdims:
             ret_shape = list(x.shape)
-            ret_shape[axis[0]] = 1
-            ret_shape[axis[1]] = 1
+            ret_shape[computed_axis[0]] = 1
+            ret_shape[computed_axis[1]] = 1
             ret = ret.reshape(ret_shape)
         return ret
     else:
         raise ValueError("Improper number of dimensions to norm")
 
 
-def _cholesky(a, no_tril=False):
+def _cholesky(a: ndarray, no_tril: bool = False) -> ndarray:
     """Cholesky decomposition.
 
     Return the Cholesky decomposition, `L * L.H`, of the square matrix `a`,

--- a/cunumeric/linalg/linalg.py
+++ b/cunumeric/linalg/linalg.py
@@ -14,7 +14,7 @@
 #
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Sequence, Union
+from typing import TYPE_CHECKING, Sequence, Union
 
 import numpy as np
 from cunumeric._ufunc.math import add, sqrt as _sqrt
@@ -258,16 +258,12 @@ def _multi_dot_three(
 
 
 def _multi_dot_matrix_chain_order(
-    arrays: Sequence[ndarray], return_costs: bool = False
-) -> Union[
-    npt.NDArray[np.int64],
-    tuple[npt.NDArray[np.int64], npt.NDArray[np.float64]],
-]:
+    arrays: Sequence[ndarray],
+) -> npt.NDArray[np.int64]:
     """
     Return a `np.array` that encodes the optimal order of mutiplications.
     The optimal order array is then used by `_multi_dot()` to do the
     multiplication.
-    Also return the cost matrix if `return_costs` is `True`
     The implementation CLOSELY follows Cormen, "Introduction to Algorithms",
     Chapter 15.2, p. 370-378.  Note that Cormen uses 1-based indices.
         cost[i, j] = min([
@@ -295,12 +291,12 @@ def _multi_dot_matrix_chain_order(
                     m[i, j] = q
                     s[i, j] = k  # Note that Cormen uses 1-based index
 
-    return (s, m) if return_costs else s
+    return s
 
 
 def _multi_dot(
     arrays: Sequence[ndarray],
-    order: Any,
+    order: npt.NDArray[np.int64],
     i: int,
     j: int,
     out: Union[ndarray, None] = None,

--- a/cunumeric/linalg/linalg.py
+++ b/cunumeric/linalg/linalg.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from __future__ import annotations
 
 import numpy as np
 from cunumeric._ufunc.math import add, sqrt as _sqrt

--- a/cunumeric/linalg/linalg.py
+++ b/cunumeric/linalg/linalg.py
@@ -430,14 +430,15 @@ def norm(
     nd = x.ndim
     if axis is None:
         computed_axis = tuple(range(nd))
+    elif not isinstance(axis, tuple):
+        computed_axis = (axis,)
     else:
-        if not isinstance(axis, tuple):
-            computed_axis = (axis,)
-        for ax in computed_axis:
-            if not isinstance(ax, int):
-                raise TypeError(
-                    "`axis` must be None, an integer or a tuple of integers"
-                )
+        computed_axis = axis
+    for ax in computed_axis:
+        if not isinstance(ax, int):
+            raise TypeError(
+                "`axis` must be None, an integer or a tuple of integers"
+            )
 
     if len(computed_axis) == 1:
         if ord == np.inf:

--- a/cunumeric/linalg/linalg.py
+++ b/cunumeric/linalg/linalg.py
@@ -83,7 +83,7 @@ def cholesky(a: ndarray) -> ndarray:
 
 # This implementation is adapted closely from NumPy
 @add_boilerplate("a")
-def matrix_power(a: ndarray, n: int) -> Union[ndarray, None]:
+def matrix_power(a: ndarray, n: int) -> ndarray:
     """
     Raise a square matrix to the (integer) power `n`.
     For positive integers `n`, the power is computed by repeated matrix
@@ -154,6 +154,8 @@ def matrix_power(a: ndarray, n: int) -> Union[ndarray, None]:
         n, bit = divmod(n, 2)
         if bit:
             result = z if result is None else matmul(result, z)
+
+    assert result is not None
 
     return result
 

--- a/cunumeric/logic.py
+++ b/cunumeric/logic.py
@@ -14,6 +14,8 @@
 #
 from __future__ import annotations
 
+from typing import TYPE_CHECKING, Any, Union
+
 import numpy as np
 
 from ._ufunc.comparison import logical_and
@@ -21,8 +23,11 @@ from ._ufunc.floating import isinf, signbit
 from .array import convert_to_cunumeric_ndarray, ndarray
 from .module import full
 
+if TYPE_CHECKING:
+    import numpy.typing as npt
 
-def isneginf(x, out=None):
+
+def isneginf(x: ndarray, out: Union[ndarray, None] = None) -> ndarray:
     """
 
     Test element-wise for negative infinity, return result as bool array.
@@ -67,7 +72,7 @@ def isneginf(x, out=None):
     return logical_and(rhs1, rhs2, out=out)
 
 
-def isposinf(x, out=None):
+def isposinf(x: ndarray, out: Union[ndarray, None] = None) -> ndarray:
     """
 
     Test element-wise for positive infinity, return result as bool array.
@@ -112,7 +117,7 @@ def isposinf(x, out=None):
     return logical_and(rhs1, rhs2, out=out)
 
 
-def iscomplex(x):
+def iscomplex(x: Union[ndarray, npt.NDArray[Any]]) -> ndarray:
     """
 
     Returns a bool array, where True if input element is complex.
@@ -146,7 +151,7 @@ def iscomplex(x):
         return x.imag != 0
 
 
-def iscomplexobj(x):
+def iscomplexobj(x: Union[ndarray, npt.NDArray[Any]]) -> bool:
     """
 
     Check for a complex type or an array of complex numbers.
@@ -179,7 +184,7 @@ def iscomplexobj(x):
         return np.iscomplexobj(x)
 
 
-def isreal(x):
+def isreal(x: Union[ndarray, npt.NDArray[Any]]) -> ndarray:
     """
 
     Returns a bool array, where True if input element is real.
@@ -214,7 +219,7 @@ def isreal(x):
         return x.imag == 0
 
 
-def isrealobj(x):
+def isrealobj(x: ndarray) -> bool:
     """
 
     Return True if x is a not complex type or an array of complex numbers.
@@ -244,7 +249,7 @@ def isrealobj(x):
     return not iscomplexobj(x)
 
 
-def isscalar(x):
+def isscalar(x: Union[ndarray, npt.NDArray[Any]]) -> bool:
     """
 
     Returns True if the type of `element` is a scalar type.

--- a/cunumeric/logic.py
+++ b/cunumeric/logic.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from __future__ import annotations
 
 import numpy as np
 

--- a/cunumeric/module.py
+++ b/cunumeric/module.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from __future__ import annotations
 
 import math
 import re
@@ -45,7 +46,7 @@ _builtin_sum = sum
 # From shape or value
 
 
-def empty(shape, dtype=np.float64):
+def empty(shape, dtype=np.float64) -> ndarray:
     """
     empty(shape, dtype=float)
 
@@ -185,7 +186,7 @@ def identity(n, dtype=float):
     return eye(N=n, M=n, dtype=dtype)
 
 
-def ones(shape, dtype=np.float64):
+def ones(shape, dtype=np.float64) -> ndarray:
     """
 
     Return a new array of given shape and type, filled with ones.

--- a/cunumeric/module.py
+++ b/cunumeric/module.py
@@ -309,7 +309,7 @@ def zeros_like(a, dtype=None):
     return full_like(a, 0, dtype=usedtype)
 
 
-def full(shape, value, dtype=None):
+def full(shape, value, dtype=None) -> ndarray:
     """
 
     Return a new array of given shape and type, filled with `fill_value`.

--- a/cunumeric/module.py
+++ b/cunumeric/module.py
@@ -113,7 +113,7 @@ def empty_like(a, dtype=None):
     return ndarray(shape, dtype=dtype, inputs=(a,))
 
 
-def eye(N, M=None, k=0, dtype=np.float64):
+def eye(N, M=None, k=0, dtype=np.float64) -> ndarray:
     """
 
     Return a 2-D array with ones on the diagonal and zeros elsewhere.
@@ -502,7 +502,7 @@ def asarray(a, dtype=None):
 
 
 @add_boilerplate("a")
-def copy(a):
+def copy(a) -> ndarray:
     """
 
     Return an array copy of the given object.
@@ -2663,7 +2663,7 @@ def inner(a, b, out=None):
 
 
 @add_boilerplate("a", "b")
-def dot(a, b, out=None):
+def dot(a, b, out=None) -> ndarray:
     """
     Dot product of two arrays. Specifically,
 

--- a/cunumeric/patch.py
+++ b/cunumeric/patch.py
@@ -24,6 +24,7 @@ This module is primarily intended for quick demonstrations or proofs of
 concept.
 
 """
+from __future__ import annotations
 
 import sys
 

--- a/cunumeric/random/__init__.py
+++ b/cunumeric/random/__init__.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from __future__ import annotations
 
 import numpy.random as _nprandom
 from cunumeric.random.random import *

--- a/cunumeric/random/random.py
+++ b/cunumeric/random/random.py
@@ -14,19 +14,24 @@
 #
 from __future__ import annotations
 
+from typing import TYPE_CHECKING, Any, Union
+
 import numpy as np
 import numpy.random as nprandom
 from cunumeric.array import ndarray
 from cunumeric.runtime import runtime
 
+if TYPE_CHECKING:
+    import numpy.typing as npt
 
-def seed(init=None):
+
+def seed(init: Union[int, None] = None) -> None:
     if init is None:
         init = 0
     runtime.set_next_random_epoch(int(init))
 
 
-def rand(*shapeargs):
+def rand(*shapeargs: int) -> Union[float, ndarray]:
     """
     rand(d0, d1, ..., dn)
 
@@ -55,14 +60,19 @@ def rand(*shapeargs):
     Multiple GPUs, Multiple CPUs
     """
 
-    if shapeargs is None:
+    if shapeargs == ():
         return nprandom.rand()
     result = ndarray(shapeargs, dtype=np.dtype(np.float64))
     result._thunk.random_uniform()
     return result
 
 
-def randint(low, high=None, size=None, dtype=None):
+def randint(
+    low: Union[int, ndarray],
+    high: Union[int, ndarray, None] = None,
+    size: Union[int, tuple[int], None] = None,
+    dtype: Union[np.dtype[Any], None] = None,
+) -> Union[int, ndarray, npt.NDArray[Any]]:
     """
     Return random integers from `low` (inclusive) to `high` (exclusive).
 
@@ -129,7 +139,7 @@ def randint(low, high=None, size=None, dtype=None):
     return result
 
 
-def randn(*shapeargs):
+def randn(*shapeargs: int) -> Union[float, ndarray]:
     """
     randn(d0, d1, ..., dn)
 
@@ -157,14 +167,14 @@ def randn(*shapeargs):
     Multiple GPUs, Multiple CPUs
     """
 
-    if shapeargs is None:
+    if shapeargs == ():
         return nprandom.randn()
     result = ndarray(shapeargs, dtype=np.dtype(np.float64))
     result._thunk.random_normal()
     return result
 
 
-def random(shape=None):
+def random(shape: Union[tuple[int], None] = None) -> Union[float, ndarray]:
     """
     random(size=None)
 

--- a/cunumeric/random/random.py
+++ b/cunumeric/random/random.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from __future__ import annotations
 
 import numpy as np
 import numpy.random as nprandom

--- a/cunumeric/runtime.py
+++ b/cunumeric/runtime.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from __future__ import annotations
 
 import struct
 import warnings

--- a/cunumeric/runtime.py
+++ b/cunumeric/runtime.py
@@ -259,7 +259,7 @@ class Runtime(object):
             result = future
         return result
 
-    def set_next_random_epoch(self, epoch):
+    def set_next_random_epoch(self, epoch: int) -> None:
         self.current_random_epoch = epoch
 
     def get_next_random_epoch(self):

--- a/cunumeric/sort.py
+++ b/cunumeric/sort.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
+from __future__ import annotations
 
 from cunumeric.config import CuNumericOpCode
 

--- a/cunumeric/thunk.py
+++ b/cunumeric/thunk.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from __future__ import annotations
 
 from abc import ABC, abstractmethod, abstractproperty
 

--- a/cunumeric/window.py
+++ b/cunumeric/window.py
@@ -120,7 +120,7 @@ def hamming(M: int) -> ndarray:
 
     Returns
     -------
-    out : ndarry
+    out : ndarray
         The window, with the maximum value normalized to one (the value
         one appears only if the number of samples is odd).
 

--- a/cunumeric/window.py
+++ b/cunumeric/window.py
@@ -120,7 +120,7 @@ def hamming(M: int) -> ndarray:
 
     Returns
     -------
-    out :
+    out : ndarry
         The window, with the maximum value normalized to one (the value
         one appears only if the number of samples is odd).
 

--- a/cunumeric/window.py
+++ b/cunumeric/window.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from __future__ import annotations
+
+from typing import Any
 
 import numpy as np
 
@@ -20,7 +23,7 @@ from .config import WindowOpCode
 from .module import empty, ones
 
 
-def _create_window(M: int, op_code: WindowOpCode, *args):
+def _create_window(M: int, op_code: WindowOpCode, *args: Any) -> ndarray:
     if M <= 0:
         return empty((0,))
     elif M == 1:
@@ -33,7 +36,7 @@ def _create_window(M: int, op_code: WindowOpCode, *args):
     return out
 
 
-def bartlett(M: int):
+def bartlett(M: int) -> ndarray:
     """
 
     Return the Bartlett window.
@@ -68,7 +71,7 @@ def bartlett(M: int):
     return _create_window(M, WindowOpCode.BARLETT)
 
 
-def blackman(M: int):
+def blackman(M: int) -> ndarray:
     """
 
     Return the Blackman window.
@@ -102,7 +105,7 @@ def blackman(M: int):
     return _create_window(M, WindowOpCode.BLACKMAN)
 
 
-def hamming(M: int):
+def hamming(M: int) -> ndarray:
     """
 
     Return the Hamming window.
@@ -117,7 +120,7 @@ def hamming(M: int):
 
     Returns
     -------
-    out : ndarray
+    out :
         The window, with the maximum value normalized to one (the value
         one appears only if the number of samples is odd).
 
@@ -134,7 +137,7 @@ def hamming(M: int):
     return _create_window(M, WindowOpCode.HAMMING)
 
 
-def hanning(M: int):
+def hanning(M: int) -> ndarray:
     """
 
     Return the Hanning window.
@@ -165,7 +168,7 @@ def hanning(M: int):
     return _create_window(M, WindowOpCode.HANNING)
 
 
-def kaiser(M: int, beta: float):
+def kaiser(M: int, beta: float) -> ndarray:
     """
 
     Return the Kaiser window.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ exclude = '''
 
 [tool.mypy]
 python_version = "3.10"
-mypy_path = "typings/:../legate.core/typings/:..legate.core/install38/lib/python3.8/site-packages/"
 
 pretty = true
 show_error_codes = true
@@ -80,6 +79,8 @@ module = [
     "cunumeric.fft",
     "cunumeric.fft.*",
     "cunumeric.install_info",
+    "cunumeric.linalg",
+    "cunumeric.linalg.*",
     "cunumeric.patch",
     "cunumeric.random",
     "cunumeric.random.*",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,29 +62,15 @@ strict_equality = true
 
 warn_unused_configs = true
 
-# For now enable each typed module individually.
 [[tool.mypy.overrides]]
 module = [
-    "cunumeric.*",
+    "cunumeric.array",
+    "cunumeric.config",
+    "cunumeric.deferred",
+    "cunumeric.eager",
+    "cunumeric.module",
+    "cunumeric.runtime",
+    "cunumeric.sort",
+    "cunumeric.thunk",
 ]
 ignore_errors = true
-
-[[tool.mypy.overrides]]
-module = [
-    "cunumeric._sphinxext",
-    "cunumeric._sphinxext.*",
-    "cunumeric._ufunc",
-    "cunumeric._ufunc.*",
-    "cunumeric.coverage",
-    "cunumeric.fft",
-    "cunumeric.fft.*",
-    "cunumeric.install_info",
-    "cunumeric.linalg",
-    "cunumeric.linalg.*",
-    "cunumeric.patch",
-    "cunumeric.random",
-    "cunumeric.random.*",
-    "cunumeric.utils",
-    "cunumeric.window",
-]
-ignore_errors = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,8 @@ module = [
     "cunumeric.fft.*",
     "cunumeric.install_info",
     "cunumeric.patch",
+    "cunumeric.random",
+    "cunumeric.random.*",
     "cunumeric.utils",
     "cunumeric.window",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,8 @@ module = [
     "cunumeric._ufunc",
     "cunumeric._ufunc.*",
     "cunumeric.coverage",
+    "cunumeric.fft",
+    "cunumeric.fft.*",
     "cunumeric.install_info",
     "cunumeric.patch",
     "cunumeric.utils",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,8 @@ ignore_errors = true
 module = [
     "cunumeric._sphinxext",
     "cunumeric._sphinxext.*",
+    "cunumeric._ufunc",
+    "cunumeric._ufunc.*",
     "cunumeric.coverage",
     "cunumeric.install_info",
     "cunumeric.patch",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ exclude = '''
 
 [tool.mypy]
 python_version = "3.10"
-mypy_path = "typings/"
+mypy_path = "typings/:../legate.core/typings/:..legate.core/install38/lib/python3.8/site-packages/"
 
 pretty = true
 show_error_codes = true
@@ -72,7 +72,12 @@ ignore_errors = true
 
 [[tool.mypy.overrides]]
 module = [
+    "cunumeric._sphinxext",
+    "cunumeric._sphinxext.*",
     "cunumeric.coverage",
+    "cunumeric.install_info",
+    "cunumeric.patch",
     "cunumeric.utils",
+    "cunumeric.window",
 ]
 ignore_errors = false

--- a/tests/unit/cunumeric/test_coverage.py
+++ b/tests/unit/cunumeric/test_coverage.py
@@ -119,7 +119,7 @@ class _Test_ufunc(cunumeric._ufunc.ufunc):
     """docstring"""
 
     def __init__(self):
-        super().__init__("_test_ufunc", "docstring", {"i": "i"})
+        super().__init__("_test_ufunc", "docstring")
 
     def __call__(self, a: int, b: int) -> int:
         return a + b


### PR DESCRIPTION
This PR adds begins adding Python types Cunumeric, starting with the following modules
```
cunumeric._sphinxext
cunumeric._ufunc
cunumeric.coverage
cunumeric.fft
cunumeric.install_info
cunumeric.linalg
cunumeric.patch
cunumeric.random
cunumeric.utils
cunumeric.window
```
Note the ugly `mypy_path` hack currently in `pyproject.toml`:
```
mypy_path = "typings/:../legate.core/typings/:..legate.core/install38/lib/python3.8/site-packages/"
```
This is because `legate` is not actually installed in the `site-packages` for the Python that is executing `mypy`. I think probably the only solution is a dedicated script to invoke `mypy` and also set the env var `MYPY_PATH` from computed values for the legate install. But if anyone has any other ideas, I would love to hear them.
