### PR TITLE
Add custom nitpicky ref checks for cunumeric APIs

### DIFF
--- a/cunumeric/_sphinxext/missing_refs.py
+++ b/cunumeric/_sphinxext/missing_refs.py
@@ -1,0 +1,78 @@
+# Copyright 2022 NVIDIA Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from __future__ import annotations
+
+from textwrap import indent
+from typing import Any
+
+from docutils import nodes
+from sphinx import addnodes
+from sphinx.application import Sphinx
+from sphinx.errors import NoUri
+from sphinx.transforms.post_transforms import SphinxPostTransform
+from sphinx.util.logging import get_node_location, getLogger
+
+from . import PARALLEL_SAFE, SphinxParallelSpec
+
+log = getLogger(__name__)
+
+SKIP = []
+
+MISSING = []
+
+
+class MissingRefs(SphinxPostTransform):
+
+    default_priority = 5
+
+    def run(self, **kwargs: Any) -> None:
+        for node in self.document.findall(addnodes.pending_xref):
+            self._check_target(node)
+
+        if MISSING:
+            header = "The following Cunumeric API links are broken:"
+            items = "\n".join(f"{loc}: {target}" for loc, target in MISSING)
+            log.warning(f"{header}\n\n{indent(items, '    ')}\n", type="ref")
+
+    def _check_target(self, node: nodes.Node) -> None:
+        target = node["reftarget"]
+
+        if not target.startswith("cunumeric.") or target in SKIP:
+            return
+
+        domain = self.env.domains[node["refdomain"]]
+
+        assert self.app.builder is not None
+
+        try:
+            uri = domain.resolve_xref(
+                self.env,
+                node.get("refdoc", self.env.docname),
+                self.app.builder,
+                node["reftype"],
+                target,
+                node,
+                nodes.TextElement("", ""),
+            )
+        except NoUri:
+            uri = None
+
+        if uri is None:
+            MISSING.append((f"{get_node_location(node)}", f"{target}"))
+
+
+def setup(app: Sphinx) -> SphinxParallelSpec:
+    app.add_post_transform(MissingRefs)
+    return PARALLEL_SAFE

--- a/docs/cunumeric/source/conf.py
+++ b/docs/cunumeric/source/conf.py
@@ -40,6 +40,7 @@ extensions = [
     "sphinx_markdown_tables",
     "recommonmark",
     "cunumeric._sphinxext.comparison_table",
+    "cunumeric._sphinxext.missing_refs",
     "cunumeric._sphinxext.ufunc_formatter",
 ]
 


### PR DESCRIPTION
This is a first partial step towards #460 The simplest way to implement is to automatically generate an `_all.rst` file that simply lists references to all implemented functions, and then let Sphinx warn/error if any are missing. However, in #420 Sphinx's built-in "nitpicky" mode was disabled, because is was too annoyingly over-broad, so missing references no longer generate warnings/errors.

This PR adds a new `missing_refs` sphinx extension that warns about missing references, *but only for explicitly added `cunumeric.*` references*.

Some notes:

* Using the `_all.rst` (to be added in the next PR) the current list of "missing" refs is all dunders:
   ```

    /home/bryan/work/cunumeric/docs/cunumeric/source/_all.rst:3: cunumeric.ndarray.__array_function__
    /home/bryan/work/cunumeric/docs/cunumeric/source/_all.rst:3: cunumeric.ndarray.__array_ufunc__
    /home/bryan/work/cunumeric/docs/cunumeric/source/_all.rst:3: cunumeric.ndarray.__div__
    /home/bryan/work/cunumeric/docs/cunumeric/source/_all.rst:3: cunumeric.ndarray.__format__
    /home/bryan/work/cunumeric/docs/cunumeric/source/_all.rst:3: cunumeric.ndarray.__hash__
    /home/bryan/work/cunumeric/docs/cunumeric/source/_all.rst:3: cunumeric.ndarray.__idiv__
    /home/bryan/work/cunumeric/docs/cunumeric/source/_all.rst:3: cunumeric.ndarray.__iter__
    /home/bryan/work/cunumeric/docs/cunumeric/source/_all.rst:3: cunumeric.ndarray.__nonzero__
    /home/bryan/work/cunumeric/docs/cunumeric/source/_all.rst:3: cunumeric.ndarray.__radd__
    /home/bryan/work/cunumeric/docs/cunumeric/source/_all.rst:3: cunumeric.ndarray.__rand__
    /home/bryan/work/cunumeric/docs/cunumeric/source/_all.rst:3: cunumeric.ndarray.__rdiv__
    /home/bryan/work/cunumeric/docs/cunumeric/source/_all.rst:3: cunumeric.ndarray.__rdivmod__
    /home/bryan/work/cunumeric/docs/cunumeric/source/_all.rst:3: cunumeric.ndarray.__reduce_ex__
    /home/bryan/work/cunumeric/docs/cunumeric/source/_all.rst:3: cunumeric.ndarray.__rfloordiv__
    /home/bryan/work/cunumeric/docs/cunumeric/source/_all.rst:3: cunumeric.ndarray.__rmod__
    /home/bryan/work/cunumeric/docs/cunumeric/source/_all.rst:3: cunumeric.ndarray.__rmul__
    /home/bryan/work/cunumeric/docs/cunumeric/source/_all.rst:3: cunumeric.ndarray.__ror__
    /home/bryan/work/cunumeric/docs/cunumeric/source/_all.rst:3: cunumeric.ndarray.__rpow__
    /home/bryan/work/cunumeric/docs/cunumeric/source/_all.rst:3: cunumeric.ndarray.__rsub__
    /home/bryan/work/cunumeric/docs/cunumeric/source/_all.rst:3: cunumeric.ndarray.__rtruediv__
    /home/bryan/work/cunumeric/docs/cunumeric/source/_all.rst:3: cunumeric.ndarray.__rxor__
    /home/bryan/work/cunumeric/docs/cunumeric/source/_all.rst:3: cunumeric.ndarray.__sizeof__
   ```
    I have not cross-checked the numpy docs yet, but I assume most or all of these *should* be added to our ref guide. 
 
## Next steps 

* After this feature is merged I will make a follow on PR to close #460 by auto-generating an `_all.rst` and adding/handling any of the currently missing refs.
* I think the module/ndarray wrappers are adding metadata to things that don't need it, e.g. 
   ```
    >>> cn.add_boilerplate._cunumeric
    CuWrapperMetadata(implemented=True, single=False, multi=False)
    ```
    Metadata should only be applied to things that have direct Numpy counterparts, correct? If so I will look into this in a different PR. Then the `SKIP` list can probably be reduced or eliminated. 

Edit: #463 was merged so the last bullet no longer applies. 