### PR TITLE
Add option to disable CPU pinning in tests

### DIFF
--- a/tests/_utils/args.py
+++ b/tests/_utils/args.py
@@ -18,7 +18,18 @@
 from __future__ import annotations
 
 from argparse import Action, ArgumentParser, Namespace
-from typing import Any, Generic, Iterable, Iterator, Sequence, TypeVar, Union
+from typing import (
+    Any,
+    Generic,
+    Iterable,
+    Iterator,
+    Literal,
+    Sequence,
+    TypeVar,
+    Union,
+)
+
+from typing_extensions import TypeAlias
 
 from . import (
     DEFAULT_CPUS_PER_NODE,
@@ -31,6 +42,18 @@ from . import (
 )
 
 T = TypeVar("T")
+
+PinOptionsType: TypeAlias = Union[
+    Literal["auto"],
+    Literal["none"],
+    Literal["strict"],
+]
+
+PIN_OPTIONS: tuple[PinOptionsType, ...] = (
+    "auto",
+    "none",
+    "strict",
+)
 
 
 class MultipleChoices(Generic[T]):
@@ -166,13 +189,11 @@ feature_opts.add_argument(
 
 
 feature_opts.add_argument(
-    "--strict-pin",
-    dest="strict_pin",
-    action="store_true",
-    help=(
-        "Pin all cores and including Python processor "
-        "(linux CPU and OMP only)"
-    ),
+    "--cpu-pin",
+    dest="cpu_pin",
+    choices=PIN_OPTIONS,
+    default="auto",
+    help="CPU pinning behavior on platforms that support CPU pinning",
 )
 
 feature_opts.add_argument(

--- a/tests/_utils/args.py
+++ b/tests/_utils/args.py
@@ -44,13 +44,13 @@ from . import (
 T = TypeVar("T")
 
 PinOptionsType: TypeAlias = Union[
-    Literal["auto"],
+    Literal["partial"],
     Literal["none"],
     Literal["strict"],
 ]
 
 PIN_OPTIONS: tuple[PinOptionsType, ...] = (
-    "auto",
+    "partial",
     "none",
     "strict",
 )
@@ -192,7 +192,7 @@ feature_opts.add_argument(
     "--cpu-pin",
     dest="cpu_pin",
     choices=PIN_OPTIONS,
-    default="auto",
+    default="partial",
     help="CPU pinning behavior on platforms that support CPU pinning",
 )
 

--- a/tests/_utils/config.py
+++ b/tests/_utils/config.py
@@ -55,7 +55,7 @@ class Config:
         self.gpus = args.gpus
         self.omps = args.omps
         self.utility = args.utility
-        self.strict_pin = args.strict_pin
+        self.cpu_pin = args.cpu_pin
         self.fbmem = args.fbmem
         self.gpu_delay = args.gpu_delay
         self.ompthreads = args.ompthreads

--- a/tests/_utils/stages/_linux/omp.py
+++ b/tests/_utils/stages/_linux/omp.py
@@ -51,22 +51,28 @@ class OMP(TestStage):
         self._init(config, system)
 
     def env(self, config: Config, system: System) -> EnvDict:
-        return {} if config.strict_pin else dict(UNPIN_ENV)
+        return {} if config.cpu_pin == "strict" else dict(UNPIN_ENV)
 
     def shard_args(self, shard: Shard, config: Config) -> ArgList:
-        return [
+        args = [
             "--omps",
             str(config.omps),
             "--ompthreads",
             str(config.ompthreads),
-            "--cpu-bind",
-            ",".join(str(x) for x in shard),
         ]
+        if config.cpu_pin != "none":
+            args += [
+                "--cpu-bind",
+                ",".join(str(x) for x in shard),
+            ]
+        return args
 
     def compute_spec(self, config: Config, system: System) -> StageSpec:
         cpus = system.cpus
         omps, threads = config.omps, config.ompthreads
-        procs = omps * threads + config.utility + int(config.strict_pin)
+        procs = (
+            omps * threads + config.utility + int(config.cpu_pin == "strict")
+        )
         workers = adjust_workers(len(cpus) // procs, config.requested_workers)
 
         shards: list[tuple[int, ...]] = []

--- a/tests/_utils/tests/stages/_linux/test_cpu.py
+++ b/tests/_utils/tests/stages/_linux/test_cpu.py
@@ -27,22 +27,41 @@ from .. import FakeSystem
 
 def test_default() -> None:
     c = Config([])
-    s = FakeSystem()
+    s = FakeSystem(cpus=12)
     stage = m.CPU(c, s)
     assert stage.kind == "cpus"
     assert stage.args == ["-cunumeric:test"]
     assert stage.env(c, s) == UNPIN_ENV
     assert stage.spec.workers > 0
 
+    shard = [(1, 2, 3), "1,2,3"]
+    assert "--cpu-bind" in stage.shard_args(shard, c)
 
-def test_strict_pin() -> None:
-    c = Config(["test.py", "--strict-pin"])
-    s = FakeSystem()
+
+def test_cpu_pin_strict() -> None:
+    c = Config(["test.py", "--cpu-pin", "strict"])
+    s = FakeSystem(cpus=12)
     stage = m.CPU(c, s)
     assert stage.kind == "cpus"
     assert stage.args == ["-cunumeric:test"]
     assert stage.env(c, s) == {}
     assert stage.spec.workers > 0
+
+    shard = [(1, 2, 3), "1,2,3"]
+    assert "--cpu-bind" in stage.shard_args(shard, c)
+
+
+def test_cpu_pin_none() -> None:
+    c = Config(["test.py", "--cpu-pin", "none"])
+    s = FakeSystem(cpus=12)
+    stage = m.CPU(c, s)
+    assert stage.kind == "cpus"
+    assert stage.args == ["-cunumeric:test"]
+    assert stage.env(c, s) == UNPIN_ENV
+    assert stage.spec.workers > 0
+
+    shard = [(1, 2, 3), "1,2,3"]
+    assert "--cpu-bind" not in stage.shard_args(shard, c)
 
 
 @pytest.mark.parametrize("shard,expected", [[(2,), "2"], [(1, 2, 3), "1,2,3"]])

--- a/tests/_utils/tests/stages/_linux/test_cpu.py
+++ b/tests/_utils/tests/stages/_linux/test_cpu.py
@@ -34,7 +34,7 @@ def test_default() -> None:
     assert stage.env(c, s) == UNPIN_ENV
     assert stage.spec.workers > 0
 
-    shard = [(1, 2, 3), "1,2,3"]
+    shard = (1, 2, 3)
     assert "--cpu-bind" in stage.shard_args(shard, c)
 
 
@@ -47,7 +47,7 @@ def test_cpu_pin_strict() -> None:
     assert stage.env(c, s) == {}
     assert stage.spec.workers > 0
 
-    shard = [(1, 2, 3), "1,2,3"]
+    shard = (1, 2, 3)
     assert "--cpu-bind" in stage.shard_args(shard, c)
 
 
@@ -60,7 +60,7 @@ def test_cpu_pin_none() -> None:
     assert stage.env(c, s) == UNPIN_ENV
     assert stage.spec.workers > 0
 
-    shard = [(1, 2, 3), "1,2,3"]
+    shard = (1, 2, 3)
     assert "--cpu-bind" not in stage.shard_args(shard, c)
 
 

--- a/tests/_utils/tests/stages/_linux/test_omp.py
+++ b/tests/_utils/tests/stages/_linux/test_omp.py
@@ -34,7 +34,7 @@ def test_default() -> None:
     assert stage.env(c, s) == UNPIN_ENV
     assert stage.spec.workers > 0
 
-    shard = [(1, 2, 3), "1,2,3"]
+    shard = (1, 2, 3)
     assert "--cpu-bind" in stage.shard_args(shard, c)
 
 
@@ -47,7 +47,7 @@ def test_cpu_pin_strict() -> None:
     assert stage.env(c, s) == {}
     assert stage.spec.workers > 0
 
-    shard = [(1, 2, 3), "1,2,3"]
+    shard = (1, 2, 3)
     assert "--cpu-bind" in stage.shard_args(shard, c)
 
 
@@ -60,7 +60,7 @@ def test_cpu_pin_none() -> None:
     assert stage.env(c, s) == UNPIN_ENV
     assert stage.spec.workers > 0
 
-    shard = [(1, 2, 3), "1,2,3"]
+    shard = (1, 2, 3)
     assert "--cpu-bind" not in stage.shard_args(shard, c)
 
 

--- a/tests/_utils/tests/stages/_linux/test_omp.py
+++ b/tests/_utils/tests/stages/_linux/test_omp.py
@@ -34,15 +34,34 @@ def test_default() -> None:
     assert stage.env(c, s) == UNPIN_ENV
     assert stage.spec.workers > 0
 
+    shard = [(1, 2, 3), "1,2,3"]
+    assert "--cpu-bind" in stage.shard_args(shard, c)
 
-def test_strict_pin() -> None:
-    c = Config(["test.py", "--strict-pin"])
+
+def test_cpu_pin_strict() -> None:
+    c = Config(["test.py", "--cpu-pin", "strict"])
     s = FakeSystem(cpus=12)
     stage = m.OMP(c, s)
     assert stage.kind == "openmp"
     assert stage.args == ["-cunumeric:test"]
     assert stage.env(c, s) == {}
     assert stage.spec.workers > 0
+
+    shard = [(1, 2, 3), "1,2,3"]
+    assert "--cpu-bind" in stage.shard_args(shard, c)
+
+
+def test_cpu_pin_none() -> None:
+    c = Config(["test.py", "--cpu-pin", "none"])
+    s = FakeSystem(cpus=12)
+    stage = m.OMP(c, s)
+    assert stage.kind == "openmp"
+    assert stage.args == ["-cunumeric:test"]
+    assert stage.env(c, s) == UNPIN_ENV
+    assert stage.spec.workers > 0
+
+    shard = [(1, 2, 3), "1,2,3"]
+    assert "--cpu-bind" not in stage.shard_args(shard, c)
 
 
 @pytest.mark.parametrize("shard,expected", [[(2,), "2"], [(1, 2, 3), "1,2,3"]])

--- a/tests/_utils/tests/test_args.py
+++ b/tests/_utils/tests/test_args.py
@@ -57,8 +57,8 @@ class TestParserDefaults:
     def test_gpus(self) -> None:
         assert m.parser.get_default("gpus") == DEFAULT_GPUS_PER_NODE
 
-    def test_strict_pin(self) -> None:
-        assert m.parser.get_default("strict_pin") is False
+    def test_cpu_pin(self) -> None:
+        assert m.parser.get_default("cpu_pin") == "auto"
 
     def test_gpu_delay(self) -> None:
         assert m.parser.get_default("gpu_delay") == DEFAULT_GPU_DELAY

--- a/tests/_utils/tests/test_args.py
+++ b/tests/_utils/tests/test_args.py
@@ -58,7 +58,7 @@ class TestParserDefaults:
         assert m.parser.get_default("gpus") == DEFAULT_GPUS_PER_NODE
 
     def test_cpu_pin(self) -> None:
-        assert m.parser.get_default("cpu_pin") == "auto"
+        assert m.parser.get_default("cpu_pin") == "partial"
 
     def test_gpu_delay(self) -> None:
         assert m.parser.get_default("gpu_delay") == DEFAULT_GPU_DELAY

--- a/tests/_utils/tests/test_config.py
+++ b/tests/_utils/tests/test_config.py
@@ -47,7 +47,7 @@ class TestConfig:
 
         assert c.cpus == DEFAULT_CPUS_PER_NODE
         assert c.gpus == DEFAULT_GPUS_PER_NODE
-        assert c.cpu_pin == "auto"
+        assert c.cpu_pin == "partial"
         assert c.gpu_delay == DEFAULT_GPU_DELAY
         assert c.fbmem == DEFAULT_GPU_MEMORY_BUDGET
         assert c.omps == DEFAULT_OMPS_PER_NODE

--- a/tests/_utils/tests/test_config.py
+++ b/tests/_utils/tests/test_config.py
@@ -31,6 +31,7 @@ from .. import (
     FEATURES,
     config as m,
 )
+from ..args import PIN_OPTIONS, PinOptionsType
 
 
 class TestConfig:
@@ -46,7 +47,7 @@ class TestConfig:
 
         assert c.cpus == DEFAULT_CPUS_PER_NODE
         assert c.gpus == DEFAULT_GPUS_PER_NODE
-        assert c.strict_pin is False
+        assert c.cpu_pin == "auto"
         assert c.gpu_delay == DEFAULT_GPU_DELAY
         assert c.fbmem == DEFAULT_GPU_MEMORY_BUDGET
         assert c.omps == DEFAULT_OMPS_PER_NODE
@@ -111,9 +112,10 @@ class TestConfig:
         c = m.Config(["test.py", f"--{opt}", "1234"])
         assert getattr(c, opt.replace("-", "_")) == 1234
 
-    def test_strict_pin(self) -> None:
-        c = m.Config(["test.py", "--strict-pin"])
-        assert c.strict_pin
+    @pytest.mark.parametrize("value", PIN_OPTIONS)
+    def test_cpu_pin(self, value: PinOptionsType) -> None:
+        c = m.Config(["test.py", "--cpu-pin", value])
+        assert c.cpu_pin == value
 
     def test_workers(self) -> None:
         c = m.Config(["test.py", "-j", "1234"])


### PR DESCRIPTION
This PR replace the test runner `--strict-pin` option with `--cpu=pin={auto, none, strict}` instead

#### none

* `REALM_SYNTHETIC_CORE_MAP` is unset
* no +1 for python processor
* `--cpu-bind` args are omitted

#### auto

* `REALM_SYNTHETIC_CORE_MAP` is unset
* no +1 for python processor
* `--cpu-bind` args are included

#### strict

* `REALM_SYNTHETIC_CORE_MAP` is ***not*** unset
*  +1 is added for python processor
* `--cpu-bind` args are included


cc @manopapad is "auto" the best choice? Nothing is automatically computed based on anything. Maybe "loose" or "lax" would be better.

