### PR TITLE
Fix missing legate-core run requirement

### DIFF
--- a/conda/conda-build/meta.yaml
+++ b/conda/conda-build/meta.yaml
@@ -132,7 +132,10 @@ requirements:
   run:
     - numpy {{ numpy_version }}
     - libopenblas =* =*openmp*
-{% if gpu_enabled_bool %}
+{% if not gpu_enabled_bool %}
+    - legate-core ={{ core_version }} =*_cpu
+{% else %}
+    - legate-core ={{ core_version }}
     - cuda-cudart >={{ cuda_version }}
     # - libcutensor >=1.3
     - cutensor >=1.3


### PR DESCRIPTION
The meta.yaml has a ignore_run_exports to ignore run_exports from legate-core, but this strips legate-core from the run requirements of cunumeric.

This patch adds legate-core back as a directly listed run requirement