### PR TITLE
Updates to api_compare.py

### DIFF
--- a/cunumeric/_sphinxext/_comparison_config.py
+++ b/cunumeric/_sphinxext/_comparison_config.py
@@ -138,7 +138,6 @@ MANIP = (
     "asfarray",
     "asfortranarray",
     "asmatrix",
-    "asscalar",
     "atleast_1d",
     "atleast_2d",
     "atleast_3d",

--- a/scripts/api_compare.py
+++ b/scripts/api_compare.py
@@ -18,9 +18,9 @@ import csv
 import sys
 from dataclasses import astuple, dataclass
 
+from cunumeric._sphinxext._comparison_config import GROUPED_CONFIGS
+from cunumeric._sphinxext._comparison_util import filter_names
 from cunumeric.coverage import is_implemented
-from cunumeric.sphinxext._comparison_config import GROUPED_CONFIGS
-from cunumeric.sphinxext._comparison_util import filter_names
 
 
 @dataclass


### PR DESCRIPTION
This PR has minor updates/fixes for `api_compare.py`:

* Numpy 1.23 removed deprecated `np.asscalar` entirely
* Sphinx ext support code moved to private module

With these changes the script is functional again:
```
gas38 ❯ legate scripts/api_compare.py 
group,numpy,cunumeric,cupy
Convolve and Correlate,2,1,2
Ufuncs,91,87,86
Logical operations,14,12,11
Einsum and related,6,6,6
Discrete Fourier transform,18,14,18
Set operations,7,1,3
Array manipulation,48,25,41
Array manipulation (ndarray),1,1,1
Factorizations,2,1,2
SVD and related,4,0,4
Eigenvalues,4,0,2
LU factorization and related,6,0,6
Input and output,20,0,17
Input and output (ndarray),2,2,2
Array creation,29,17,25
Array creation (ndarray),1,1,1
Mathematical functions,30,7,27
"Searching, sorting, and counting",18,12,18
Advanced statistics,22,2,19
Miscellaneous matrix routines,1,0,1
Packing and unpacking bits,2,2,2
Indexing,23,7,16
Padding arrays,1,0,1
Random sampling,51,5,49
Functional programming,4,0,2
```