### PR TITLE
Support -vv for more verbose test output

### DIFF
--- a/tests/_utils/args.py
+++ b/tests/_utils/args.py
@@ -212,8 +212,9 @@ test_opts.add_argument(
     "-v",
     "--verbose",
     dest="verbose",
-    action="store_true",
-    help="Print more debugging information",
+    action="count",
+    default=0,
+    help="Display verbose output. Use -vv for even more output (test stdout)",
 )
 
 

--- a/tests/_utils/test_stages/test_stage.py
+++ b/tests/_utils/test_stages/test_stage.py
@@ -169,10 +169,12 @@ class TestStage(Protocol):
         test_file_string = str(test_file)
         args = PER_FILE_ARGS.get(test_file_string, [])
 
-        # This is somewhat ugly but necessary in order to make pytest generate
-        # more verbose output for integration tests when --verbose is specified
-        if "integration" in test_file_string and config.verbose:
+        # These are a bit ugly but necessary in order to make pytest generate
+        # more verbose output for integration tests when -v, -vv is specified
+        if "integration" in test_file_string and config.verbose > 0:
             args += ["-v"]
+        if "integration" in test_file_string and config.verbose > 1:
+            args += ["-s"]
 
         return args
 

--- a/tests/_utils/tests/test_args.py
+++ b/tests/_utils/tests/test_args.py
@@ -75,7 +75,7 @@ class TestParserDefaults:
         assert m.parser.get_default("workers") is None
 
     def test_verbose(self) -> None:
-        assert m.parser.get_default("verbose") is False
+        assert m.parser.get_default("verbose") == 0
 
     def test_dry_run(self) -> None:
         assert m.parser.get_default("dry_run") is False

--- a/tests/_utils/tests/test_config.py
+++ b/tests/_utils/tests/test_config.py
@@ -51,7 +51,7 @@ class TestConfig:
 
         assert c.debug is False
         assert c.dry_run is False
-        assert c.verbose is False
+        assert c.verbose == 0
         assert c.test_root is None
         assert c.requested_workers is None
         assert isinstance(c.legate_dir, Path)
@@ -121,9 +121,13 @@ class TestConfig:
         assert c.dry_run is True
 
     @pytest.mark.parametrize("arg", ("-v", "--verbose"))
-    def test_verbose(self, arg: str) -> None:
+    def test_verbose1(self, arg: str) -> None:
         c = m.Config(["test.py", arg])
-        assert c.verbose is True
+        assert c.verbose == 1
+
+    def test_verbose2(self) -> None:
+        c = m.Config(["test.py", "-vv"])
+        assert c.verbose == 2
 
     @pytest.mark.parametrize("arg", ("-C", "--directory"))
     def test_test_root(self, arg: str) -> None:


### PR DESCRIPTION
Requested by @fduguet-nv This PR adds support for a `-vv` option to `test.py`. When `-vv` is sprecified, the pytest `-s` option is added to the individual test file invocations that the `test.py` test runner launches. This will cause the `stdout` output, which is normally suppressed on passing tests, to be displayed unconditionally. 

