### PR TITLE
Make the validation condition for random distributions lenient

### DIFF
--- a/tests/integration/utils/random.py
+++ b/tests/integration/utils/random.py
@@ -168,4 +168,4 @@ def assert_distribution(a, theo_mean, theo_stdev, mean_tol=1e-2, stdev_tol=2):
     #       method, we make the check lenient to avoid random
     #       failures in the CI. (we still need the check to catch
     #       the cases that are obviously wrong.)
-    assert np.abs(theo_stdev - stdev) / theo_stdev <= stdev_tol
+    assert np.abs(theo_stdev - stdev) / min(theo_stdev, stdev) <= stdev_tol

--- a/tests/integration/utils/random.py
+++ b/tests/integration/utils/random.py
@@ -143,7 +143,9 @@ class ModuleGenerator:
         return num.random.zipf(alpha, shape, dtype)
 
 
-def assert_distribution(a, theo_mean, theo_stdev, mean_tol=1e-2, stdev_tol=2):
+def assert_distribution(
+    a, theo_mean, theo_stdev, mean_tol=1e-2, stdev_tol=1.0
+):
     if True:
         aa = np.array(a)
         average = np.mean(aa)

--- a/tests/integration/utils/random.py
+++ b/tests/integration/utils/random.py
@@ -157,9 +157,7 @@ def assert_distribution(a, theo_mean, theo_stdev, mean_tol=1e-2, stdev_tol=2):
         f"average = {average} - theoretical {theo_mean}"
         + f", stdev = {stdev} - theoretical {theo_stdev}\n"
     )
-    assert np.abs(theo_mean - average) < mean_tol * np.max(
-        (1.0, np.abs(theo_mean))
-    )
+    assert abs(theo_mean - average) < mean_tol * max(1.0, abs(theo_mean))
     # the theoretical standard deviation can't be 0
     assert theo_stdev != 0
     # TODO: this check is not a good proxy to validating that the samples
@@ -168,4 +166,4 @@ def assert_distribution(a, theo_mean, theo_stdev, mean_tol=1e-2, stdev_tol=2):
     #       method, we make the check lenient to avoid random
     #       failures in the CI. (we still need the check to catch
     #       the cases that are obviously wrong.)
-    assert np.abs(theo_stdev - stdev) / min(theo_stdev, stdev) <= stdev_tol
+    assert abs(theo_stdev - stdev) / min(theo_stdev, stdev) <= stdev_tol

--- a/tests/integration/utils/random.py
+++ b/tests/integration/utils/random.py
@@ -168,4 +168,4 @@ def assert_distribution(a, theo_mean, theo_stdev, mean_tol=1e-2, stdev_tol=2):
     #       method, we make the check lenient to avoid random
     #       failures in the CI. (we still need the check to catch
     #       the cases that are obviously wrong.)
-    assert np.abs(theo_stdev - stdev) < stdev_tol * np.abs(theo_stdev)
+    assert np.abs(theo_stdev - stdev) / theo_stdev <= stdev_tol

--- a/tests/integration/utils/random.py
+++ b/tests/integration/utils/random.py
@@ -143,7 +143,7 @@ class ModuleGenerator:
         return num.random.zipf(alpha, shape, dtype)
 
 
-def assert_distribution(a, theo_mean, theo_stdev, tolerance=1e-2):
+def assert_distribution(a, theo_mean, theo_stdev, mean_tol=1e-2, stdev_tol=2):
     if True:
         aa = np.array(a)
         average = np.mean(aa)
@@ -154,12 +154,18 @@ def assert_distribution(a, theo_mean, theo_stdev, tolerance=1e-2):
             num.mean((a - average) ** 2)
         )  # num.std(a) -> does not work
     print(
-        f"average = {average} - expected {theo_mean}"
-        + f", stdev = {stdev} - expected {theo_stdev}\n"
+        f"average = {average} - theoretical {theo_mean}"
+        + f", stdev = {stdev} - theoretical {theo_stdev}\n"
     )
-    assert np.abs(theo_mean - average) < tolerance * np.max(
+    assert np.abs(theo_mean - average) < mean_tol * np.max(
         (1.0, np.abs(theo_mean))
     )
-    assert np.abs(theo_stdev - stdev) < tolerance * np.max(
-        (1.0, np.abs(theo_stdev))
-    )
+    # the theoretical standard deviation can't be 0
+    assert theo_stdev != 0
+    # TODO: this check is not a good proxy to validating that the samples
+    #       respect the assumed random distribution unless we draw
+    #       extremely many samples. until we find a better validation
+    #       method, we make the check lenient to avoid random
+    #       failures in the CI. (we still need the check to catch
+    #       the cases that are obviously wrong.)
+    assert np.abs(theo_stdev - stdev) < stdev_tol * np.abs(theo_stdev)


### PR DESCRIPTION
The current validation check for random distributions is causing random test failures in the CI. It simply checks if the standard deviation of the samples is close enough to the theoretical value, but failing this test doesn't have any statistical significance unless we draw extremely many samples. (i.e., a particular run might be simply very unlucky.) until we find a better way to validate samples, this PR simply relaxes the check to avoid any unexpected and undesirable test failures.