### PR TITLE
Update compress/take tests for pytest

### DIFF
--- a/tests/integration/test_compress.py
+++ b/tests/integration/test_compress.py
@@ -14,67 +14,90 @@
 #
 
 import numpy as np
+import pytest
 from test_tools.generators import mk_seq_array
 
 import cunumeric as num
 from legate.core import LEGATE_MAX_DIM
 
 
-def test():
-    # test on the 1D array:
+def test_1d():
     a = mk_seq_array(np, (10,))
     a_num = num.array(a)
+
     res = np.compress([True, False, True], a, axis=0)
     res_num = num.compress([True, False, True], a_num, axis=0)
+
     assert np.array_equal(res_num, res)
 
-    # testing compress on 2D array with different axis
+
+@pytest.mark.parametrize("axis", (0, 1))
+def test_2d_axis(axis):
     a = np.array([[1, 2], [3, 4], [5, 6]])
     num_a = num.array(a)
-    res_np = np.compress([0, 1], a, axis=0)
-    res_num = num.compress([0, 1], num_a, axis=0)
+
+    res_np = np.compress([0, 1], a, axis=axis)
+    res_num = num.compress([0, 1], num_a, axis=axis)
+
     assert np.array_equal(res_num, res_np)
 
-    res_np = np.compress([0, 1], a, axis=1)
-    res_num = num.compress([0, 1], num_a, axis=1)
-    assert np.array_equal(res_num, res_np)
 
-    # tesing when condition is a bool type
+def test_bool_condition():
+    a = np.array([[1, 2], [3, 4], [5, 6]])
+    num_a = num.array(a)
+
     res_np = np.compress([True, False], a, axis=1)
     res_num = num.compress([True, False], num_a, axis=1)
+
     assert np.array_equal(res_num, res_np)
 
-    # testing with output array
+
+def test_out():
+    a = np.array([[1, 2], [3, 4], [5, 6]])
+    num_a = num.array(a)
     out_np = np.array([[1], [1], [1]])
     out_num = num.array(out_np)
+
     res_np = np.compress([0, 1], a, axis=1, out=out_np)
     res_num = num.compress([0, 1], num_a, axis=1, out=out_num)
+
     assert np.array_equal(res_num, res_np)
     assert np.array_equal(out_num, out_np)
 
-    # the case when input and output arrays have different types
+
+def test_different_types():
     a = np.array([[1, 2], [3, 4], [5, 6]], dtype=float)
     num_a = num.array(a)
+    out_np = np.array([[1], [1], [1]])
+    out_num = num.array(out_np)
+
     res_np = np.compress([0, 1], a, axis=1, out=out_np)
     res_num = num.compress([0, 1], num_a, axis=1, out=out_num)
+
     assert np.array_equal(res_num, res_np)
     assert np.array_equal(out_num, out_np)
 
-    for ndim in range(1, LEGATE_MAX_DIM + 1):
-        shape = (5,) * ndim
-        np_arr = mk_seq_array(np, shape)
-        num_arr = mk_seq_array(num, shape)
-        # make sure condition is between 1 and 2
-        np_condition = mk_seq_array(np, (5,)) % 2
-        num_condition = mk_seq_array(num, (5,)) % 2
-        res_np = np.compress(np_condition, np_arr)
-        res_num = num.compress(num_condition, num_arr)
+
+@pytest.mark.parametrize("ndim", range(1, LEGATE_MAX_DIM + 1))
+def test_ndim(ndim):
+    shape = (5,) * ndim
+    np_arr = mk_seq_array(np, shape)
+    num_arr = mk_seq_array(num, shape)
+    # make sure condition is between 1 and 2
+    np_condition = mk_seq_array(np, (5,)) % 2
+    num_condition = mk_seq_array(num, (5,)) % 2
+
+    res_np = np.compress(np_condition, np_arr)
+    res_num = num.compress(num_condition, num_arr)
+    assert np.array_equal(res_num, res_np)
+
+    for axis in range(ndim):
+        res_np = np.compress(np_condition, np_arr, axis)
+        res_num = num.compress(num_condition, num_arr, axis)
         assert np.array_equal(res_num, res_np)
-        for axis in range(ndim):
-            res_np = np.compress(np_condition, np_arr, axis)
-            res_num = num.compress(num_condition, num_arr, axis)
-            assert np.array_equal(res_num, res_np)
 
 
 if __name__ == "__main__":
-    test()
+    import sys
+
+    sys.exit(pytest.main(sys.argv))

