### PR TITLE
Make `install.py` reconfigure editable installs when build type changes

### DIFF
--- a/install.py
+++ b/install.py
@@ -303,10 +303,14 @@ def install_cunumeric(
     if verbose:
         pip_install_cmd += ["-vv"]
 
-    cmake_flags = []
+    # Also use preexisting CMAKE_ARGS from conda if set
+    cmake_flags = cmd_env.get("CMAKE_ARGS", "").split(" ")
 
     if cmake_generator:
-        cmake_flags += [f"-G'{cmake_generator}'"]
+        if " " not in cmake_generator:
+            cmake_flags += [f"-G{cmake_generator}"]
+        else:
+            cmake_flags += [f"-G'{cmake_generator}'"]
 
     if debug or verbose:
         cmake_flags += ["--log-level=%s" % ("DEBUG" if debug else "VERBOSE")]
@@ -355,7 +359,7 @@ def install_cunumeric(
     cmd_env.update(
         {
             "SKBUILD_BUILD_OPTIONS": f"-j{str(thread_count)}",
-            "SKBUILD_CONFIGURE_OPTIONS": "\n".join(cmake_flags),
+            "CMAKE_ARGS": " ".join(cmake_flags),
         }
     )
 

--- a/install.py
+++ b/install.py
@@ -296,6 +296,9 @@ def install_cunumeric(
             pip_install_cmd += ["--no-deps", "--no-build-isolation"]
         pip_install_cmd += ["--upgrade"]
 
+    if unknown is not None:
+        pip_install_cmd += unknown
+
     pip_install_cmd += ["."]
     if verbose:
         pip_install_cmd += ["-vv"]

--- a/scripts/build-install.sh
+++ b/scripts/build-install.sh
@@ -13,7 +13,7 @@ source ./scripts/util/uninstall-global-legion-legate-core-and-cunumeric.sh
 rm -rf ./{build,_skbuild,dist,cunumeric.egg-info}
 
 # Define CMake configuration arguments
-cmake_args=
+cmake_args="${CMAKE_ARGS:-}"
 
 # Use ninja-build if installed
 if [[ -n "$(which ninja)" ]]; then cmake_args+="-GNinja"; fi
@@ -29,7 +29,7 @@ ninja_args="-j$(nproc --ignore=2)"
 
 # Build cunumeric + cunumeric_python and install into the current Python environment
 SKBUILD_BUILD_OPTIONS="$ninja_args"       \
-SKBUILD_CONFIGURE_OPTIONS="$cmake_args"   \
+CMAKE_ARGS="$cmake_args"                  \
     python -m pip install                 \
         --root / --prefix "$CONDA_PREFIX" \
         --no-deps --no-build-isolation    \

--- a/scripts/build-no-install.sh
+++ b/scripts/build-no-install.sh
@@ -11,7 +11,7 @@ source ./scripts/util/compiler-flags.sh
 rm -rf ./{build,_skbuild,dist,cunumeric.egg-info}
 
 # Define CMake configuration arguments
-cmake_args=
+cmake_args="${CMAKE_ARGS:-}"
 
 # Use ninja-build if installed
 if [[ -n "$(which ninja)" ]]; then cmake_args+="-GNinja"; fi
@@ -27,7 +27,7 @@ ninja_args="-j$(nproc --ignore=2)"
 
 # Build legion_core + legion_core_python and perform an "editable" install
 SKBUILD_BUILD_OPTIONS="$ninja_args"       \
-SKBUILD_CONFIGURE_OPTIONS="$cmake_args"   \
+CMAKE_ARGS="$cmake_args"                  \
 SETUPTOOLS_ENABLE_FEATURES="legacy-editable" \
     python -m pip install                 \
         --root / --prefix "$CONDA_PREFIX" \

--- a/scripts/build-separately-no-install.sh
+++ b/scripts/build-separately-no-install.sh
@@ -11,7 +11,7 @@ source ./scripts/util/compiler-flags.sh
 rm -rf ./{build,_skbuild,dist,cunumeric.egg-info}
 
 # Define CMake configuration arguments
-cmake_args=
+cmake_args="${CMAKE_ARGS:-}"
 
 # Use ninja-build if installed
 if [[ -n "$(which ninja)" ]]; then cmake_args+="-GNinja"; fi
@@ -44,7 +44,7 @@ cmake_args+="
 
 # Build legion_core_python and perform an "editable" install
 SKBUILD_BUILD_OPTIONS="$ninja_args"       \
-SKBUILD_CONFIGURE_OPTIONS="$cmake_args"   \
+CMAKE_ARGS="$cmake_args"                  \
 SETUPTOOLS_ENABLE_FEATURES="legacy-editable" \
     python -m pip install                 \
         --root / --prefix "$CONDA_PREFIX" \

--- a/scripts/build-with-legate-no-install.sh
+++ b/scripts/build-with-legate-no-install.sh
@@ -13,7 +13,7 @@ source ./scripts/util/read-legate-core-root.sh "$0"
 rm -rf ./{build,_skbuild,dist,cunumeric.egg-info}
 
 # Define CMake configuration arguments
-cmake_args=
+cmake_args="${CMAKE_ARGS:-}"
 
 # Use ninja-build if installed
 if [[ -n "$(which ninja)" ]]; then cmake_args+="-GNinja"; fi
@@ -28,7 +28,7 @@ ninja_args="-j$(nproc --ignore=2)"
 
 # Build legion_core + legion_core_python and perform an "editable" install
 SKBUILD_BUILD_OPTIONS="$ninja_args"       \
-SKBUILD_CONFIGURE_OPTIONS="$cmake_args"   \
+CMAKE_ARGS="$cmake_args"                  \
 SETUPTOOLS_ENABLE_FEATURES="legacy-editable" \
     python -m pip install                 \
         --root / --prefix "$CONDA_PREFIX" \

--- a/scripts/build-with-legate-separately-no-install.sh
+++ b/scripts/build-with-legate-separately-no-install.sh
@@ -13,7 +13,7 @@ source ./scripts/util/read-legate-core-root.sh "$0"
 rm -rf ./{build,_skbuild,dist,cunumeric.egg-info}
 
 # Define CMake configuration arguments
-cmake_args=
+cmake_args="${CMAKE_ARGS:-}"
 
 # Use ninja-build if installed
 if [[ -n "$(which ninja)" ]]; then cmake_args+="-GNinja"; fi
@@ -45,7 +45,7 @@ cmake_args+="
 
 # Build legion_core_python and perform an "editable" install
 SKBUILD_BUILD_OPTIONS="$ninja_args"       \
-SKBUILD_CONFIGURE_OPTIONS="$cmake_args"   \
+CMAKE_ARGS="$cmake_args"                  \
 SETUPTOOLS_ENABLE_FEATURES="legacy-editable" \
     python -m pip install                 \
         --root / --prefix "$CONDA_PREFIX" \

--- a/scripts/util/uninstall-global-legion-legate-core-and-cunumeric.sh
+++ b/scripts/util/uninstall-global-legion-legate-core-and-cunumeric.sh
@@ -1,10 +1,10 @@
 #! /usr/bin/env bash
 
-rm -rf $(find "$CONDA_PREFIX/lib" -type d -name '*cunumeric*') \
-       $(find "$CONDA_PREFIX/lib" -type f -name 'libcunumeric*') \
-       $(find "$CONDA_PREFIX/lib" -type f -name 'cunumeric.egg-link') \
-       $(find "$CONDA_PREFIX/include" -type f -name 'tci.h') \
-       $(find "$CONDA_PREFIX/include" -type d -name 'tci') \
-       $(find "$CONDA_PREFIX/include" -type d -name 'tblis') \
-       $(find "$CONDA_PREFIX/include" -type d -name 'cunumeric') \
+rm -rf $(find "$CONDA_PREFIX/lib" -mindepth 1 -type d -name '*cunumeric*') \
+       $(find "$CONDA_PREFIX/lib" -mindepth 1 -type f -name 'libcunumeric*') \
+       $(find "$CONDA_PREFIX/lib" -mindepth 1 -type f -name 'cunumeric.egg-link') \
+       $(find "$CONDA_PREFIX/include" -mindepth 1 -type f -name 'tci.h') \
+       $(find "$CONDA_PREFIX/include" -mindepth 1 -type d -name 'tci') \
+       $(find "$CONDA_PREFIX/include" -mindepth 1 -type d -name 'tblis') \
+       $(find "$CONDA_PREFIX/include" -mindepth 1 -type d -name 'cunumeric') \
        ;


### PR DESCRIPTION
Addresses same problem as https://github.com/nv-legate/legate.core/pull/455, but in cuNumeric.