### PR TITLE
Fix a compiler warning

### DIFF
--- a/src/cunumeric/unary/convert_util.h
+++ b/src/cunumeric/unary/convert_util.h
@@ -42,6 +42,9 @@ struct ConvertOp {
       return static_cast<DST>(src.real()) || static_cast<DST>(src.imag());
     else
       return static_cast<DST>(src.real());
+    // Unreachable
+    assert(false);
+    return DST{};
   }
 };
 


### PR DESCRIPTION
Some compiler doesn't like a single if-else statement in a value-returning function that has a return statement in both branches.