### PR TITLE
Construct NumPy arrays correctly from 0D deferred arrays backed by region fields

### DIFF
--- a/cunumeric/deferred.py
+++ b/cunumeric/deferred.py
@@ -288,7 +288,10 @@ class DeferredArray(NumPyThunk):
                 initializer = _CuNumericNDarray(
                     shape, self.dtype, address, strides, False
                 )
-                return np.asarray(initializer)
+                result = np.asarray(initializer)
+                if self.shape == ():
+                    result = result.reshape(())
+                return result
 
             result = cast("npt.NDArray[Any]", alloc.consume(construct_ndarray))
 

--- a/tests/integration/test_slicing.py
+++ b/tests/integration/test_slicing.py
@@ -68,6 +68,18 @@ def test_3d():
     assert np.array_equal(firstslice, firstslicegold)
 
 
+def test_0d():
+    in_np = np.array([1, 2])
+    in_num = num.array([1, 2])
+
+    sl_np = in_np[1:].reshape(())
+    sl_num = in_num[1:].reshape(())
+
+    # Test inline mapping for a 0-d array
+    print(sl_num)
+    assert np.array_equal(sl_np, sl_num)
+
+
 # TODO: Legate needs 4-D arrays for this to work correctly
 @pytest.mark.skip
 def test_4d():


### PR DESCRIPTION
With https://github.com/nv-legate/legate.core/pull/340 we can now inline map 0D stores, but the allocations are 1D instead of 0D, due to the limitation in Legion. This PR adds a reshaping call to turn them back to 0D.