### PR TITLE
Add RuntimeError exception to legate.time

### DIFF
--- a/examples/cg.py
+++ b/examples/cg.py
@@ -21,7 +21,7 @@ from benchmark import run_benchmark
 
 try:
     from legate.timing import time
-except ImportError:
+except (ImportError, RuntimeError):
     from time import perf_counter_ns
 
     def time():

--- a/examples/einsum.py
+++ b/examples/einsum.py
@@ -22,7 +22,7 @@ from benchmark import run_benchmark
 
 try:
     from legate.timing import time
-except ImportError:
+except (ImportError, RuntimeError):
     from time import perf_counter_ns
 
     def time():

--- a/examples/jacobi.py
+++ b/examples/jacobi.py
@@ -22,7 +22,7 @@ from benchmark import run_benchmark
 
 try:
     from legate.timing import time
-except ImportError:
+except (ImportError, RuntimeError):
     from time import perf_counter_ns
 
     def time():

--- a/examples/logreg.py
+++ b/examples/logreg.py
@@ -22,7 +22,7 @@ from benchmark import run_benchmark
 
 try:
     from legate.timing import time
-except ImportError:
+except (ImportError, RuntimeError):
     from time import perf_counter_ns
 
     def time():

--- a/examples/sort.py
+++ b/examples/sort.py
@@ -22,7 +22,7 @@ from benchmark import run_benchmark
 
 try:
     from legate.timing import time
-except ImportError:
+except (ImportError, RuntimeError):
     from time import perf_counter_ns
 
     def time():

--- a/examples/stencil.py
+++ b/examples/stencil.py
@@ -22,7 +22,7 @@ from benchmark import run_benchmark
 
 try:
     from legate.timing import time
-except ImportError:
+except (ImportError, RuntimeError):
     from time import perf_counter_ns
 
     def time():


### PR DESCRIPTION
When running cupy tests, it raises RuntimeError.
Add RuntimeError exception to legate.time to fix it.