### PR TITLE
markdown version fix

### DIFF
--- a/conda/environment-test-3.10.yml
+++ b/conda/environment-test-3.10.yml
@@ -38,6 +38,7 @@ dependencies:
     - jinja2
     - pydata-sphinx-theme
     - recommonmark
+    - markdown<3.4.0
     - sphinx>=4.4.0
     - sphinx-copybutton
     - sphinx-markdown-tables

--- a/conda/environment-test-3.8.yml
+++ b/conda/environment-test-3.8.yml
@@ -38,6 +38,7 @@ dependencies:
     - jinja2
     - pydata-sphinx-theme
     - recommonmark
+    - markdown<3.4.0
     - sphinx>=4.4.0
     - sphinx-copybutton
     - sphinx-markdown-tables

--- a/conda/environment-test-3.9.yml
+++ b/conda/environment-test-3.9.yml
@@ -38,6 +38,7 @@ dependencies:
     - jinja2
     - pydata-sphinx-theme
     - recommonmark
+    - markdown<3.4.0
     - sphinx>=4.4.0
     - sphinx-copybutton
     - sphinx-markdown-tables


### PR DESCRIPTION
I had to add upper version for `markdown` due to some breaking changes to it that are not yet supported  in the latest release of the `sphinx-markdown-tables`.
Please see more details here: https://github.com/ryanfox/sphinx-markdown-tables/issues/36