### PR TITLE
Fix `linalg.solve` when inputs are scalars

### DIFF
--- a/src/cunumeric/matrix/solve_template.inl
+++ b/src/cunumeric/matrix/solve_template.inl
@@ -71,7 +71,7 @@ struct SolveImpl {
     size_t a_strides[2];
     VAL* a = a_array.read_write_accessor<VAL, 2>(a_shape).ptr(a_shape, a_strides);
 #ifdef DEBUG_CUNUMERIC
-    assert(a_strides[0] == 1 && a_strides[1] == m);
+    assert(a_array.is_future() || (a_strides[0] == 1 && a_strides[1] == m));
 #endif
     VAL* b = nullptr;
 
@@ -92,7 +92,7 @@ struct SolveImpl {
       size_t b_strides[2];
       b = b_array.read_write_accessor<VAL, 2>(b_shape).ptr(b_shape, b_strides);
 #ifdef DEBUG_CUNUMERIC
-      assert(b_strides[0] == 1 && b_strides[1] == m);
+      assert(b_array.is_future() || (b_strides[0] == 1 && b_strides[1] == m));
 #endif
     }
 

--- a/tests/integration/test_solve.py
+++ b/tests/integration/test_solve.py
@@ -64,6 +64,18 @@ def test_solve_2d(n, a_dtype, b_dtype):
     assert allclose(b, num.matmul(a, out), rtol=rtol, atol=atol)
 
 
+def test_solve_corner_cases():
+    a = num.random.rand(1, 1)
+    b = num.random.rand(1)
+
+    out = num.linalg.solve(a, b)
+    assert allclose(b, num.matmul(a, out))
+
+    b = num.random.rand(1, 1)
+    out = num.linalg.solve(a, b)
+    assert allclose(b, num.matmul(a, out))
+
+
 if __name__ == "__main__":
     import sys
 


### PR DESCRIPTION
This and [a companion PR](https://github.com/nv-legate/legate.core/pull/365) should address #583.