### PR TITLE
Fixing issues with advanced_indexing_kernel

### DIFF
--- a/src/cunumeric/index/advanced_indexing.cu
+++ b/src/cunumeric/index/advanced_indexing.cu
@@ -63,7 +63,7 @@ static __global__ void __launch_bounds__(THREADS_PER_BLOCK, MIN_CTAS_PER_SM)
                            const size_t key_dim)
 {
   const size_t tid = blockIdx.x * blockDim.x + threadIdx.x;
-  if (tid > volume) return;
+  if (tid >= volume) return;
   auto point = pitches.unflatten(tid, origin);
   if (index[point] == true) {
     Point<DIM> out_p;

--- a/src/cunumeric/index/advanced_indexing_omp.cc
+++ b/src/cunumeric/index/advanced_indexing_omp.cc
@@ -52,12 +52,9 @@ struct AdvancedIndexingImplBody<VariantKind::OMP, CODE, DIM, OUT_TYPE> {
     }  // end of parallel
     size_t size = 0;
     for (auto idx = 0; idx < max_threads; ++idx) {
+      offsets[idx] = size;
       size += sizes[idx];
-      offsets[idx] = sizes[idx];
     }
-
-    thrust::exclusive_scan(
-      thrust::omp::par, offsets.ptr(0), offsets.ptr(0) + max_threads, offsets.ptr(0));
 
     return size;
   }

--- a/src/cunumeric/index/advanced_indexing_omp.cc
+++ b/src/cunumeric/index/advanced_indexing_omp.cc
@@ -31,34 +31,6 @@ template <LegateTypeCode CODE, int DIM, typename OUT_TYPE>
 struct AdvancedIndexingImplBody<VariantKind::OMP, CODE, DIM, OUT_TYPE> {
   using VAL = legate_type_of<CODE>;
 
-  template <typename OUT_T>
-  void compute_output(Buffer<OUT_T, DIM>& out,
-                      const AccessorRO<VAL, DIM>& in,
-                      const AccessorRO<bool, DIM>& index,
-                      const Pitches<DIM - 1>& pitches,
-                      const Rect<DIM>& rect,
-                      const size_t volume,
-                      int64_t out_idx,
-                      const int key_dim,
-                      const size_t skip_size) const
-  {
-#pragma omp for schedule(static)
-    for (size_t idx = 0; idx < volume; ++idx) {
-      auto p = pitches.unflatten(idx, rect.lo);
-      if (index[p] == true) {
-        Point<DIM> out_p;
-        out_p[0] = out_idx;
-        for (size_t i = 0; i < DIM - key_dim; i++) {
-          size_t j     = key_dim + i;
-          out_p[i + 1] = p[j];
-        }
-        for (size_t i = DIM - key_dim + 1; i < DIM; i++) out_p[i] = 0;
-        fill_out(out[out_p], p, in[p]);
-        if ((idx + 1) % skip_size == 0) out_idx++;
-      }
-    }
-  }
-
   size_t compute_output_offsets(ThreadLocalStorage<int64_t>& offsets,
                                 const AccessorRO<bool, DIM>& index,
                                 const Pitches<DIM - 1>& pitches,
@@ -80,6 +52,7 @@ struct AdvancedIndexingImplBody<VariantKind::OMP, CODE, DIM, OUT_TYPE> {
     }  // end of parallel
     size_t size = thrust::reduce(thrust::omp::par, sizes.begin(), sizes.end(), 0);
     thrust::exclusive_scan(thrust::omp::par, sizes.begin(), sizes.end(), offsets.begin());
+
     return size;
   }
 
@@ -117,7 +90,22 @@ struct AdvancedIndexingImplBody<VariantKind::OMP, CODE, DIM, OUT_TYPE> {
     {
       const int tid   = omp_get_thread_num();
       int64_t out_idx = offsets[tid];
-      compute_output(out, input, index, pitches, rect, volume, out_idx, key_dim, skip_size);
+#pragma omp for schedule(static)
+      for (size_t idx = 0; idx < volume; ++idx) {
+        auto p = pitches.unflatten(idx, rect.lo);
+        if (index[p] == true) {
+          Point<DIM> out_p;
+          out_p[0] = out_idx;
+          for (size_t i = 0; i < DIM - key_dim; i++) {
+            size_t j     = key_dim + i;
+            out_p[i + 1] = p[j];
+          }
+          for (size_t i = DIM - key_dim + 1; i < DIM; i++) out_p[i] = 0;
+          fill_out(out[out_p], p, input[p]);
+          if ((idx + 1) % skip_size == 0) out_idx++;
+        }
+      }
+
     }  // end parallel region
   }
 };

--- a/src/cunumeric/index/advanced_indexing_omp.cc
+++ b/src/cunumeric/index/advanced_indexing_omp.cc
@@ -31,7 +31,7 @@ template <LegateTypeCode CODE, int DIM, typename OUT_TYPE>
 struct AdvancedIndexingImplBody<VariantKind::OMP, CODE, DIM, OUT_TYPE> {
   using VAL = legate_type_of<CODE>;
 
-  size_t compute_output_offsets(Buffer<int64_t>& offsets,
+  size_t compute_output_offsets(ThreadLocalStorage<int64_t>& offsets,
                                 const AccessorRO<bool, DIM>& index,
                                 const Pitches<DIM - 1>& pitches,
                                 const Rect<DIM>& rect,
@@ -74,8 +74,7 @@ struct AdvancedIndexingImplBody<VariantKind::OMP, CODE, DIM, OUT_TYPE> {
 
     const auto max_threads = omp_get_max_threads();
     const size_t volume    = rect.volume();
-    auto kind    = CuNumeric::has_numamem ? Memory::Kind::SOCKET_MEM : Memory::Kind::SYSTEM_MEM;
-    auto offsets = create_buffer<int64_t>(max_threads, kind);
+    ThreadLocalStorage<int64_t> offsets(max_threads);
     size_t size =
       compute_output_offsets(offsets, index, pitches, rect, volume, skip_size, max_threads);
 

--- a/src/cunumeric/omp_help.h
+++ b/src/cunumeric/omp_help.h
@@ -39,9 +39,6 @@ struct ThreadLocalStorage {
     return *reinterpret_cast<VAL*>(storage_.data() + CACHE_LINE_SIZE * idx);
   }
 
-  VAL* begin() { return reinterpret_cast<VAL*>(storage_.data()); }
-  VAL* end() { return reinterpret_cast<VAL*>(storage_.data() + CACHE_LINE_SIZE * num_threads_); }
-
  private:
   std::vector<int8_t> storage_;
   size_t num_threads_;


### PR DESCRIPTION
There are 2 issues fixed in this PR:
1) Fix CUDA kernel logic
2) Fix incorrect use of ThreadLocalStorage in the OpenMP kernel