### PR TITLE
Add CI job to build docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,7 @@ jobs:
           - {name: 2 OpenMPs test, options: --use openmp --omps 2 --ompthreads 2 --debug, log: omps}
           - {name: Eager execution test, options: --use eager --debug, log: eager}
           - {name: mypy, options: mypy, log: mypy}
+          - {name: documentation, options: docs, log: docs}
     name: ${{ matrix.name }}
     steps:
       - name: Dump GitHub context


### PR DESCRIPTION
This PR adds a CI job to build the documentation, so that a PR will fail if the docs are not build-able. Currently the build docs are not saved off anywhere, but this could be potentially done. 