### PR TITLE
Fix OSX test shard generation

### DIFF
--- a/tests/_utils/stages/_osx/cpu.py
+++ b/tests/_utils/stages/_osx/cpu.py
@@ -60,4 +60,5 @@ class CPU(TestStage):
             len(system.cpus) // procs, config.requested_workers
         )
 
-        return StageSpec(workers, [])
+        # return a dummy set of shards just for the runner to iterate over
+        return StageSpec(workers, [(i,) for i in range(workers)])

--- a/tests/_utils/stages/_osx/eager.py
+++ b/tests/_utils/stages/_osx/eager.py
@@ -60,4 +60,5 @@ class Eager(TestStage):
         degree = min(N, 60)  # ~LEGION_MAX_NUM_PROCS just in case
         workers = adjust_workers(degree, config.requested_workers)
 
-        return StageSpec(workers, [])
+        # return a dummy set of shards just for the runner to iterate over
+        return StageSpec(workers, [(i,) for i in range(workers)])

--- a/tests/_utils/stages/_osx/omp.py
+++ b/tests/_utils/stages/_osx/omp.py
@@ -66,4 +66,5 @@ class OMP(TestStage):
             len(system.cpus) // procs, config.requested_workers
         )
 
-        return StageSpec(workers, [])
+        # return a dummy set of shards just for the runner to iterate over
+        return StageSpec(workers, [(i,) for i in range(workers)])

--- a/tests/_utils/system.py
+++ b/tests/_utils/system.py
@@ -144,13 +144,19 @@ class System:
     def gpus(self) -> tuple[GPUInfo, ...]:
         """A list of GPUs on the system, including total memory information."""
 
-        # This pynvml import is protected inside this method so that in case
-        # pynvml is not installed, tests stages that don't need gpu info (e.g.
-        # cpus, eager) will proceed unaffected. Test stages that do require
-        # gpu info will fail here with an ImportError.
-        import pynvml  # type: ignore[import]
+        try:
+            # This pynvml import is protected inside this method so that in
+            # case pynvml is not installed, tests stages that don't need gpu
+            # info (e.g. cpus, eager) will proceed unaffected. Test stages
+            # that do require gpu info will fail here with an ImportError.
+            import pynvml  # type: ignore[import]
 
-        pynvml.nvmlInit()
+            # Also a pynvml package is available on some platforms that won't
+            # have GPUs for some reason. In which case this init call will
+            # fail.
+            pynvml.nvmlInit()
+        except Exception:
+            return ()
 
         num_gpus = pynvml.nvmlDeviceGetCount()
 


### PR DESCRIPTION
This PR fixes two issues with the test runner on OSX:

* Inexplicably, there is a `pynvml` package that exists and can be imported on OSX (it just fails on initialization). The condition is handled more gracefully
* The CPU pinning PR made the OSX stages return empty shards since pinning is not possible on OSX. But at least need to return a dummy shard of the proper length for the stage to queue over. 