### PR TITLE
Add support for curand conda package build

### DIFF
--- a/conda/conda-build/build.sh
+++ b/conda/conda-build/build.sh
@@ -4,6 +4,9 @@ install_args=()
 if [ -z "$CPU_ONLY" ]; then
   # cutensor, relying on the conda cutensor package
   install_args+=("--with-cutensor" "$PREFIX")
+else
+  # When we build without cuda, we need to provide the location of curand
+  install_args+=("--with-curand" "$PREFIX")
 fi
 
 # location of legate-core

--- a/conda/conda-build/meta.yaml
+++ b/conda/conda-build/meta.yaml
@@ -72,7 +72,7 @@ requirements:
     - cuda-nvcc ={{ cuda_version }}
 {% endif %}
   host:
-    # the nvcc requirement is necessary because it contains crt/host_config.h used by cuda runtime. This is a packaging bug that has been reported.P
+    # the nvcc requirement is necessary because it contains crt/host_config.h used by cuda runtime. This is a packaging bug that has been reported.
     - cuda-nvcc ={{ cuda_version }}
     - python
     - openblas =* =*openmp*

--- a/conda/conda-build/meta.yaml
+++ b/conda/conda-build/meta.yaml
@@ -74,6 +74,10 @@ requirements:
   host:
     # the nvcc requirement is necessary because it contains crt/host_config.h used by cuda runtime. This is a packaging bug that has been reported.
     - cuda-nvcc ={{ cuda_version }}
+    # libcurand is used both in CPU and GPU builds
+    - libcurand-dev
+    # cudart needed for CPU and GPU builds because of curand
+    - cuda-cudart-dev ={{ cuda_version }}
     - python
     - openblas =* =*openmp*
 {% if not gpu_enabled_bool %}
@@ -81,7 +85,6 @@ requirements:
 {% else %}
     - legate-core >={{ core_version }}
     - cuda-driver-dev ={{ cuda_version }}
-    - cuda-cudart-dev ={{ cuda_version }}
     # - libcutensor-dev >=1.3
     - cutensor >=1.3
     - cuda-nvtx
@@ -89,7 +92,6 @@ requirements:
     - libcusolver-dev
     - libcufft-dev
     - nccl
-    - libcurand-dev
 {% endif %}
 
   run:

--- a/conda/conda-build/meta.yaml
+++ b/conda/conda-build/meta.yaml
@@ -72,6 +72,8 @@ requirements:
     - cuda-nvcc ={{ cuda_version }}
 {% endif %}
   host:
+    # the nvcc requirement is necessary because it contains crt/host_config.h used by cuda runtime. This is a packaging bug that has been reported.P
+    - cuda-nvcc ={{ cuda_version }}
     - python
     - openblas =* =*openmp*
 {% if not gpu_enabled_bool %}
@@ -87,6 +89,7 @@ requirements:
     - libcusolver-dev
     - libcufft-dev
     - nccl
+    - libcurand-dev
 {% endif %}
 
   run:
@@ -99,6 +102,8 @@ requirements:
     - libcublas
     - libcusolver
     - libcufft
+    # libcurand only enabled for a GPU package, include-only for CPU package
+    - libcurand
 {% endif %}
     - opt_einsum >=3.3
     - scipy


### PR DESCRIPTION
Curand is provided as a separate package in the Nvidia conda packaging system. The Nvidia channel `cudart-dev` package relies on some include files from `cuda-nvcc`. This is probably a bug (reported), but for now we need `cuda-nvcc` for the files that are included from curand and then from cudart.