### PR TITLE
mypy pre-commit hook for local but not CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,11 @@
 repos:
+    - repo: https://github.com/pre-commit/mirrors-mypy
+      rev: 'v0.982'
+      hooks:
+        - id: mypy
+          language: system
+          pass_filenames: false
+          args: ['cunumeric']
     - repo: https://github.com/PyCQA/isort
       rev: 5.10.1
       hooks:
@@ -25,5 +32,9 @@ repos:
           entry: python scripts/hooks/enforce_pytest_main.py
           language: python
           pass_filenames: false
+
+ci:
+  skip: [mypy]
+
 default_language_version:
     python: python3


### PR DESCRIPTION
It's difficult to run `mypy` on cunumeric in the `pre-commit.ci` service due to our complicated build, but it is possible to only run it locally (which works find in a dev env)  and leave Mypy on CI to the full post-build test job. 
