### PR TITLE
Be stricter applying CuWrapperMetadata

### DIFF
--- a/cunumeric/coverage.py
+++ b/cunumeric/coverage.py
@@ -214,7 +214,7 @@ def clone_module(
     from ._ufunc.ufunc import ufunc as lgufunc
 
     for attr, value in new_globals.items():
-        # We don't need to wrap anything that is not in the origin module
+        # Only need to wrap things that are in the origin module to begin with
         if attr not in origin_module.__dict__:
             continue
         if isinstance(value, (FunctionType, lgufunc)):
@@ -260,6 +260,9 @@ def clone_np_ndarray(cls: type) -> type:
     reporting = runtime.args.report_coverage
 
     for attr, value in cls.__dict__.items():
+        # Only need to wrap things that are in the origin class to begin with
+        if not hasattr(origin_class, attr):
+            continue
         if should_wrap(value):
             wrapped = implemented(value, class_name, attr, reporting=reporting)
             setattr(cls, attr, wrapped)

--- a/cunumeric/coverage.py
+++ b/cunumeric/coverage.py
@@ -214,6 +214,9 @@ def clone_module(
     from ._ufunc.ufunc import ufunc as lgufunc
 
     for attr, value in new_globals.items():
+        # We don't need to wrap anything that is not in the origin module
+        if attr not in origin_module.__dict__:
+            continue
         if isinstance(value, (FunctionType, lgufunc)):
             wrapped = implemented(
                 cast(AnyCallable, value), mod_name, attr, reporting=reporting

--- a/tests/unit/cunumeric/test_coverage.py
+++ b/tests/unit/cunumeric/test_coverage.py
@@ -318,6 +318,9 @@ _DestCode = """
 def function2():
     pass
 
+def extra():
+    pass
+
 attr2 = 30
 """
 
@@ -346,6 +349,8 @@ class Test_clone_module:
         assert _Dest.function2.__wrapped__
         assert _Dest.function2._cunumeric.implemented
 
+        assert not hasattr(_Dest.extra, "_cunumeric")
+
     @patch.object(cunumeric.runtime.args, "report_coverage", False)
     def test_report_coverage_False(self) -> None:
         assert not cunumeric.runtime.args.report_coverage
@@ -368,6 +373,8 @@ class Test_clone_module:
 
         assert _Dest.function2.__wrapped__
         assert _Dest.function2._cunumeric.implemented
+
+        assert not hasattr(_Dest.extra, "_cunumeric")
 
 
 @m.clone_np_ndarray

--- a/tests/unit/cunumeric/test_coverage.py
+++ b/tests/unit/cunumeric/test_coverage.py
@@ -385,6 +385,9 @@ class _Test_ndarray:
     def conjugate(self):
         return self, "conjugate"
 
+    def extra(self):
+        return "extra"
+
     attr1 = 10
     attr2 = 30
 
@@ -406,6 +409,8 @@ class Test_clone_np_ndarray:
         assert _Test_ndarray.conjugate.__wrapped__
         assert _Test_ndarray.conjugate._cunumeric.implemented
 
+        assert not hasattr(_Test_ndarray.extra, "_cunumeric")
+
     @patch.object(cunumeric.runtime.args, "report_coverage", False)
     def test_report_coverage_False(self) -> None:
         assert not cunumeric.runtime.args.report_coverage
@@ -421,6 +426,8 @@ class Test_clone_np_ndarray:
 
         assert _Test_ndarray.conjugate.__wrapped__
         assert _Test_ndarray.conjugate._cunumeric.implemented
+
+        assert not hasattr(_Test_ndarray.extra, "_cunumeric")
 
     # TODO (bev) Not sure how to unit test this. Try to use a toy ndarray class
     # (as above) for testing, and numpy gets unhappy. On the other hand, if we


### PR DESCRIPTION
As noted in #462 it seems that the coverage machinery is a little over-eager. Specifically, it is applying `._cunumeric` metadata to "extra" things that exist in `cunumeric` but don't exist in `numpy`, e.g. `add_boilerplate` as one example. This is does not really cause any problems directly, i.e. the coverage reporting is not affected by it. But the superfluous metadata can make things annoying for other use-cases (e.g. needing to add a `SKIP` list in #462) 