### PR TITLE
Docs coverage check

### DIFF
--- a/cunumeric/_sphinxext/implemented_index.py
+++ b/cunumeric/_sphinxext/implemented_index.py
@@ -1,0 +1,78 @@
+# Copyright 2022 NVIDIA Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from __future__ import annotations
+
+from typing import Any
+
+from docutils import nodes
+from sphinx.application import Sphinx
+from sphinx.util.logging import getLogger
+
+import cunumeric as cn
+
+from ..coverage import is_implemented
+from . import PARALLEL_SAFE, SphinxParallelSpec
+from ._cunumeric_directive import CunumericDirective
+
+log = getLogger(__name__)
+
+
+def _filter(x: Any) -> bool:
+    return (
+        callable(x)
+        and is_implemented(x)
+        and (x.__name__.startswith("__") or not x.__name__.startswith("_"))
+    )
+
+
+namespaces = (
+    cn,
+    cn.fft,
+    cn.linalg,
+    cn.random,
+)
+
+
+class ImplementedIndex(CunumericDirective):
+
+    has_content = False
+    required_arguments = 0
+    optional_arguments = 0
+
+    def run(self) -> nodes.Node:
+
+        refs: list[str] = []
+        for ns in namespaces:
+            refs += [
+                f"* :obj:`{ns.__name__}.{x.__name__}`"
+                for n, x in ns.__dict__.items()
+                if _filter(x)
+            ]
+        refs += [
+            f"* :obj:`cunumeric.ndarray.{x.__name__}`"
+            for x in cn.ndarray.__dict__.values()
+            if _filter(x)
+        ]
+
+        rst_text = "\n".join(sorted(set(refs)))
+
+        log.debug(rst_text)
+
+        return self.parse(rst_text, "<implemented-index>")
+
+
+def setup(app: Sphinx) -> SphinxParallelSpec:
+    app.add_directive_to_domain("py", "implemented-index", ImplementedIndex)
+    return PARALLEL_SAFE

--- a/cunumeric/_sphinxext/missing_refs.py
+++ b/cunumeric/_sphinxext/missing_refs.py
@@ -14,7 +14,6 @@
 #
 from __future__ import annotations
 
-from textwrap import indent
 from typing import Any
 
 from docutils import nodes
@@ -28,7 +27,27 @@ from . import PARALLEL_SAFE, SphinxParallelSpec
 
 log = getLogger(__name__)
 
-SKIP: list[str] = []
+SKIP = (
+    "cunumeric.cast",
+    "cunumeric.ndarray.__array_function__",
+    "cunumeric.ndarray.__array_ufunc__",
+    "cunumeric.ndarray.__format__",
+    "cunumeric.ndarray.__hash__",
+    "cunumeric.ndarray.__iter__",
+    "cunumeric.ndarray.__radd__",
+    "cunumeric.ndarray.__rand__",
+    "cunumeric.ndarray.__rdivmod__",
+    "cunumeric.ndarray.__reduce_ex__",
+    "cunumeric.ndarray.__rfloordiv__",
+    "cunumeric.ndarray.__rmod__",
+    "cunumeric.ndarray.__rmul__",
+    "cunumeric.ndarray.__ror__",
+    "cunumeric.ndarray.__rpow__",
+    "cunumeric.ndarray.__rsub__",
+    "cunumeric.ndarray.__rtruediv__",
+    "cunumeric.ndarray.__rxor__",
+    "cunumeric.ndarray.__sizeof__",
+)
 
 MISSING: list[tuple[str, str]] = []
 
@@ -41,12 +60,7 @@ class MissingRefs(SphinxPostTransform):
         for node in self.document.findall(addnodes.pending_xref):
             self._check_target(node)
 
-        if MISSING:
-            header = "The following Cunumeric API links are broken:"
-            items = "\n".join(f"{loc}: {target}" for loc, target in MISSING)
-            log.warning(f"{header}\n\n{indent(items, '    ')}\n", type="ref")
-
-    def _check_target(self, node: Any) -> None:
+    def _check_target(self, node: nodes.Node) -> None:
         target = node["reftarget"]
 
         if not target.startswith("cunumeric.") or target in SKIP:
