### PR TITLE
Add missing put method to docs

### DIFF
--- a/docs/cunumeric/source/api/_ndarray.rst
+++ b/docs/cunumeric/source/api/_ndarray.rst
@@ -43,6 +43,7 @@ cunumeric.ndarray
       ~ndarray.nonzero
       ~ndarray.partition
       ~ndarray.prod
+      ~ndarray.put
       ~ndarray.ravel
       ~ndarray.reshape
       ~ndarray.searchsorted

--- a/docs/cunumeric/source/api/ndarray.rst
+++ b/docs/cunumeric/source/api/ndarray.rst
@@ -124,7 +124,7 @@ Item selection and manipulation
    :toctree: generated/
 
    ndarray.take
-   .. ndarray.put
+   ndarray.put
    .. ndarray.repeat
    ndarray.choose
    ndarray.sort


### PR DESCRIPTION
This PR adds the `ndarray.put` method to the docs, which was causing the docs build to fail. 