### PR TITLE
src/cunumeric/search: make nonzero not always allocate SYS_MEM buffers

### DIFF
--- a/src/cunumeric/search/nonzero_omp.cc
+++ b/src/cunumeric/search/nonzero_omp.cc
@@ -59,7 +59,8 @@ struct NonzeroImplBody<VariantKind::OMP, CODE, DIM> {
       for (auto idx = 1; idx < max_threads; ++idx) offsets[idx] = offsets[idx - 1] + sizes[idx - 1];
     }
 
-    for (auto& result : results) result = create_buffer<int64_t>(size, Memory::Kind::SYSTEM_MEM);
+    auto kind = CuNumeric::has_numamem ? Memory::Kind::SOCKET_MEM : Memory::Kind::SYSTEM_MEM;
+    for (auto& result : results) result = create_buffer<int64_t>(size, kind);
 
 #pragma omp parallel
     {

--- a/src/cunumeric/set/unique_omp.cc
+++ b/src/cunumeric/set/unique_omp.cc
@@ -68,7 +68,8 @@ struct UniqueImplBody<VariantKind::OMP, CODE, DIM> {
     auto& final_dedup_set = dedup_set[0];
     size_t size           = final_dedup_set.size();
     size_t pos            = 0;
-    auto result           = create_buffer<VAL>(size);
+    auto kind   = CuNumeric::has_numamem ? Memory::Kind::SOCKET_MEM : Memory::Kind::SYSTEM_MEM;
+    auto result = create_buffer<VAL>(size, kind);
 
     for (auto e : final_dedup_set) result[pos++] = e;
 


### PR DESCRIPTION
This commit fixes a bug where nonzero would always allocate data in
system memory for output buffers even when numa memories were available.
This led to error messages like:
```
[0 - 7f2e7001d000]    1.243573 {5}{runtime}: [error 608] LEGION ERROR: Field 1048586 of output region 0 of task cunumeric::NonzeroTask (UID: 58) is requested to have an instance on memory 1e00000000000002, but the returned instance is allocated on memory 1e00000000000000. (from file /opt/legate/legate.core/legion/runtime/legion/runtime.cc:5797)
For more information see:
http://legion.stanford.edu/messages/error_code.html#error_code_608
```