--- a/tests/integration/test_take.py
+++ b/tests/integration/test_take.py
@@ -14,106 +14,115 @@
 #
 
 import numpy as np
+import pytest
 from test_tools.generators import mk_seq_array
 
 import cunumeric as num
 from legate.core import LEGATE_MAX_DIM
 
+x = mk_seq_array(np, (3, 4, 5))
+x_num = mk_seq_array(num, (3, 4, 5))
+indices = mk_seq_array(np, (8,))
+indices_num = num.array(indices)
+indices2 = mk_seq_array(np, (3,))
+indices2_num = num.array(indices2)
 
-def test():
 
-    x = mk_seq_array(np, (3, 4, 5))
-    x_num = mk_seq_array(num, (3, 4, 5))
-    indices = mk_seq_array(np, (8,))
-    indices_num = num.array(indices)
-
-    # testing the case when no axis provided
+def test_no_axis():
     res = np.take(x, indices)
     res_num = num.take(x_num, indices_num)
+
     assert np.array_equal(res_num, res)
 
-    # testing different modes with different axis
-    res = np.take(x, indices, axis=0, mode="clip")
-    res_num = num.take(x_num, indices_num, axis=0, mode="clip")
+
+@pytest.mark.parametrize("mode", ("clip", "wrap"))
+@pytest.mark.parametrize("axis", (0, 1, 2))
+def test_different_axis_mode(axis, mode):
+    res = np.take(x, indices, axis=axis, mode=mode)
+    res_num = num.take(x_num, indices_num, axis=axis, mode=mode)
     assert np.array_equal(res_num, res)
 
-    res = np.take(x, indices, axis=1, mode="wrap")
-    res_num = num.take(x_num, indices_num, axis=1, mode="wrap")
-    assert np.array_equal(res_num, res)
 
-    res = np.take(x, indices, axis=2, mode="clip")
-    res_num = num.take(x_num, indices_num, axis=2, mode="clip")
-    assert np.array_equal(res_num, res)
-
-    indices2 = mk_seq_array(np, (3,))
-    indices2_num = num.array(indices2)
-
+def test_different_axis_default_mode():
     res = np.take(x, indices2, axis=1)
     res_num = num.take(x_num, indices2_num, axis=1)
+
     assert np.array_equal(res_num, res)
 
+
+def test_different_axis_raise_mode():
     res = np.take(x, indices2, axis=2, mode="raise")
     res_num = num.take(x_num, indices2_num, axis=2, mode="raise")
     assert np.array_equal(res_num, res)
 
-    # testing with output array
+
+def test_with_out_array():
     out = np.ones((3, 4, 3), dtype=int)
     out_num = num.array(out)
-    res = np.take(x, indices2, axis=2, mode="raise", out=out)
-    res_num = num.take(x_num, indices2_num, axis=2, mode="raise", out=out_num)
+    np.take(x, indices2, axis=2, mode="raise", out=out)
+    num.take(x_num, indices2_num, axis=2, mode="raise", out=out_num)
     assert np.array_equal(out_num, out)
 
-    # testing the case when indices is a scalar
-    res = np.take(x, 7, axis=0, mode="clip")
-    res_num = num.take(x_num, 7, axis=0, mode="clip")
-    assert np.array_equal(res_num, res)
 
-    res = np.take(x, 7, axis=0, mode="wrap")
-    res_num = num.take(x_num, 7, axis=0, mode="wrap")
-    assert np.array_equal(res_num, res)
-
+def test_indices_list_single():
     x = np.arange(6)
     x_num = num.array(x)
 
     res = x.take([3], axis=0)
     res_num = x_num.take([3], axis=0)
+
     assert np.array_equal(res_num, res)
+
+
+def test_indices_list():
+    x = np.arange(6)
+    x_num = num.array(x)
 
     res = x.take([-6, -5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5], axis=0)
     res_num = x_num.take([-6, -5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5], axis=0)
+
     assert np.array_equal(res_num, res)
 
