### PR TITLE
Add a pre-commit check to enforce pytest main convention

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,5 +17,13 @@ repos:
         - id: clang-format
           files: \.(cu|cuh|h|cc|inl)$
           types_or: []
+    - repo: local
+      hooks:
+        - id: enforce-pytest-main
+          name: Enforce pytest.main
+          description: Make sure tests use sys.ext(pytest.main(...))
+          entry: python scripts/hooks/enforce_pytest_main.py
+          language: python
+          pass_filenames: false
 default_language_version:
     python: python3

--- a/scripts/hooks/enforce_pytest_main.py
+++ b/scripts/hooks/enforce_pytest_main.py
@@ -1,0 +1,42 @@
+# Copyright 2022 NVIDIA Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import sys
+from pathlib import Path
+from typing import NoReturn
+
+BOILERPLATE = "sys.exit(pytest.main(sys.argv))"
+
+TESTS_TOP = Path(__file__).parents[2] / "tests"
+
+TEST_DIRS = (TESTS_TOP / "unit", TESTS_TOP / "integration")
+
+
+def enforce_pytest_main() -> NoReturn:
+
+    for dir in TEST_DIRS:
+        for path in dir.rglob("*.py"):
+
+            if not path.is_file() or not path.name.startswith("test_"):
+                continue
+
+            if not open(path).readlines()[-1].strip() == BOILERPLATE:
+                print(f"Test file {path} missing required boilerplate")
+                sys.exit(1)
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    enforce_pytest_main()

--- a/tests/unit/cunumeric/_sphinxext/test__comparison_util.py
+++ b/tests/unit/cunumeric/_sphinxext/test__comparison_util.py
@@ -60,4 +60,4 @@ class Test_filter_names:
 if __name__ == "__main__":
     import sys
 
-    pytest.main(sys.argv)
+    sys.exit(pytest.main(sys.argv))


### PR DESCRIPTION
This PR adds a new pre-commit hook `enforce-pytest-main` that ensures that all test modules end with 
```
sys.exit(pytest.main(sys.argv))
```
I had tried to originally test for 
```
if __name__ == "__main__":
    import sys

    sys.exit(pytest.main(sys.argv))
``` 
but there are a few tests that have more complicated "main checks" so that they can also be run as standalone scripts.