### PR TITLE
Handle the case where LAPACK_*potrf is a macro, not a function

### DIFF
--- a/src/cunumeric/matrix/potrf.cc
+++ b/src/cunumeric/matrix/potrf.cc
@@ -25,20 +25,14 @@ namespace cunumeric {
 using namespace Legion;
 using namespace legate;
 
-template <typename Potrf, typename VAL>
-static inline void potrf_template(Potrf potrf, VAL* array, int32_t m, int32_t n)
-{
-  char uplo    = 'L';
-  int32_t info = 0;
-  potrf(&uplo, &n, array, &m, &info);
-  if (info != 0) throw legate::TaskException("Matrix is not positive definite");
-}
-
 template <>
 struct PotrfImplBody<VariantKind::CPU, LegateTypeCode::FLOAT_LT> {
   void operator()(float* array, int32_t m, int32_t n)
   {
-    potrf_template(LAPACK_spotrf, array, m, n);
+    char uplo    = 'L';
+    int32_t info = 0;
+    LAPACK_spotrf(&uplo, &n, array, &m, &info);
+    if (info != 0) throw legate::TaskException("Matrix is not positive definite");
   }
 };
 
@@ -46,7 +40,10 @@ template <>
 struct PotrfImplBody<VariantKind::CPU, LegateTypeCode::DOUBLE_LT> {
   void operator()(double* array, int32_t m, int32_t n)
   {
-    potrf_template(LAPACK_dpotrf, array, m, n);
+    char uplo    = 'L';
+    int32_t info = 0;
+    LAPACK_dpotrf(&uplo, &n, array, &m, &info);
+    if (info != 0) throw legate::TaskException("Matrix is not positive definite");
   }
 };
 
@@ -54,7 +51,10 @@ template <>
 struct PotrfImplBody<VariantKind::CPU, LegateTypeCode::COMPLEX64_LT> {
   void operator()(complex<float>* array, int32_t m, int32_t n)
   {
-    potrf_template(LAPACK_cpotrf, reinterpret_cast<__complex__ float*>(array), m, n);
+    char uplo    = 'L';
+    int32_t info = 0;
+    LAPACK_cpotrf(&uplo, &n, reinterpret_cast<__complex__ float*>(array), &m, &info);
+    if (info != 0) throw legate::TaskException("Matrix is not positive definite");
   }
 };
 
@@ -62,7 +62,10 @@ template <>
 struct PotrfImplBody<VariantKind::CPU, LegateTypeCode::COMPLEX128_LT> {
   void operator()(complex<double>* array, int32_t m, int32_t n)
   {
-    potrf_template(LAPACK_zpotrf, reinterpret_cast<__complex__ double*>(array), m, n);
+    char uplo    = 'L';
+    int32_t info = 0;
+    LAPACK_zpotrf(&uplo, &n, reinterpret_cast<__complex__ double*>(array), &m, &info);
+    if (info != 0) throw legate::TaskException("Matrix is not positive definite");
   }
 };
 

--- a/src/cunumeric/matrix/potrf_omp.cc
+++ b/src/cunumeric/matrix/potrf_omp.cc
@@ -26,20 +26,14 @@ namespace cunumeric {
 using namespace Legion;
 using namespace legate;
 
-template <typename Potrf, typename VAL>
-static inline void potrf_template(Potrf potrf, VAL* array, int32_t m, int32_t n)
-{
-  char uplo    = 'L';
-  int32_t info = 0;
-  potrf(&uplo, &n, array, &m, &info);
-  if (info != 0) throw legate::TaskException("Matrix is not positive definite");
-}
-
 template <>
 struct PotrfImplBody<VariantKind::OMP, LegateTypeCode::FLOAT_LT> {
   void operator()(float* array, int32_t m, int32_t n)
   {
-    potrf_template(LAPACK_spotrf, array, m, n);
+    char uplo    = 'L';
+    int32_t info = 0;
+    LAPACK_spotrf(&uplo, &n, array, &m, &info);
+    if (info != 0) throw legate::TaskException("Matrix is not positive definite");
   }
 };
 
@@ -47,7 +41,10 @@ template <>
 struct PotrfImplBody<VariantKind::OMP, LegateTypeCode::DOUBLE_LT> {
   void operator()(double* array, int32_t m, int32_t n)
   {
-    potrf_template(LAPACK_dpotrf, array, m, n);
+    char uplo    = 'L';
+    int32_t info = 0;
+    LAPACK_dpotrf(&uplo, &n, array, &m, &info);
+    if (info != 0) throw legate::TaskException("Matrix is not positive definite");
   }
 };
 
@@ -55,7 +52,10 @@ template <>
 struct PotrfImplBody<VariantKind::OMP, LegateTypeCode::COMPLEX64_LT> {
   void operator()(complex<float>* array, int32_t m, int32_t n)
   {
-    potrf_template(LAPACK_cpotrf, reinterpret_cast<__complex__ float*>(array), m, n);
+    char uplo    = 'L';
+    int32_t info = 0;
+    LAPACK_cpotrf(&uplo, &n, reinterpret_cast<__complex__ float*>(array), &m, &info);
+    if (info != 0) throw legate::TaskException("Matrix is not positive definite");
   }
 };
 
@@ -63,7 +63,10 @@ template <>
 struct PotrfImplBody<VariantKind::OMP, LegateTypeCode::COMPLEX128_LT> {
   void operator()(complex<double>* array, int32_t m, int32_t n)
   {
-    potrf_template(LAPACK_zpotrf, reinterpret_cast<__complex__ double*>(array), m, n);
+    char uplo    = 'L';
+    int32_t info = 0;
+    LAPACK_zpotrf(&uplo, &n, reinterpret_cast<__complex__ double*>(array), &m, &info);
+    if (info != 0) throw legate::TaskException("Matrix is not positive definite");
   }
 };
 


### PR DESCRIPTION
This is working around some recent changes to OpenBLAS. Previously we were using
the internal names for functions, e.g. "spotrf_". OpenBLAS changed the
definitions of these internal functions, so in a previous PR we switched to
using the public functions, e.g. "LAPACK_spotrf". These used to be function
symbols, but in the latest update OpenBLAS changed these to be macros.