### PR TITLE
Allow scalar cunumeric ndarrays as array indices

### DIFF
--- a/cunumeric/array.py
+++ b/cunumeric/array.py
@@ -14,6 +14,7 @@
 #
 from __future__ import annotations
 
+import operator
 import warnings
 from collections.abc import Iterable
 from functools import reduce, wraps
@@ -823,6 +824,12 @@ class ndarray:
 
     def _convert_key(self, key, first=True):
         # Convert any arrays stored in a key to a cuNumeric array
+        if isinstance(key, slice):
+            key = slice(
+                operator.index(key.start) if key.start is not None else None,
+                operator.index(key.stop) if key.stop is not None else None,
+                operator.index(key.step) if key.step is not None else None,
+            )
         if (
             key is np.newaxis
             or key is Ellipsis
@@ -969,6 +976,9 @@ class ndarray:
         from ._ufunc import multiply
 
         return multiply(self, rhs, out=self)
+
+    def __index__(self) -> int:
+        return self.__array__().__index__()
 
     def __int__(self):
         """a.__int__(/)

--- a/tests/integration/test_get_item.py
+++ b/tests/integration/test_get_item.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import numpy as np
 import pytest
 
 import cunumeric as num
@@ -22,6 +23,23 @@ def test_basic():
     assert x[0] == 1
     assert x[1] == 2
     assert x[2] == 3
+
+
+ARRAYS_4_3_2_1_0 = [
+    4 - num.arange(5),
+    4 - np.arange(5),
+    [4, 3, 2, 1, 0],
+]
+
+
+@pytest.mark.parametrize("arr", ARRAYS_4_3_2_1_0)
+def test_scalar_ndarray_as_index(arr):
+    offsets = num.arange(5)  # [0, 1, 2, 3, 4]
+    offset = offsets[3]  # 3
+    # assert arr[offset] == 1  # TODO: doesn't work when arr is a num.ndarray
+    assert np.array_equal(arr[offset - 2 : offset], [3, 2])
+    arr[offset - 2 : offset] = [-1, -1]
+    assert np.array_equal(arr, [4, -1, -1, 1, 0])
 
 
 if __name__ == "__main__":

--- a/tests/integration/test_get_item.py
+++ b/tests/integration/test_get_item.py
@@ -38,8 +38,6 @@ def test_scalar_ndarray_as_index(arr):
     offset = offsets[3]  # 3
     # assert arr[offset] == 1  # TODO: doesn't work when arr is a num.ndarray
     assert np.array_equal(arr[offset - 2 : offset], [3, 2])
-    arr[offset - 2 : offset] = [-1, -1]
-    assert np.array_equal(arr, [4, -1, -1, 1, 0])
 
 
 if __name__ == "__main__":

--- a/tests/integration/test_set_item.py
+++ b/tests/integration/test_set_item.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import numpy as np
 import pytest
 
 import cunumeric as num
@@ -26,6 +27,22 @@ def test_basic():
     assert x[0] == 1
     assert x[1] == 2
     assert x[2] == 3
+
+
+ARRAYS_4_3_2_1_0 = [
+    4 - num.arange(5),
+    4 - np.arange(5),
+    [4, 3, 2, 1, 0],
+]
+
+
+@pytest.mark.parametrize("arr", ARRAYS_4_3_2_1_0)
+def test_scalar_ndarray_as_index(arr):
+    offsets = num.arange(5)  # [0, 1, 2, 3, 4]
+    offset = offsets[3]  # 3
+    # arr[offset] = -1  # TODO: doesn't work when arr is a num.ndarray
+    arr[offset - 2 : offset] = [-1, -1]
+    assert np.array_equal(arr, [4, -1, -1, 1, 0])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Another attempt at solving https://github.com/nv-legate/cunumeric/issues/472, using the `operator.index(.)` method instead of `int()`, as the python documentation suggests, and handling some additional cases (also support indexing numpy ndarrays and python lists).