It is recommended that this option be used in conjunction with the `--files` argument, in order to obtain more manageable output. Here is an example of such usage:
```
dev38 ❯ ./test.py --use=cuda,cpus,eager -vv --files tests/integration/test_binary_op_broadcast.py                         

############################################################
### 
### Test Suite Configuration
### 
### * Feature stages       : cpus, cuda, eager
### * Test files per stage : 1
### 
############################################################

############################################################
### Entering stage: CPU (with 1 worker)
############################################################

[PASS] (CPU) tests/integration/test_binary_op_broadcast.py
   ============================= test session starts ==============================
   platform linux -- Python 3.8.13, pytest-7.1.2, pluggy-1.0.0 -- /home/bryan/anaconda3/envs/dev38/bin/python3
   cachedir: .pytest_cache
   rootdir: /home/bryan/work/cunumeric, configfile: pyproject.toml
   plugins: cov-3.0.0, mock-3.8.1
   collecting ... collected 4 items
   
   tests/integration/test_binary_op_broadcast.py::test_random[2-(20, 21, 22)]   (20, 21) x (21,)
     (20, 21) x (1, 21)
     (20, 21) x (20, 1)
   PASSED
   tests/integration/test_binary_op_broadcast.py::test_random[2-(1, 21, 22)]   (1, 21) x (21,)
     (1, 21) x (1, 21)
     (1, 21) x (1, 1)
   PASSED
   tests/integration/test_binary_op_broadcast.py::test_random[3-(20, 21, 22)]   (20, 21, 22) x (22,)
     (20, 21, 22) x (21, 22)
     (20, 21, 22) x (1, 21, 22)
     (20, 21, 22) x (20, 1, 22)
     (20, 21, 22) x (20, 21, 1)
     (20, 21, 22) x (20, 1, 1)
     (20, 21, 22) x (1, 21, 1)
     (20, 21, 22) x (1, 1, 22)
   PASSED
   tests/integration/test_binary_op_broadcast.py::test_random[3-(1, 21, 22)]   (1, 21, 22) x (22,)
     (1, 21, 22) x (21, 22)
     (1, 21, 22) x (1, 21, 22)
     (1, 21, 22) x (1, 1, 22)
     (1, 21, 22) x (1, 21, 1)
     (1, 21, 22) x (1, 1, 1)
     (1, 21, 22) x (1, 21, 1)
     (1, 21, 22) x (1, 1, 22)
   PASSED
   
   ============================== 4 passed in 0.43s ===============================
   [0 - 7fd3894ec000]    0.000084 {4}{threads}: reservation ('CPU proc 1d00000000000004') cannot be satisfied
   
                           CPU: Passed 1 of 1 tests (100.0%)

############################################################
### 
### Exiting state: CPU
### 
### * Results      : 1 / 1 files passed (100.0%)
### * Elapsed time : 0:00:01.831223
### 
############################################################

############################################################
### Entering stage: GPU (with 7 workers)
############################################################

[PASS] (GPU) tests/integration/test_binary_op_broadcast.py
   ============================= test session starts ==============================
   platform linux -- Python 3.8.13, pytest-7.1.2, pluggy-1.0.0 -- /home/bryan/anaconda3/envs/dev38/bin/python3
   cachedir: .pytest_cache
   rootdir: /home/bryan/work/cunumeric, configfile: pyproject.toml
   plugins: cov-3.0.0, mock-3.8.1
   collecting ... collected 4 items
   
   tests/integration/test_binary_op_broadcast.py::test_random[2-(20, 21, 22)]   (20, 21) x (21,)
     (20, 21) x (1, 21)
     (20, 21) x (20, 1)
   PASSED
   tests/integration/test_binary_op_broadcast.py::test_random[2-(1, 21, 22)]   (1, 21) x (21,)
     (1, 21) x (1, 21)
     (1, 21) x (1, 1)
   PASSED
   tests/integration/test_binary_op_broadcast.py::test_random[3-(20, 21, 22)]   (20, 21, 22) x (22,)
     (20, 21, 22) x (21, 22)
     (20, 21, 22) x (1, 21, 22)
     (20, 21, 22) x (20, 1, 22)
     (20, 21, 22) x (20, 21, 1)
     (20, 21, 22) x (20, 1, 1)
     (20, 21, 22) x (1, 21, 1)
     (20, 21, 22) x (1, 1, 22)
   PASSED
   tests/integration/test_binary_op_broadcast.py::test_random[3-(1, 21, 22)]   (1, 21, 22) x (22,)
     (1, 21, 22) x (21, 22)
     (1, 21, 22) x (1, 21, 22)
     (1, 21, 22) x (1, 1, 22)
     (1, 21, 22) x (1, 21, 1)
     (1, 21, 22) x (1, 1, 1)
     (1, 21, 22) x (1, 21, 1)
     (1, 21, 22) x (1, 1, 22)
   PASSED
   
   ============================== 4 passed in 0.67s ===============================
   [0 - 7f941e08d000]    0.000098 {4}{threads}: reservation ('CPU proc 1d00000000000003') cannot be satisfied
   
                           GPU: Passed 1 of 1 tests (100.0%)

############################################################
### 
### Exiting state: GPU
### 
### * Results      : 1 / 1 files passed (100.0%)
### * Elapsed time : 0:00:02.297075
### 
############################################################

############################################################
### Entering stage: Eager (with 1 worker)
############################################################

[PASS] (Eager) tests/integration/test_binary_op_broadcast.py
   ============================= test session starts ==============================
   platform linux -- Python 3.8.13, pytest-7.1.2, pluggy-1.0.0 -- /home/bryan/anaconda3/envs/dev38/bin/python3
   cachedir: .pytest_cache
   rootdir: /home/bryan/work/cunumeric, configfile: pyproject.toml
   plugins: cov-3.0.0, mock-3.8.1
   collecting ... collected 4 items
   
   tests/integration/test_binary_op_broadcast.py::test_random[2-(20, 21, 22)]   (20, 21) x (21,)
     (20, 21) x (1, 21)
     (20, 21) x (20, 1)
   PASSED
   tests/integration/test_binary_op_broadcast.py::test_random[2-(1, 21, 22)]   (1, 21) x (21,)
     (1, 21) x (1, 21)
     (1, 21) x (1, 1)
   PASSED
   tests/integration/test_binary_op_broadcast.py::test_random[3-(20, 21, 22)]   (20, 21, 22) x (22,)
     (20, 21, 22) x (21, 22)
     (20, 21, 22) x (1, 21, 22)
     (20, 21, 22) x (20, 1, 22)
     (20, 21, 22) x (20, 21, 1)
     (20, 21, 22) x (20, 1, 1)
     (20, 21, 22) x (1, 21, 1)
     (20, 21, 22) x (1, 1, 22)
   PASSED
   tests/integration/test_binary_op_broadcast.py::test_random[3-(1, 21, 22)]   (1, 21, 22) x (22,)
     (1, 21, 22) x (21, 22)
     (1, 21, 22) x (1, 21, 22)
     (1, 21, 22) x (1, 1, 22)
     (1, 21, 22) x (1, 21, 1)
     (1, 21, 22) x (1, 1, 1)
     (1, 21, 22) x (1, 21, 1)
     (1, 21, 22) x (1, 1, 22)
   PASSED
   
   ============================== 4 passed in 0.04s ===============================
   [0 - 7fb6a8ab5000]    0.000068 {4}{threads}: reservation ('CPU proc 1d00000000000002') cannot be satisfied
   
                         Eager: Passed 1 of 1 tests (100.0%)

############################################################
### 
### Exiting state: Eager
### 
### * Results      : 1 / 1 files passed (100.0%)
### * Elapsed time : 0:00:01.318096
### 
############################################################

    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                     All tests: Passed 3 of 3 tests (100.0%)
```