### PR TITLE
Fall back to NumPy in __array_function__ and __array_ufunc__

### DIFF
--- a/cunumeric/module.py
+++ b/cunumeric/module.py
@@ -3690,8 +3690,8 @@ def isclose(a, b, rtol=1e-5, atol=1e-8, equal_nan=False):
     return out
 
 
-@add_boilerplate("a", "b")
-def array_equal(a, b):
+@add_boilerplate("a1", "a2")
+def array_equal(a1, a2, equal_nan=False):
     """
 
     True if two arrays have the same shape and elements, False otherwise.
@@ -3700,6 +3700,10 @@ def array_equal(a, b):
     ----------
     a1, a2 : array_like
         Input arrays.
+    equal_nan : bool
+        Whether to compare NaN's as equal. If the dtype of a1 and a2 is
+        complex, values will be considered equal if either the real or the
+        imaginary component of a given value is ``nan``.
 
     Returns
     -------
@@ -3714,10 +3718,15 @@ def array_equal(a, b):
     --------
     Multiple GPUs, Multiple CPUs
     """
-    if a.shape != b.shape:
+    if equal_nan:
+        raise NotImplementedError(
+            "cuNumeric does not support `equal_nan` yet for `array_equal`"
+        )
+
+    if a1.shape != a2.shape:
         return False
     return ndarray._perform_binary_reduction(
-        BinaryOpCode.EQUAL, a, b, dtype=np.dtype(np.bool_)
+        BinaryOpCode.EQUAL, a1, a2, dtype=np.dtype(np.bool_)
     )
 
 

--- a/tests/integration/test_fallback.py
+++ b/tests/integration/test_fallback.py
@@ -1,0 +1,39 @@
+# Copyright 2022 NVIDIA Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import numpy as np
+import pytest
+
+import cunumeric as num
+
+
+def test_array_equal():
+    a = num.array([1, 2, 3])
+    assert np.array_equal(a, a, equal_nan=True)
+
+
+def test_ufunc():
+    in_num = num.array([0, 1, 2, 3])
+    in_np = in_num.__array__()
+
+    out_num = np.logical_and.reduce(in_num)
+    out_np = np.logical_and.reduce(in_np)
+    assert np.array_equal(out_num, out_np)
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main(sys.argv))


### PR DESCRIPTION
One side effect of #353 is that it redirects all NumPy calls to cuNumeric whenever cuNumeric has an implementation. This is problematic because this happens unconditionally and the cuNumeric implementation is often incomplete; even if the user explicitly makes a NumPy call via the `numpy` module, it can still go to cuNumeric and crashes. This PR to remedy the situation by catching `NotImplementedError`s coming out from cuNumeric and falling back to NumPy.