### PR TITLE
Stop instantiating min and max reduction ops for complex types

### DIFF
--- a/src/cunumeric/arg.cc
+++ b/src/cunumeric/arg.cc
@@ -45,25 +45,23 @@ DEFINE_IDENTITIES(uint8_t)
 DEFINE_IDENTITIES(uint16_t)
 DEFINE_IDENTITIES(uint32_t)
 DEFINE_IDENTITIES(uint64_t)
-DEFINE_IDENTITIES(complex<float>)
 
 #define _REGISTER_REDOP(ID, TYPE) Runtime::register_reduction_op<TYPE>(ID);
 
-#define REGISTER_REDOPS(OP)                                                                        \
-  {                                                                                                \
-    _REGISTER_REDOP(context.get_reduction_op_id(OP<float>::REDOP_ID), OP<float>)                   \
-    _REGISTER_REDOP(context.get_reduction_op_id(OP<double>::REDOP_ID), OP<double>)                 \
-    _REGISTER_REDOP(context.get_reduction_op_id(OP<int8_t>::REDOP_ID), OP<int8_t>)                 \
-    _REGISTER_REDOP(context.get_reduction_op_id(OP<int16_t>::REDOP_ID), OP<int16_t>)               \
-    _REGISTER_REDOP(context.get_reduction_op_id(OP<int32_t>::REDOP_ID), OP<int32_t>)               \
-    _REGISTER_REDOP(context.get_reduction_op_id(OP<int64_t>::REDOP_ID), OP<int64_t>)               \
-    _REGISTER_REDOP(context.get_reduction_op_id(OP<uint8_t>::REDOP_ID), OP<uint8_t>)               \
-    _REGISTER_REDOP(context.get_reduction_op_id(OP<uint16_t>::REDOP_ID), OP<uint16_t>)             \
-    _REGISTER_REDOP(context.get_reduction_op_id(OP<uint32_t>::REDOP_ID), OP<uint32_t>)             \
-    _REGISTER_REDOP(context.get_reduction_op_id(OP<uint64_t>::REDOP_ID), OP<uint64_t>)             \
-    _REGISTER_REDOP(context.get_reduction_op_id(OP<bool>::REDOP_ID), OP<bool>)                     \
-    _REGISTER_REDOP(context.get_reduction_op_id(OP<__half>::REDOP_ID), OP<__half>)                 \
-    _REGISTER_REDOP(context.get_reduction_op_id(OP<complex<float>>::REDOP_ID), OP<complex<float>>) \
+#define REGISTER_REDOPS(OP)                                                            \
+  {                                                                                    \
+    _REGISTER_REDOP(context.get_reduction_op_id(OP<float>::REDOP_ID), OP<float>)       \
+    _REGISTER_REDOP(context.get_reduction_op_id(OP<double>::REDOP_ID), OP<double>)     \
+    _REGISTER_REDOP(context.get_reduction_op_id(OP<int8_t>::REDOP_ID), OP<int8_t>)     \
+    _REGISTER_REDOP(context.get_reduction_op_id(OP<int16_t>::REDOP_ID), OP<int16_t>)   \
+    _REGISTER_REDOP(context.get_reduction_op_id(OP<int32_t>::REDOP_ID), OP<int32_t>)   \
+    _REGISTER_REDOP(context.get_reduction_op_id(OP<int64_t>::REDOP_ID), OP<int64_t>)   \
+    _REGISTER_REDOP(context.get_reduction_op_id(OP<uint8_t>::REDOP_ID), OP<uint8_t>)   \
+    _REGISTER_REDOP(context.get_reduction_op_id(OP<uint16_t>::REDOP_ID), OP<uint16_t>) \
+    _REGISTER_REDOP(context.get_reduction_op_id(OP<uint32_t>::REDOP_ID), OP<uint32_t>) \
+    _REGISTER_REDOP(context.get_reduction_op_id(OP<uint64_t>::REDOP_ID), OP<uint64_t>) \
+    _REGISTER_REDOP(context.get_reduction_op_id(OP<bool>::REDOP_ID), OP<bool>)         \
+    _REGISTER_REDOP(context.get_reduction_op_id(OP<__half>::REDOP_ID), OP<__half>)     \
   }
 
 void register_cpu_reduction_operators(legate::LibraryContext& context)

--- a/src/cunumeric/cunumeric.cu
+++ b/src/cunumeric/cunumeric.cu
@@ -48,21 +48,20 @@ class CUDAReductionOpWrapper : public T {
     NULL,                                                                           \
     false);
 
-#define REGISTER_REDOPS(OP)                                                                        \
-  {                                                                                                \
-    _REGISTER_REDOP(context.get_reduction_op_id(OP<float>::REDOP_ID), OP<float>)                   \
-    _REGISTER_REDOP(context.get_reduction_op_id(OP<double>::REDOP_ID), OP<double>)                 \
-    _REGISTER_REDOP(context.get_reduction_op_id(OP<int8_t>::REDOP_ID), OP<int8_t>)                 \
-    _REGISTER_REDOP(context.get_reduction_op_id(OP<int16_t>::REDOP_ID), OP<int16_t>)               \
-    _REGISTER_REDOP(context.get_reduction_op_id(OP<int32_t>::REDOP_ID), OP<int32_t>)               \
-    _REGISTER_REDOP(context.get_reduction_op_id(OP<int64_t>::REDOP_ID), OP<int64_t>)               \
-    _REGISTER_REDOP(context.get_reduction_op_id(OP<uint8_t>::REDOP_ID), OP<uint8_t>)               \
-    _REGISTER_REDOP(context.get_reduction_op_id(OP<uint16_t>::REDOP_ID), OP<uint16_t>)             \
-    _REGISTER_REDOP(context.get_reduction_op_id(OP<uint32_t>::REDOP_ID), OP<uint32_t>)             \
-    _REGISTER_REDOP(context.get_reduction_op_id(OP<uint64_t>::REDOP_ID), OP<uint64_t>)             \
-    _REGISTER_REDOP(context.get_reduction_op_id(OP<bool>::REDOP_ID), OP<bool>)                     \
-    _REGISTER_REDOP(context.get_reduction_op_id(OP<__half>::REDOP_ID), OP<__half>)                 \
-    _REGISTER_REDOP(context.get_reduction_op_id(OP<complex<float>>::REDOP_ID), OP<complex<float>>) \
+#define REGISTER_REDOPS(OP)                                                            \
+  {                                                                                    \
+    _REGISTER_REDOP(context.get_reduction_op_id(OP<float>::REDOP_ID), OP<float>)       \
+    _REGISTER_REDOP(context.get_reduction_op_id(OP<double>::REDOP_ID), OP<double>)     \
+    _REGISTER_REDOP(context.get_reduction_op_id(OP<int8_t>::REDOP_ID), OP<int8_t>)     \
+    _REGISTER_REDOP(context.get_reduction_op_id(OP<int16_t>::REDOP_ID), OP<int16_t>)   \
+    _REGISTER_REDOP(context.get_reduction_op_id(OP<int32_t>::REDOP_ID), OP<int32_t>)   \
+    _REGISTER_REDOP(context.get_reduction_op_id(OP<int64_t>::REDOP_ID), OP<int64_t>)   \
+    _REGISTER_REDOP(context.get_reduction_op_id(OP<uint8_t>::REDOP_ID), OP<uint8_t>)   \
+    _REGISTER_REDOP(context.get_reduction_op_id(OP<uint16_t>::REDOP_ID), OP<uint16_t>) \
+    _REGISTER_REDOP(context.get_reduction_op_id(OP<uint32_t>::REDOP_ID), OP<uint32_t>) \
+    _REGISTER_REDOP(context.get_reduction_op_id(OP<uint64_t>::REDOP_ID), OP<uint64_t>) \
+    _REGISTER_REDOP(context.get_reduction_op_id(OP<bool>::REDOP_ID), OP<bool>)         \
+    _REGISTER_REDOP(context.get_reduction_op_id(OP<__half>::REDOP_ID), OP<__half>)     \
   }
 
 void register_gpu_reduction_operators(legate::LibraryContext& context)

--- a/src/cunumeric/unary/unary_red_util.h
+++ b/src/cunumeric/unary/unary_red_util.h
@@ -151,7 +151,7 @@ struct UnaryRedOp<UnaryRedCode::COUNT_NONZERO, TYPE_CODE> {
 
 template <legate::LegateTypeCode TYPE_CODE>
 struct UnaryRedOp<UnaryRedCode::MAX, TYPE_CODE> {
-  static constexpr bool valid = TYPE_CODE != legate::LegateTypeCode::COMPLEX128_LT;
+  static constexpr bool valid = !legate::is_complex<legate::legate_type_of<TYPE_CODE>>::value;
 
   using RHS = legate::legate_type_of<TYPE_CODE>;
   using VAL = RHS;
@@ -174,7 +174,7 @@ struct UnaryRedOp<UnaryRedCode::MAX, TYPE_CODE> {
 
 template <legate::LegateTypeCode TYPE_CODE>
 struct UnaryRedOp<UnaryRedCode::MIN, TYPE_CODE> {
-  static constexpr bool valid = TYPE_CODE != legate::LegateTypeCode::COMPLEX128_LT;
+  static constexpr bool valid = !legate::is_complex<legate::legate_type_of<TYPE_CODE>>::value;
 
   using RHS = legate::legate_type_of<TYPE_CODE>;
   using VAL = RHS;
@@ -243,7 +243,7 @@ struct UnaryRedOp<UnaryRedCode::SUM, TYPE_CODE> {
 
 template <legate::LegateTypeCode TYPE_CODE>
 struct UnaryRedOp<UnaryRedCode::ARGMAX, TYPE_CODE> {
-  static constexpr bool valid = TYPE_CODE != legate::LegateTypeCode::COMPLEX128_LT;
+  static constexpr bool valid = !legate::is_complex<legate::legate_type_of<TYPE_CODE>>::value;
 
   using RHS = legate::legate_type_of<TYPE_CODE>;
   using VAL = Argval<RHS>;
@@ -276,7 +276,7 @@ struct UnaryRedOp<UnaryRedCode::ARGMAX, TYPE_CODE> {
 
 template <legate::LegateTypeCode TYPE_CODE>
 struct UnaryRedOp<UnaryRedCode::ARGMIN, TYPE_CODE> {
-  static constexpr bool valid = TYPE_CODE != legate::LegateTypeCode::COMPLEX128_LT;
+  static constexpr bool valid = !legate::is_complex<legate::legate_type_of<TYPE_CODE>>::value;
 
   using RHS = legate::legate_type_of<TYPE_CODE>;
   using VAL = Argval<RHS>;


### PR DESCRIPTION
It turns out that min and max reductions on complex types are rejected in the Python code even though the C++ reduction code was instantiating the template for those cases. This PR fixes the inconsistency by removing those instances.