### PR TITLE
Collect test failure details at the end

### DIFF
--- a/tests/_utils/stages/__init__.py
+++ b/tests/_utils/stages/__init__.py
@@ -23,6 +23,7 @@ from typing import Dict, Type
 
 from .. import FeatureType
 from .test_stage import TestStage
+from .util import log_proc
 
 if sys.platform == "darwin":
     from ._osx import CPU, Eager, GPU, OMP

--- a/tests/_utils/stages/test_stage.py
+++ b/tests/_utils/stages/test_stage.py
@@ -231,8 +231,8 @@ class TestStage(Protocol):
 
         self.delay(shard, config, system)
 
-        result = system.run(cmd, env=self._env(config, system))
-        log_proc(self.name, result, test_file, config)
+        result = system.run(cmd, test_file, env=self._env(config, system))
+        log_proc(self.name, result, config, verbose=config.verbose)
 
         self.shards.put(shard)
 

--- a/tests/_utils/stages/util.py
+++ b/tests/_utils/stages/util.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import timedelta
-from pathlib import Path
 from typing import Tuple, Union
 
 from typing_extensions import TypeAlias
@@ -66,6 +65,24 @@ class StageResult:
 
 
 def adjust_workers(workers: int, requested_workers: Union[int, None]) -> int:
+    """Adjust computed workers according to command line requested workers.
+
+    The final number of workers will only be adjusted down by this function.
+
+    Parameters
+    ----------
+    workers: int
+        The computed number of workers to use
+
+    requested_workers: int | None, optional
+        Requested number of workers from the user, if supplied (default: None)
+
+    Returns
+    -------
+    int
+        The number of workers to actually use
+
+    """
     if requested_workers is not None and requested_workers < 0:
         raise ValueError("requested workers must be non-negative")
 
@@ -83,12 +100,13 @@ def adjust_workers(workers: int, requested_workers: Union[int, None]) -> int:
 
 
 def log_proc(
-    name: str, proc: ProcessResult, test_file: Path, config: Config
+    name: str, proc: ProcessResult, config: Config, *, verbose: bool
 ) -> None:
+    """Log a process result according to the current configuration"""
     if config.debug or config.dry_run:
         LOG(shell(proc.invocation))
-    msg = f"({name}) {test_file}"
-    details = proc.output.split("\n") if config.verbose else None
+    msg = f"({name}) {proc.test_file}"
+    details = proc.output.split("\n") if verbose else None
     if proc.skipped:
         LOG(skipped(msg))
     elif proc.returncode == 0:

--- a/tests/_utils/system.py
+++ b/tests/_utils/system.py
@@ -23,6 +23,7 @@ import os
 import sys
 from dataclasses import dataclass
 from functools import cached_property
+from pathlib import Path
 from subprocess import PIPE, STDOUT, run as stdlib_run
 from typing import Sequence
 
@@ -34,6 +35,9 @@ class ProcessResult:
 
     #: The command invovation, including relevant environment vars
     invocation: str
+
+    #  User-friendly test file path to use in reported output
+    test_file: Path
 
     #: Whether this process was actually invoked
     skipped: bool = False
@@ -67,6 +71,7 @@ class System:
     def run(
         self,
         cmd: Sequence[str],
+        test_file: Path,
         *,
         env: EnvDict | None = None,
         cwd: str | None = None,
@@ -78,6 +83,9 @@ class System:
         cmd : sequence of str
             The command to run, split on whitespace into a sequence
             of strings
+
+        test_file : Path
+            User-friendly test file path to use in reported output
 
         env : dict[str, str] or None, optional, default: None
             Environment variables to apply when running the command
@@ -97,7 +105,7 @@ class System:
         invocation = envstr + " ".join(cmd)
 
         if self.dry_run:
-            return ProcessResult(invocation, skipped=True)
+            return ProcessResult(invocation, test_file, skipped=True)
 
         full_env = dict(os.environ)
         full_env.update(env)
@@ -107,7 +115,10 @@ class System:
         )
 
         return ProcessResult(
-            invocation, returncode=proc.returncode, output=proc.stdout
+            invocation,
+            test_file,
+            returncode=proc.returncode,
+            output=proc.stdout,
         )
 
     @cached_property

--- a/tests/_utils/tests/stages/test_test_stage.py
+++ b/tests/_utils/tests/stages/test_test_stage.py
@@ -60,7 +60,8 @@ class TestTestStage:
         c = Config([])
         stage = MockTestStage(c, s)
         stage.result = StageResult(
-            [ProcessResult("invoke")], timedelta(seconds=2.123)
+            [ProcessResult("invoke", Path("test/file"))],
+            timedelta(seconds=2.123),
         )
         outro = stage.outro
         assert "Exiting stage: mock" in outro

--- a/tests/_utils/tests/test_system.py
+++ b/tests/_utils/tests/test_system.py
@@ -18,6 +18,7 @@
 from __future__ import annotations
 
 import sys
+from pathlib import Path
 from subprocess import CompletedProcess
 from unittest.mock import MagicMock
 
@@ -43,12 +44,14 @@ class TestSystem:
     def test_run(self, mock_subprocess_run: MagicMock) -> None:
         s = m.System()
 
-        expected = m.ProcessResult(CMD, returncode=10, output="<output>")
+        expected = m.ProcessResult(
+            CMD, Path("test/file"), returncode=10, output="<output>"
+        )
         mock_subprocess_run.return_value = CompletedProcess(
             CMD, 10, stdout="<output>"
         )
 
-        result = s.run(CMD.split())
+        result = s.run(CMD.split(), Path("test/file"))
         mock_subprocess_run.assert_called()
 
         assert result == expected
@@ -56,7 +59,7 @@ class TestSystem:
     def test_dry_run(self, mock_subprocess_run: MagicMock) -> None:
         s = m.System(dry_run=True)
 
-        result = s.run(CMD.split())
+        result = s.run(CMD.split(), Path("test/file"))
         mock_subprocess_run.assert_not_called()
 
         assert result.output == ""


### PR DESCRIPTION
This PR changes the test runner to collect and display details of all individual test failures in one place at the end of the run:

![image](https://user-images.githubusercontent.com/1078448/186197053-2b5c500a-fbf5-487e-91ec-367da09bb1a4.png)

With this change it is not necessary to add `-v` just to see the details of test failures. 