-    for ndim in range(1, LEGATE_MAX_DIM + 1):
-        shape = (5,) * ndim
-        np_arr = mk_seq_array(np, shape)
-        num_arr = mk_seq_array(num, shape)
-        np_indices = mk_seq_array(np, (4,))
-        num_indices = mk_seq_array(num, (4,))
-        res_np = np.take(np_arr, np_indices)
-        res_num = num.take(num_arr, num_indices)
-        assert np.array_equal(res_num, res_np)
-        for axis in range(ndim):
-            res_np = np.take(np_arr, np_indices, axis=axis)
-            res_num = num.take(num_arr, num_indices, axis=axis)
-            assert np.array_equal(res_num, res_np)
-        np_indices = mk_seq_array(np, (8,))
-        num_indices = mk_seq_array(num, (8,))
-        res_np = np.take(np_arr, np_indices, mode="wrap")
-        res_num = num.take(num_arr, num_indices, mode="wrap")
-        assert np.array_equal(res_num, res_np)
-        res_np = np.take(np_arr, np_indices, mode="clip")
-        res_num = num.take(num_arr, num_indices, mode="clip")
-        assert np.array_equal(res_num, res_np)
-        for axis in range(ndim):
-            res_np = np.take(np_arr, np_indices, axis=axis, mode="clip")
-            res_num = num.take(num_arr, num_indices, axis=axis, mode="clip")
-            assert np.array_equal(res_num, res_np)
-            res_np = np.take(np_arr, np_indices, axis=axis, mode="wrap")
-            res_num = num.take(num_arr, num_indices, axis=axis, mode="wrap")
-            assert np.array_equal(res_num, res_np)
 
-    return
+@pytest.mark.parametrize("mode", ("clip", "wrap"))
+def test_scalar_indices_mode(mode):
+    res = np.take(x, 7, axis=0, mode=mode)
+    res_num = num.take(x_num, 7, axis=0, mode=mode)
+
+    assert np.array_equal(res_num, res)
+
+
+@pytest.mark.parametrize("mode", ("clip", "wrap"))
+@pytest.mark.parametrize("ndim", range(1, LEGATE_MAX_DIM + 1))
+def test_ndim(ndim, mode):
+    shape = (5,) * ndim
+    np_arr = mk_seq_array(np, shape)
+    num_arr = mk_seq_array(num, shape)
+    np_indices = mk_seq_array(np, (4,))
+    num_indices = mk_seq_array(num, (4,))
+    res_np = np.take(np_arr, np_indices)
+    res_num = num.take(num_arr, num_indices)
+
+    assert np.array_equal(res_num, res_np)
+    for axis in range(ndim):
+        res_np = np.take(np_arr, np_indices, axis=axis)
+        res_num = num.take(num_arr, num_indices, axis=axis)
+        assert np.array_equal(res_num, res_np)
+
+    np_indices = mk_seq_array(np, (8,))
+    num_indices = mk_seq_array(num, (8,))
+
+    res_np = np.take(np_arr, np_indices, mode=mode)
+    res_num = num.take(num_arr, num_indices, mode=mode)
+
+    assert np.array_equal(res_num, res_np)
+    for axis in range(ndim):
+        res_np = np.take(np_arr, np_indices, axis=axis, mode=mode)
+        res_num = num.take(num_arr, num_indices, axis=axis, mode=mode)
+        assert np.array_equal(res_num, res_np)
 
 
 if __name__ == "__main__":
-    test()
+    import sys
+
+    sys.exit(pytest.main(sys.argv))


### PR DESCRIPTION
Here were some more tests that were not calling `sys.exit`, meaning that if the tests were to fail, the result would only be *printed*, but would not cause a CI job to fail (as it should). cc @marcinz I will work on #434 soon to help enforce this requirement on our test modules. 

As long as I was updating these files, I also took the opportunity to bring them more in line with the other test files, that split tests into discrete, descriptively named test functions, and utilize `pytest.parametrize`, etc. cc @ipdemes can you review and confirm that my changes preserve the intent of the original tests?

cc @magnatelee I didn't happen to see the original PR for this go by. I will try to be more pro-active regarding scanning new PRs, but if there are any that involve new tests please don't hesitate to ping me explicitly to raise my attention. FWIW in general I'd like to encourage the [Arrange-Act-Assert](https://automationpanda.com/2020/07/07/arrange-act-assert-a-pattern-for-writing-good-tests/) (AAA) pattern for tests, which looks like:
```python
@pytest.mark.parametrize("axis", (0, 1))
def test_2d_axis(axis):

    # Arrange
    a = np.array([[1, 2], [3, 4], [5, 6]])
    num_a = num.array(a)

    # Act
    res_np = np.compress([0, 1], a, axis=axis)
    res_num = num.compress([0, 1], num_a, axis=axis)

    # Assert
    assert np.array_equal(res_num, res_np)
```
Ideally with this pattern, each test only contains a single assertion (in a descriptively named test function), and if there is repeated "setup" then pytest fixtures are a good way to factor out the "Arrange" section as well, so that the test functions are typically very short. I have not added comments to the tests here, but I have adjusted vertical white space to distinguish the AAA sections. 