@@ -70,7 +84,11 @@ class MissingRefs(SphinxPostTransform):
             uri = None
 
         if uri is None:
-            MISSING.append((f"{get_node_location(node)}", f"{target}"))
+            loc = get_node_location(node)
+            log.warning(
+                f"Cunumeric reference missing a target: {loc}: {target}",
+                type="ref",
+            )
 
 
 def setup(app: Sphinx) -> SphinxParallelSpec:

--- a/cunumeric/_sphinxext/missing_refs.py
+++ b/cunumeric/_sphinxext/missing_refs.py
@@ -60,7 +60,7 @@ class MissingRefs(SphinxPostTransform):
         for node in self.document.findall(addnodes.pending_xref):
             self._check_target(node)
 
-    def _check_target(self, node: nodes.Node) -> None:
+    def _check_target(self, node: Any) -> None:
         target = node["reftarget"]
 
         if not target.startswith("cunumeric.") or target in SKIP:

--- a/cunumeric/coverage.py
+++ b/cunumeric/coverage.py
@@ -77,6 +77,9 @@ class CuWrapperMetadata:
 
 class CuWrapped(AnyCallable, Protocol):
     _cunumeric: CuWrapperMetadata
+    __wrapped__: Any
+    __name__: str
+    __qualname__: str
 
 
 def implemented(

--- a/cunumeric/coverage.py
+++ b/cunumeric/coverage.py
@@ -106,6 +106,13 @@ def implemented(
         def wrapper(*args: Any, **kwargs: Any) -> Any:
             return func(*args, **kwargs)
 
+    # This is incredibly ugly and unpleasant, but @wraps(func) doesn't handle
+    # ufuncs the way we need it to. The alternative would be to vendor and
+    # modify a custom version of @wraps
+    if hasattr(wrapper.__wrapped__, "_name"):
+        wrapper.__name__ = wrapper.__wrapped__._name
+        wrapper.__qualname__ = wrapper.__wrapped__._name
+
     # TODO (bev) Scraping text to set flags seems a bit fragile. It would be
     # preferable to start with flags, and use those to update docstrings.
     multi = "Multiple GPUs" in (getattr(func, "__doc__", None) or "")

--- a/cunumeric/random/generator.py
+++ b/cunumeric/random/generator.py
@@ -205,6 +205,33 @@ class Generator:
 
 
 def default_rng(seed: Union[int, None] = None) -> Generator:
+    """Construct a new Generator with the default BitGenerator (PCG64).
+
+    Parameters
+    ----------
+    seed :
+        {None, int, array_like[ints], SeedSequence, BitGenerator, Generator},
+        optional
+
+        A seed to initialize the `BitGenerator`. If None, then fresh,
+        unpredictable entropy will be pulled from the OS. If an ``int`` or
+        ``array_like[ints]`` is passed, then it will be passed to
+        `SeedSequence` to derive the initial `BitGenerator` state. One may also
+        pass in a `SeedSequence` instance.
+        Additionally, when passed a `BitGenerator`, it will be wrapped by
+        `Generator`. If passed a `Generator`, it will be returned unaltered.
+
+    Returns
+    -------
+    Generator
+        The initialized generator object.
+
+    Notes
+    -----
+    If ``seed`` is not a `BitGenerator` or a `Generator`, a new `BitGenerator`
+    is instantiated. This function does not manage a default global instance.
+
+    """
     if seed is None:
         return Generator(XORWOW())
     elif isinstance(seed, BitGenerator):

--- a/cunumeric/random/generator.py
+++ b/cunumeric/random/generator.py
@@ -20,6 +20,8 @@ import numpy as np
 from cunumeric.random.bitgenerator import XORWOW, BitGenerator
 
 if TYPE_CHECKING:
+    from typing import Any
+
     import numpy.typing as npt
 
     from ..array import ndarray
@@ -204,33 +206,39 @@ class Generator:
         return self.bit_generator.bytes(length=length)
 
 
-def default_rng(seed: Union[int, None] = None) -> Generator:
-    """Construct a new Generator with the default BitGenerator (PCG64).
+# TODO: Leaving the type of `seed` vague, since the proper type
+# `Union[None, int, BitGenerator, Generator]` currently breaks the docs build.
+# TODO: Link to other classes using :class:`cunumeric.random.<class>`, once
+# we add documentation for them.
+def default_rng(seed: Union[None, Any] = None) -> Generator:
+    """
+    Construct a new `Generator` with the default `BitGenerator` (XORWOW).
 
     Parameters
     ----------
-    seed :
-        {None, int, array_like[ints], SeedSequence, BitGenerator, Generator},
-        optional
-
+    seed : {None, int, BitGenerator, Generator}, optional
         A seed to initialize the `BitGenerator`. If None, then fresh,
-        unpredictable entropy will be pulled from the OS. If an ``int`` or
-        ``array_like[ints]`` is passed, then it will be passed to
-        `SeedSequence` to derive the initial `BitGenerator` state. One may also
-        pass in a `SeedSequence` instance.
-        Additionally, when passed a `BitGenerator`, it will be wrapped by
-        `Generator`. If passed a `Generator`, it will be returned unaltered.
+        unpredictable entropy will be pulled from the OS. If passed a
+        `BitGenerator`, it will be wrapped by `Generator`. If passed a
+        `Generator`, it will be returned unaltered.
 
     Returns
     -------
     Generator
-        The initialized generator object.
+        The initialized `Generator` object.
 
     Notes
     -----
     If ``seed`` is not a `BitGenerator` or a `Generator`, a new `BitGenerator`
     is instantiated. This function does not manage a default global instance.
 
+    See Also
+    --------
+    numpy.random.default_rng
+
+    Availability
+    --------
+    Multiple GPUs, Multiple CPUs
     """
     if seed is None:
         return Generator(XORWOW())

--- a/cunumeric/random/random.py
+++ b/cunumeric/random/random.py
@@ -26,6 +26,22 @@ if TYPE_CHECKING:
 
 
 def seed(init: Union[int, None] = None) -> None:
+    """
+    (Re-)seed the global random number generator.
+
+    Parameters
+    ----------
+    init : int, optional
+        The seed number to use
+
+    See Also
+    --------
+    numpy.random.seed
+
+    Availability
+    --------
+    Multiple GPUs, Multiple CPUs
+    """
     if init is None:
         init = 0
     runtime.set_next_random_epoch(int(init))

--- a/docs/cunumeric/source/_implemented.rst
+++ b/docs/cunumeric/source/_implemented.rst
@@ -1,0 +1,8 @@
+.. This page exists to collect references to all cunumeric functions and
+.. methods that are "implemented". Doing so, any implemented functions or
+.. methods that are not present in the docs (but should be) will result in
+.. docs build errors
+
+:orphan:
+
+.. implemented-index::

--- a/docs/cunumeric/source/api/random.rst
+++ b/docs/cunumeric/source/api/random.rst
@@ -9,6 +9,7 @@ Functions in :mod:`cunumeric.random`
 .. autosummary::
    :toctree: generated/
 
+   default_rng
    rand
    randint
    randn

--- a/docs/cunumeric/source/conf.py
+++ b/docs/cunumeric/source/conf.py
@@ -40,6 +40,7 @@ extensions = [
     "sphinx_markdown_tables",
     "recommonmark",
     "cunumeric._sphinxext.comparison_table",
+    "cunumeric._sphinxext.implemented_index",
     "cunumeric._sphinxext.missing_refs",
     "cunumeric._sphinxext.ufunc_formatter",
 ]

--- a/tests/unit/cunumeric/test_coverage.py
+++ b/tests/unit/cunumeric/test_coverage.py
@@ -136,6 +136,8 @@ class Test_implemented:
     ) -> None:
         wrapped = m.implemented(_test_func, "foo", "_test_func")
 
+        assert wrapped.__name__ == _test_func.__name__
+        assert wrapped.__qualname__ == _test_func.__qualname__
         assert wrapped.__doc__ == _test_func.__doc__
         assert wrapped.__wrapped__ is _test_func
 
@@ -159,6 +161,8 @@ class Test_implemented:
             _test_func, "foo", "_test_func", reporting=False
         )
 
+        assert wrapped.__name__ == _test_func.__name__
+        assert wrapped.__qualname__ == _test_func.__qualname__
         assert wrapped.__doc__ == _test_func.__doc__
         assert wrapped.__wrapped__ is _test_func
 
@@ -171,6 +175,10 @@ class Test_implemented:
         self, mock_record_api_call: MagicMock
     ) -> None:
         wrapped = m.implemented(_test_ufunc, "foo", "_test_ufunc")
+
+        # these had to be special-cased, @wraps does not handle them
+        assert wrapped.__name__ == _test_ufunc._name
+        assert wrapped.__qualname__ == _test_ufunc._name
 
         assert wrapped.__doc__ == _test_ufunc.__doc__
         assert wrapped.__wrapped__ is _test_ufunc
@@ -195,6 +203,10 @@ class Test_implemented:
             _test_ufunc, "foo", "_test_func", reporting=False
         )
 
+        # these had to be special-cased, @wraps does not handle them
+        assert wrapped.__name__ == _test_ufunc._name
+        assert wrapped.__qualname__ == _test_ufunc._name
+
         assert wrapped.__doc__ == _test_ufunc.__doc__
         assert wrapped.__wrapped__ is _test_ufunc
 
@@ -210,6 +222,8 @@ class Test_unimplemented:
     ) -> None:
         wrapped = m.unimplemented(_test_func, "foo", "_test_func")
 
+        assert wrapped.__name__ == _test_func.__name__
+        assert wrapped.__qualname__ == _test_func.__qualname__
         assert wrapped.__doc__ == _test_func.__doc__
         assert wrapped.__wrapped__ is _test_func
 
@@ -233,6 +247,8 @@ class Test_unimplemented:
             _test_func, "foo", "_test_func", reporting=False
         )
 
+        assert wrapped.__name__ == _test_func.__name__
+        assert wrapped.__qualname__ == _test_func.__qualname__
         assert wrapped.__doc__ == _test_func.__doc__
         assert wrapped.__wrapped__ is _test_func
 


### PR DESCRIPTION
ref: closes #460 

This PR does the following:

* Fixes a bug with wrapping ufuncs where `@wraps` fails to correctly capture the object name
* Simplifies `MissingRefs` to report warnings individually (Sphinx will print all of them)
* Adds an `ImplementedIndex` that creates a reference for every "implemented" function that is not explicity skipped. 

This last is an implicit check that all implemented functions are present in the docs, since otherwise a missing-refs warning will be triggered. 

I have explicitly skipped the following missing items:
```
SKIP = (
    "cunumeric.cast",
    "cunumeric.ndarray.__array_function__",
    "cunumeric.ndarray.__array_ufunc__",
    "cunumeric.ndarray.__format__",
    "cunumeric.ndarray.__hash__",
    "cunumeric.ndarray.__iter__",
    "cunumeric.ndarray.__radd__",
    "cunumeric.ndarray.__rand__",
    "cunumeric.ndarray.__rdivmod__",
    "cunumeric.ndarray.__reduce_ex__",
    "cunumeric.ndarray.__rfloordiv__",
    "cunumeric.ndarray.__rmod__",
    "cunumeric.ndarray.__rmul__",
    "cunumeric.ndarray.__ror__",
    "cunumeric.ndarray.__rpow__",
    "cunumeric.ndarray.__rsub__",
    "cunumeric.ndarray.__rtruediv__",
    "cunumeric.ndarray.__rxor__",
    "cunumeric.ndarray.__sizeof__",
)
```
With the exception of the array protocol, none of these have entries in the numpy docs, so it seems appropriate to skip them. Please provide any appropriate guidance, however. If we want to include the array protocols, we need to decided where to pu them (they are not on the `ndarray` docs page in the numpy docs). But I am not sure we expect end-users to be using these?
