### PR TITLE
Report Elapsed Time in cholesky's output

### DIFF
--- a/examples/cholesky.py
+++ b/examples/cholesky.py
@@ -27,7 +27,9 @@ def cholesky(n, dtype):
     np.linalg.cholesky(input)
     stop = time()
     flops = (n**3) / 3 + 2 * n / 3
-    print(f"{(stop - start) * 1e-3} ms, {flops / (stop - start) * 1e-3} GOP/s")
+    total = (stop - start) / 1000.0
+    print(f"Elapsed Time: {total} ms")
+    print(f"{flops / total} GOP/s")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
All other examples report `Elapsed Time`. This will make existing parsing scripts usable with cholesky too.