### PR TITLE
Mark temporary conversion outputs as linear for eager storage recycling

### DIFF
--- a/cunumeric/_ufunc/ufunc.py
+++ b/cunumeric/_ufunc/ufunc.py
@@ -218,7 +218,7 @@ class ufunc:
                 f"{arr.dtype} to {to_dtype} with casting rule '{casting}'"
             )
 
-        return arr.astype(to_dtype)
+        return arr._astype(to_dtype, temporary=True)
 
     def _maybe_create_result(
         self,
@@ -366,7 +366,7 @@ class unary_ufunc(ufunc):
         if not precision_fixed:
             if arr.dtype in self._resolution_cache:
                 to_dtype = self._resolution_cache[arr.dtype]
-                arr = arr.astype(to_dtype)
+                arr = arr._astype(to_dtype, temporary=True)
                 return arr, np.dtype(self._types[to_dtype.char])
 
         chosen = None
@@ -385,7 +385,9 @@ class unary_ufunc(ufunc):
         to_dtype = np.dtype(chosen)
         self._resolution_cache[arr.dtype] = to_dtype
 
-        return arr.astype(to_dtype), np.dtype(self._types[to_dtype.char])
+        return arr._astype(to_dtype, temporary=True), np.dtype(
+            self._types[to_dtype.char]
+        )
 
     def __call__(
         self,
@@ -449,7 +451,7 @@ class multiout_unary_ufunc(ufunc):
         if not precision_fixed:
             if arr.dtype in self._resolution_cache:
                 to_dtype = self._resolution_cache[arr.dtype]
-                arr = arr.astype(to_dtype)
+                arr = arr._astype(to_dtype, temporary=True)
                 return arr, to_dtypes(self._types[to_dtype.char])
 
         chosen = None
@@ -468,7 +470,9 @@ class multiout_unary_ufunc(ufunc):
         to_dtype = np.dtype(chosen)
         self._resolution_cache[arr.dtype] = to_dtype
 
-        return arr.astype(to_dtype), to_dtypes(self._types[to_dtype.char])
+        return arr._astype(to_dtype, temporary=True), to_dtypes(
+            self._types[to_dtype.char]
+        )
 
     def __call__(
         self,
@@ -597,7 +601,8 @@ class binary_ufunc(ufunc):
 
         if key in self._types:
             arrs = [
-                arr.astype(to_dtype) for arr, to_dtype in zip(arrs, to_dtypes)
+                arr._astype(to_dtype, temporary=True)
+                for arr, to_dtype in zip(arrs, to_dtypes)
             ]
             return arrs, np.dtype(self._types[key])
 
@@ -605,7 +610,7 @@ class binary_ufunc(ufunc):
             if key in self._resolution_cache:
                 to_dtypes = self._resolution_cache[key]
                 arrs = [
-                    arr.astype(to_dtype)
+                    arr._astype(to_dtype, temporary=True)
                     for arr, to_dtype in zip(arrs, to_dtypes)
                 ]
                 return arrs, np.dtype(self._types[to_dtypes])
@@ -638,7 +643,10 @@ class binary_ufunc(ufunc):
             )
 
         self._resolution_cache[key] = chosen
-        arrs = [arr.astype(to_dtype) for arr, to_dtype in zip(arrs, chosen)]
+        arrs = [
+            arr._astype(to_dtype, temporary=True)
+            for arr, to_dtype in zip(arrs, chosen)
+        ]
 
         return arrs, np.dtype(self._types[chosen])
 

--- a/cunumeric/array.py
+++ b/cunumeric/array.py
@@ -1860,6 +1860,17 @@ class ndarray:
         Multiple GPUs, Multiple CPUs
 
         """
+        return self._astype(dtype, order, casting, subok, copy, False)
+
+    def _astype(
+        self,
+        dtype: npt.DTypeLike,
+        order: OrderType = "C",
+        casting: CastingKind = "unsafe",
+        subok: bool = True,
+        copy: bool = True,
+        temporary: bool = False,
+    ) -> ndarray:
         dtype = np.dtype(dtype)
         if self.dtype == dtype:
             return self
@@ -1879,7 +1890,7 @@ class ndarray:
                 f"to the rule '{casting}'"
             )
         result = ndarray(self.shape, dtype=dtype, inputs=(self,))
-        result._thunk.convert(self._thunk, warn=False)
+        result._thunk.convert(self._thunk, warn=False, temporary=temporary)
         return result
 
     @add_boilerplate()

--- a/cunumeric/deferred.py
+++ b/cunumeric/deferred.py
@@ -1184,6 +1184,7 @@ class DeferredArray(NumPyThunk):
         rhs: Any,
         warn: bool = True,
         nan_op: ConvertCode = ConvertCode.NOOP,
+        temporary: bool = False,
     ) -> None:
         lhs_array = self
         rhs_array = rhs
@@ -1209,6 +1210,9 @@ class DeferredArray(NumPyThunk):
         task.add_alignment(lhs, rhs)
 
         task.execute()
+
+        if temporary:
+            lhs.set_linear()
 
     @auto_convert([1, 2])
     def convolve(self, v: Any, lhs: Any, mode: ConvolveMode) -> None:

--- a/cunumeric/eager.py
+++ b/cunumeric/eager.py
@@ -490,6 +490,7 @@ class EagerArray(NumPyThunk):
         rhs: Any,
         warn: bool = True,
         nan_op: ConvertCode = ConvertCode.NOOP,
+        temporary: bool = False,
     ) -> None:
         self.check_eager_args(rhs)
         if self.deferred is not None:

--- a/cunumeric/thunk.py
+++ b/cunumeric/thunk.py
@@ -157,6 +157,7 @@ class NumPyThunk(ABC):
         rhs: Any,
         warn: bool = True,
         nan_op: ConvertCode = ConvertCode.NOOP,
+        temporary: bool = False,
     ) -> None:
         ...
 


### PR DESCRIPTION
This PR uses a feature added by https://github.com/nv-legate/legate.core/pull/364 to recycle storages for stores temporarily created by type conversions.