### PR TITLE
Configure test overrides in the project test.py

### DIFF
--- a/test.py
+++ b/test.py
@@ -18,9 +18,26 @@ from __future__ import annotations
 
 import sys
 
+from legate.tester import PER_FILE_ARGS, SKIPPED_EXAMPLES
 from legate.tester.config import Config
 from legate.tester.test_plan import TestPlan
 from legate.tester.test_system import TestSystem
+
+SKIPPED_EXAMPLES.update(
+    {
+        "examples/ingest.py",
+        "examples/kmeans_sort.py",
+        "examples/lstm_full.py",
+        "examples/wgrad.py",
+    }
+)
+
+PER_FILE_ARGS.update(
+    {
+        "examples/lstm_full.py": ["--file", "resources/lstm_input.txt"],
+    }
+)
+
 
 if __name__ == "__main__":
     config = Config(sys.argv)


### PR DESCRIPTION
The PR moves the configuration of cunumeric-specific `SKIPPED_EXAMPLES` and `PER_FILE_ARGS` to cunumeric's `test.py` (where they belong). After this is merged, a corresponding PR in `legate.core` will change the default values in `legate.tester` to be empty. 

This is being done as part of adding support for additional overrides/customizations