### PR TITLE
Disable nitpicky mode

### DIFF
--- a/conda/environment-test-3.10.yml
+++ b/conda/environment-test-3.10.yml
@@ -28,6 +28,7 @@ dependencies:
   - pynvml
   - pytest
   - pytest-cov
+  - types-docutils
 
   # pip dependencies
   - pip

--- a/conda/environment-test-3.8.yml
+++ b/conda/environment-test-3.8.yml
@@ -28,6 +28,7 @@ dependencies:
   - pynvml
   - pytest
   - pytest-cov
+  - types-docutils
 
   # pip dependencies
   - pip

--- a/conda/environment-test-3.9.yml
+++ b/conda/environment-test-3.9.yml
@@ -28,6 +28,7 @@ dependencies:
   - pynvml
   - pytest
   - pytest-cov
+  - types-docutils
 
   # pip dependencies
   - pip

--- a/docs/cunumeric/Makefile
+++ b/docs/cunumeric/Makefile
@@ -18,7 +18,7 @@
 
 # You can set these variables from the command line, and also
 # from the environment for the first two.
-SPHINXOPTS     ?= -n -v -W
+SPHINXOPTS     ?= -v -W
 PARALLEL_BUILD ?= 1
 SPHINXBUILD    ?= legate $(shell which sphinx-build)
 SOURCEDIR      = source

--- a/docs/cunumeric/source/conf.py
+++ b/docs/cunumeric/source/conf.py
@@ -19,20 +19,11 @@
 # list see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
-# -- Path setup --------------------------------------------------------------
-
-# If extensions (or modules to document with autodoc) are in another directory,
-# add these directories to sys.path here. If the directory is relative to the
-# documentation root, use os.path.abspath to make it absolute, like shown here.
-#
-
-
 # -- Project information -----------------------------------------------------
 
 project = "cunumeric"
 copyright = "2021-2022, NVIDIA"
 author = "NVIDIA"
-
 
 # -- General configuration ---------------------------------------------------
 
@@ -52,8 +43,6 @@ extensions = [
     "cunumeric._sphinxext.ufunc_formatter",
 ]
 
-copybutton_prompt_text = ">>> "
-
 # The master toctree document.
 master_doc = "index"
 
@@ -67,12 +56,10 @@ source_suffix = {".rst": "restructuredtext", ".md": "markdown"}
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = []
 
-
 # -- Options for HTML output -------------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-#
 html_theme = "pydata_sphinx_theme"
 
 # Add any paths that contain custom static files (such as style sheets) here,
@@ -82,34 +69,20 @@ html_static_path = ["_static"]
 
 pygments_style = "sphinx"
 
-nitpick_ignore = [
-    ("py:class", "1-D array of"),
-    ("py:class", "any"),
-    ("py:class", "array_like"),
-    ("py:class", "array"),
-    ("py:class", "complex ndarray"),
-    ("py:class", "data-type"),
-    ("py:class", "M"),
-    ("py:class", "N"),
-    ("py:class", "nested list of array_like"),
-    ("py:class", "optional"),
-    ("py:class", "scalar"),
-    ("py:class", "scalars"),
-    ("py:class", "sequence of ints"),
-    ("py:class", "type"),
-]
-
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3/", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
 }
 
-# Config napolean
-napoleon_custom_sections = [("Availability", "returns_style")]
+# -- Options for extensions --------------------------------------------------
 
 autosummary_generate = True
 
+copybutton_prompt_text = ">>> "
+
 mathjax_path = "https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"
+
+napoleon_custom_sections = [("Availability", "returns_style")]
 
 
 def setup(app):


### PR DESCRIPTION
This PR removes the `-n` in the Sphinx `Makefile`, which turns off "nitpicky" mode. This means that implicit "auto" references, e.g. `arg: foo` in docstrings will still attempt to generate references, but will not warning if the target does not exist. Explicit references with no target e.g. `:func:~foo` will still generate warnings. 

This change means we no longer have to maintain an ugly `nitpick_ignores` list just in order to have more narrative argument type descriptions in docstrings where appropriate. Note that things like `arg: ndarray` *do* still work just fine (resulting in a link to `cunumeric.ndarray`). This change only affects things like `"complex ndarray"`, etc. which will now simply be passes as-is with no warning. 

Additionally, this PR adds `types-docutils` to the env files. This change is not directly related to the sphinx change above, but came up coincidentally (needed for mypy to work on our sphinx extensions).  Assuming this PR is merged I will make a similar env change in legate-core. 