### PR TITLE
Fix test_floating.py test to call sys.exit

### DIFF
--- a/cunumeric/_ufunc/ufunc.py
+++ b/cunumeric/_ufunc/ufunc.py
@@ -264,7 +264,7 @@ class ufunc:
         raise TypeError("return arrays must be of ArrayType")
 
     def _prepare_operands(
-        self, *args: Any, out: Union[ndarray, None], where: bool = True
+        self, *args: Any, out: Union[ndarray, tuple[ndarray, ...], None], where: bool = True
     ) -> tuple[
         Sequence[ndarray],
         Sequence[Union[ndarray, None]],
@@ -295,6 +295,8 @@ class ufunc:
             computed_out = (None,) * self.nout
         elif not isinstance(out, tuple):
             computed_out = (out,)
+        else:
+            computed_out = out
 
         outputs = tuple(
             self._maybe_convert_output_to_cunumeric_ndarray(arr)
@@ -469,7 +471,7 @@ class multiout_unary_ufunc(ufunc):
     def __call__(
         self,
         *args: Any,
-        out: Union[ndarray, None] = None,
+        out: Union[ndarray, tuple[ndarray, ...], None] = None,
         where: bool = True,
         casting: CastingKind = "same_kind",
         order: str = "K",

--- a/cunumeric/_ufunc/ufunc.py
+++ b/cunumeric/_ufunc/ufunc.py
@@ -264,7 +264,10 @@ class ufunc:
         raise TypeError("return arrays must be of ArrayType")
 
     def _prepare_operands(
-        self, *args: Any, out: Union[ndarray, tuple[ndarray, ...], None], where: bool = True
+        self,
+        *args: Any,
+        out: Union[ndarray, tuple[ndarray, ...], None],
+        where: bool = True,
     ) -> tuple[
         Sequence[ndarray],
         Sequence[Union[ndarray, None]],

--- a/tests/integration/test_floating.py
+++ b/tests/integration/test_floating.py
@@ -141,4 +141,4 @@ def test_typing_unary(fun, dtype, shape):
 if __name__ == "__main__":
     import sys
 
-    pytest.main(sys.argv)
+    sys.exit(pytest.main(sys.argv))


### PR DESCRIPTION
Because this test is not calling `sys.exit`, the test failures are not correctly registered. In this PR we fix the test and the failing test cases.