### PR TITLE
Fix nargs for report:dump-csv

### DIFF
--- a/cunumeric/runtime.py
+++ b/cunumeric/runtime.py
@@ -107,7 +107,7 @@ ARGS = [
         ArgSpec(
             action="store",
             type=str,
-            nargs=1,
+            nargs="?",
             default=None,
             dest="report_dump_csv",
             help="Save a coverage report to a specified CSV file",


### PR DESCRIPTION
There are currently no tests that cover this. I will put this under test when I figure out a more general strategy for testing runtime arg configuration in client libraries. 