### PR TITLE
Eliminate empty kernel launch in `cunumeric.unique`

### DIFF
--- a/src/cunumeric/set/unique.cu
+++ b/src/cunumeric/set/unique.cu
@@ -153,27 +153,32 @@ struct UniqueImplBody<VariantKind::GPU, CODE, DIM> {
     // Make a copy of the input as we're going to sort it
     auto temp = create_buffer<VAL>(volume);
     VAL* ptr  = temp.ptr(0);
-    if (in.accessor.is_dense_arbitrary(rect)) {
-      auto* src = in.ptr(rect.lo);
-      CHECK_CUDA(cudaMemcpyAsync(ptr, src, sizeof(VAL) * volume, cudaMemcpyDeviceToDevice, stream));
-    } else {
-      const size_t num_blocks = (volume + THREADS_PER_BLOCK - 1) / THREADS_PER_BLOCK;
-      copy_into_buffer<<<num_blocks, THREADS_PER_BLOCK, 0, stream>>>(
-        ptr, in, rect.lo, pitches, volume);
-    }
-    CHECK_CUDA_STREAM(stream);
+    VAL* end  = ptr;
+    if (volume > 0) {
+      if (in.accessor.is_dense_arbitrary(rect)) {
+        auto* src = in.ptr(rect.lo);
+        CHECK_CUDA(
+          cudaMemcpyAsync(ptr, src, sizeof(VAL) * volume, cudaMemcpyDeviceToDevice, stream));
+      } else {
+        const size_t num_blocks = (volume + THREADS_PER_BLOCK - 1) / THREADS_PER_BLOCK;
+        copy_into_buffer<<<num_blocks, THREADS_PER_BLOCK, 0, stream>>>(
+          ptr, in, rect.lo, pitches, volume);
+      }
+      CHECK_CUDA_STREAM(stream);
 
-    // Find unique values
-    thrust::sort(thrust::cuda::par.on(stream), ptr, ptr + volume);
-    auto* end = thrust::unique(thrust::cuda::par.on(stream), ptr, ptr + volume);
+      // Find unique values
+      thrust::sort(thrust::cuda::par.on(stream), ptr, ptr + volume);
+      auto* end = thrust::unique(thrust::cuda::par.on(stream), ptr, ptr + volume);
+    }
 
     Piece<VAL> result;
     result.second = end - ptr;
     auto buf_size = (get_aligned_size(result.second * sizeof(VAL)) + sizeof(VAL) - 1) / sizeof(VAL);
     assert(end - ptr <= buf_size);
     result.first = create_buffer<VAL>(buf_size);
-    CHECK_CUDA(cudaMemcpyAsync(
-      result.first.ptr(0), ptr, sizeof(VAL) * result.second, cudaMemcpyDeviceToDevice, stream));
+    if (result.second > 0)
+      CHECK_CUDA(cudaMemcpyAsync(
+        result.first.ptr(0), ptr, sizeof(VAL) * result.second, cudaMemcpyDeviceToDevice, stream));
 
     if (comms.size() > 0) {
       // The launch domain is 1D because of the output region

--- a/tests/integration/test_unique.py
+++ b/tests/integration/test_unique.py
@@ -20,6 +20,16 @@ from legate.core import LEGATE_MAX_DIM
 import cunumeric as num
 
 
+def test_with_nonzero():
+    (a,) = num.nonzero(num.array([1, 1, 0, 0]))
+    a_np = a.__array__()
+
+    b = num.unique(a)
+    b_np = num.unique(a_np)
+
+    assert np.array_equal(b, b_np)
+
+
 @pytest.mark.parametrize("ndim", range(LEGATE_MAX_DIM + 1))
 def test_ndim(ndim):
     shape = (4,) * ndim


### PR DESCRIPTION
Fixes a bug in `cunumeric.unique` that launches an empty kernel.