### PR TITLE
Force positive values for log and sqrt tests

### DIFF
--- a/tests/integration/test_unary_ufunc.py
+++ b/tests/integration/test_unary_ufunc.py
@@ -215,7 +215,7 @@ def test_log_ops(op):
     check_op_input(op, astype="F", out_dtype="D")
 
     check_op_input(op, randint=True, a_min=3, a_max=10)
-    check_op_input(op, shape=(1,), offset=3)
+    check_op_input(op, shape=(1,), a_min=0.1, offset=3)
 
 
 even_root_ops = ("sqrt",)
@@ -231,7 +231,7 @@ def test_even_root_ops(op):
     # Complex inputs can be negative
     check_op_input(op, astype="F", out_dtype="D")
     check_op_input(op, randint=True, a_min=3, a_max=10)
-    check_op_input(op, shape=(1,), offset=3)
+    check_op_input(op, shape=(1,), a_min=0.1, offset=3)
 
 
 odd_root_ops = ("cbrt",)


### PR DESCRIPTION
Certain tests can occasionally get negative values from randn, but they should only operate on positive values. This adds a floor value to the random number generators to ensure values are always positive.