### PR TITLE
Remove run dependency on curand

### DIFF
--- a/conda/conda-build/meta.yaml
+++ b/conda/conda-build/meta.yaml
@@ -104,8 +104,6 @@ requirements:
     - libcublas
     - libcusolver
     - libcufft
-    # libcurand only enabled for a GPU package, include-only for CPU package
-    - libcurand
 {% endif %}
     - opt_einsum >=3.3
     - scipy


### PR DESCRIPTION
It seems that the curand dependency is include only, so we can remove the run dependency.