### PR TITLE
Support python coverage test.

### DIFF
--- a/tests/_utils/args.py
+++ b/tests/_utils/args.py
@@ -237,7 +237,6 @@ test_opts.add_argument(
     help="Path to Legate installation directory",
 )
 
-
 test_opts.add_argument(
     "-C",
     "--directory",
@@ -249,6 +248,38 @@ test_opts.add_argument(
     help="Root directory containing the tests subdirectory",
 )
 
+test_opts.add_argument(
+    "--cov_bin",
+    dest="cov_bin",
+    action="store",
+    default=None,
+    required=False,
+    help=(
+        "coverage binary location, "
+        "e.g. /conda_path/envs/env_name/bin/coverage"
+    ),
+)
+
+test_opts.add_argument(
+    "--cov_args",
+    dest="cov_args",
+    action="store",
+    default="run -a --branch",
+    required=False,
+    help="coverage run command arguments, e.g. run -a --branch",
+)
+
+test_opts.add_argument(
+    "--cov_src_path",
+    dest="cov_src_path",
+    action="store",
+    default=None,
+    required=False,
+    help=(
+        "path value of --source in coverage run command, "
+        "e.g. /project_path/cunumeric/cunumeric"
+    ),
+)
 
 test_opts.add_argument(
     "-j",

--- a/tests/_utils/config.py
+++ b/tests/_utils/config.py
@@ -41,7 +41,7 @@ class Config:
         args, self._extra_args = parser.parse_known_args(argv[1:])
 
         # which tests to run
-        self.examples = True
+        self.examples = False if args.cov_bin else True
         self.integration = True
         self.unit = args.unit
         self.files = args.files
@@ -66,6 +66,9 @@ class Config:
         self.test_root = args.test_root
         self.requested_workers = args.workers
         self.legate_dir = self._compute_legate_dir(args)
+        self.cov_bin = args.cov_bin
+        self.cov_args = args.cov_args
+        self.cov_src_path = args.cov_src_path
 
     @property
     def env(self) -> EnvDict:

--- a/tests/_utils/stages/test_stage.py
+++ b/tests/_utils/stages/test_stage.py
@@ -229,7 +229,19 @@ class TestStage(Protocol):
         stage_args = self.args + self.shard_args(shard, config)
         file_args = self.file_args(test_file, config)
 
-        cmd = [str(config.legate_path), str(test_path)]
+        if config.cov_bin:
+            coverage_args = config.cov_args.split()
+            if config.cov_src_path:
+                coverage_args += ["--source=%s" % config.cov_src_path]
+            cmd = (
+                [str(config.legate_path)]
+                + [config.cov_bin]
+                + coverage_args
+                + [str(test_path)]
+            )
+        else:
+            cmd = [str(config.legate_path), str(test_path)]
+
         cmd += stage_args + file_args + config.extra_args
 
         self.delay(shard, config, system)


### PR DESCRIPTION
If we specify --cov_bin, it will run legate command with "coverage run". coverage here is a python module which measures python source code coverage.
e.g.:
./test.py --use=cuda --cov_bin /home/robinw/miniconda3/envs/legate/bin/coverage --cov_src_path /home/robinw/legate/cunumeric/cunumeric --debug --verbose

If we don't specify --cov_bin, it will run legate command without "coverage run" as before.
./test.py --use=cuda --debug --verbose
