### PR TITLE
src/cunumeric/matrix: stop including coll.h in solve_template.inl (#620)

### DIFF
--- a/src/cunumeric/matrix/solve_template.inl
+++ b/src/cunumeric/matrix/solve_template.inl
@@ -18,8 +18,6 @@
 
 #include <vector>
 
-#include "core/comm/coll.h"
-
 // Useful for IDEs
 #include "cunumeric/matrix/solve.h"
 


### PR DESCRIPTION
This file was included unnecessarily, and led to build issues on distributed machines. In particular, including coll.h pulls in mpi.h, which is an unresolved header to NVCC.

Signed-off-by: Rohan Yadav <rohany@alumni.cmu.edu>
