### PR TITLE
Delay label checking on fresh PRs

### DIFF
--- a/.github/workflows/require-labels.yml
+++ b/.github/workflows/require-labels.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - name: Delay checking labels if PR is just created
         if: ${{ github.event.action == 'opened' }}
-        run: sleep 60s
+        run: sleep 300s
         shell: bash
       - name: Check Labels
         uses: mheap/github-action-required-labels@v2

--- a/.github/workflows/require-labels.yml
+++ b/.github/workflows/require-labels.yml
@@ -6,7 +6,12 @@ jobs:
   label:
     runs-on: ubuntu-latest
     steps:
-      - uses: mheap/github-action-required-labels@v2
+      - name: Delay checking labels if PR is just created
+        if: ${{ github.event.action == 'opened' }}
+        run: sleep 60s
+        shell: bash
+      - name: Check Labels
+        uses: mheap/github-action-required-labels@v2
         with:
           mode: exactly
           count: 1


### PR DESCRIPTION
When a PR is created, the authors will often set the labels soon after creation. We will have a "grace period" on a new pull request to allow setting labels after the PR is created.