### PR TITLE
Minor test QOL improvements: make cunumeric  imports consistent

### DIFF
--- a/tests/integration/test_array_dunders.py
+++ b/tests/integration/test_array_dunders.py
@@ -18,64 +18,73 @@ import pytest
 
 import cunumeric as num
 
-np_arr = np.eye(4)
-np_vec = np.arange(4).astype(np.float64)
-num_arr = num.array(np_arr)
-num_vec = num.array(np_vec)
+arr_np = np.eye(4)
+vec_np = np.arange(4).astype(np.float64)
+
+arr_num = num.array(arr_np)
+vec_num = num.array(vec_np)
+
 indices = [0, 3, 1, 2]
 
 
 def test_array_function_implemented():
-    res_np = np.dot(np_arr, np_vec)
-    res_num = np.dot(num_arr, num_vec)
+    res_np = np.dot(arr_np, vec_np)
+    res_num = np.dot(arr_num, vec_num)
+
     assert np.array_equal(res_np, res_num)
     assert isinstance(res_num, num.ndarray)  # implemented
 
 
 def test_array_function_unimplemented():
-    res_np = np.linalg.tensorsolve(np_arr, np_vec)
-    res_num = np.linalg.tensorsolve(num_arr, num_vec)
+    res_np = np.linalg.tensorsolve(arr_np, vec_np)
+    res_num = np.linalg.tensorsolve(arr_num, vec_num)
+
     assert np.array_equal(res_np, res_num)
     assert isinstance(res_num, np.ndarray)  # unimplemented
 
 
 def test_array_ufunc_through_array_op():
-    assert np.array_equal(num_vec + num_vec, np_vec + np_vec)
-    assert isinstance(num_vec + np_vec, num.ndarray)
-    assert isinstance(np_vec + num_vec, num.ndarray)
+    assert np.array_equal(vec_num + vec_num, vec_np + vec_np)
+    assert isinstance(vec_num + vec_np, num.ndarray)
+    assert isinstance(vec_np + vec_num, num.ndarray)
 
 
 def test_array_ufunc_call():
-    res_np = np.add(np_vec, np_vec)
-    res_num = np.add(num_vec, num_vec)
+    res_np = np.add(vec_np, vec_np)
+    res_num = np.add(vec_num, vec_num)
+
     assert np.array_equal(res_np, res_num)
     assert isinstance(res_num, num.ndarray)  # implemented
 
 
 def test_array_ufunc_reduce():
-    res_np = np.add.reduce(np_vec)
-    res_num = np.add.reduce(num_vec)
+    res_np = np.add.reduce(vec_np)
+    res_num = np.add.reduce(vec_num)
+
     assert np.array_equal(res_np, res_num)
     assert isinstance(res_num, num.ndarray)  # implemented
 
 
 def test_array_ufunc_accumulate():
-    res_np = np.add.accumulate(np_vec)
-    res_num = np.add.accumulate(num_vec)
+    res_np = np.add.accumulate(vec_np)
+    res_num = np.add.accumulate(vec_num)
+
     assert np.array_equal(res_np, res_num)
     assert isinstance(res_num, np.ndarray)  # unimplemented
 
 
 def test_array_ufunc_reduceat():
-    res_np = np.add.reduceat(np_vec, indices)
-    res_num = np.add.reduceat(num_vec, indices)
+    res_np = np.add.reduceat(vec_np, indices)
+    res_num = np.add.reduceat(vec_num, indices)
+
     assert np.array_equal(res_np, res_num)
     assert isinstance(res_num, np.ndarray)  # unimplemented
 
 
 def test_array_ufunc_outer():
-    res_np = np.add.outer(np_vec, np_vec)
-    res_num = np.add.outer(num_vec, num_vec)
+    res_np = np.add.outer(vec_np, vec_np)
+    res_num = np.add.outer(vec_num, vec_num)
+
     assert np.array_equal(res_np, res_num)
     assert isinstance(res_num, np.ndarray)  # unimplemented
 
@@ -83,8 +92,10 @@ def test_array_ufunc_outer():
 def test_array_ufunc_at():
     res_np = np.full((4,), 42)
     res_num = num.full((4,), 42)
-    np.add.at(res_np, indices, np_vec)
-    np.add.at(res_num, indices, num_vec)
+
+    np.add.at(res_np, indices, vec_np)
+    np.add.at(res_num, indices, vec_num)
+
     assert np.array_equal(res_np, res_num)
     assert isinstance(res_num, num.ndarray)
 

--- a/tests/integration/test_array_dunders.py
+++ b/tests/integration/test_array_dunders.py
@@ -16,77 +16,77 @@
 import numpy as np
 import pytest
 
-import cunumeric as cn
+import cunumeric as num
 
 np_arr = np.eye(4)
 np_vec = np.arange(4).astype(np.float64)
-cn_arr = cn.array(np_arr)
-cn_vec = cn.array(np_vec)
+num_arr = num.array(np_arr)
+num_vec = num.array(np_vec)
 indices = [0, 3, 1, 2]
 
 
 def test_array_function_implemented():
-    np_res = np.dot(np_arr, np_vec)
-    cn_res = np.dot(cn_arr, cn_vec)
-    assert np.array_equal(np_res, cn_res)
-    assert isinstance(cn_res, cn.ndarray)  # implemented
+    res_np = np.dot(np_arr, np_vec)
+    res_num = np.dot(num_arr, num_vec)
+    assert np.array_equal(res_np, res_num)
+    assert isinstance(res_num, num.ndarray)  # implemented
 
 
 def test_array_function_unimplemented():
-    np_res = np.linalg.tensorsolve(np_arr, np_vec)
-    cn_res = np.linalg.tensorsolve(cn_arr, cn_vec)
-    assert np.array_equal(np_res, cn_res)
-    assert isinstance(cn_res, np.ndarray)  # unimplemented
+    res_np = np.linalg.tensorsolve(np_arr, np_vec)
+    res_num = np.linalg.tensorsolve(num_arr, num_vec)
+    assert np.array_equal(res_np, res_num)
+    assert isinstance(res_num, np.ndarray)  # unimplemented
 
 
 def test_array_ufunc_through_array_op():
-    assert np.array_equal(cn_vec + cn_vec, np_vec + np_vec)
-    assert isinstance(cn_vec + np_vec, cn.ndarray)
-    assert isinstance(np_vec + cn_vec, cn.ndarray)
+    assert np.array_equal(num_vec + num_vec, np_vec + np_vec)
+    assert isinstance(num_vec + np_vec, num.ndarray)
+    assert isinstance(np_vec + num_vec, num.ndarray)
 
 
 def test_array_ufunc_call():
-    np_res = np.add(np_vec, np_vec)
-    cn_res = np.add(cn_vec, cn_vec)
-    assert np.array_equal(np_res, cn_res)
-    assert isinstance(cn_res, cn.ndarray)  # implemented
+    res_np = np.add(np_vec, np_vec)
+    res_num = np.add(num_vec, num_vec)
+    assert np.array_equal(res_np, res_num)
+    assert isinstance(res_num, num.ndarray)  # implemented
 
 
 def test_array_ufunc_reduce():
-    np_res = np.add.reduce(np_vec)
-    cn_res = np.add.reduce(cn_vec)
-    assert np.array_equal(np_res, cn_res)
-    assert isinstance(cn_res, cn.ndarray)  # implemented
+    res_np = np.add.reduce(np_vec)
+    res_num = np.add.reduce(num_vec)
+    assert np.array_equal(res_np, res_num)
+    assert isinstance(res_num, num.ndarray)  # implemented
 
 
 def test_array_ufunc_accumulate():
-    np_res = np.add.accumulate(np_vec)
-    cn_res = np.add.accumulate(cn_vec)
-    assert np.array_equal(np_res, cn_res)
-    assert isinstance(cn_res, np.ndarray)  # unimplemented
+    res_np = np.add.accumulate(np_vec)
+    res_num = np.add.accumulate(num_vec)
+    assert np.array_equal(res_np, res_num)
+    assert isinstance(res_num, np.ndarray)  # unimplemented
 
 
 def test_array_ufunc_reduceat():
-    np_res = np.add.reduceat(np_vec, indices)
-    cn_res = np.add.reduceat(cn_vec, indices)
-    assert np.array_equal(np_res, cn_res)
-    assert isinstance(cn_res, np.ndarray)  # unimplemented
+    res_np = np.add.reduceat(np_vec, indices)
+    res_num = np.add.reduceat(num_vec, indices)
+    assert np.array_equal(res_np, res_num)
+    assert isinstance(res_num, np.ndarray)  # unimplemented
 
 
 def test_array_ufunc_outer():
-    np_res = np.add.outer(np_vec, np_vec)
-    cn_res = np.add.outer(cn_vec, cn_vec)
-    assert np.array_equal(np_res, cn_res)
-    assert isinstance(cn_res, np.ndarray)  # unimplemented
+    res_np = np.add.outer(np_vec, np_vec)
+    res_num = np.add.outer(num_vec, num_vec)
+    assert np.array_equal(res_np, res_num)
+    assert isinstance(res_num, np.ndarray)  # unimplemented
 
 
 def test_array_ufunc_at():
-    np_res = np.full((4,), 42)
-    cn_res = cn.full((4,), 42)
-    np.add.at(np_res, indices, np_vec)
-    np.add.at(cn_res, indices, cn_vec)
-    assert np.array_equal(np_res, cn_res)
-    assert isinstance(cn_res, cn.ndarray)
+    res_np = np.full((4,), 42)
+    res_num = num.full((4,), 42)
+    np.add.at(res_np, indices, np_vec)
+    np.add.at(res_num, indices, num_vec)
+    assert np.array_equal(res_np, res_num)
+    assert isinstance(res_num, num.ndarray)
 
 
 if __name__ == "__main__":

--- a/tests/integration/test_diag_indices.py
+++ b/tests/integration/test_diag_indices.py
@@ -17,62 +17,62 @@ import numpy as np
 import pytest
 from legate.core import LEGATE_MAX_DIM
 
-import cunumeric as cn
+import cunumeric as num
 
 
 def test_diag_indices_default_ndim():
-    np_res = np.diag_indices(10)
-    cn_res = cn.diag_indices(10)
-    assert np.array_equal(np_res, cn_res)
+    a_np = np.diag_indices(10)
+    a_num = num.diag_indices(10)
+    assert np.array_equal(a_np, a_num)
 
 
 @pytest.mark.parametrize("ndim", range(0, LEGATE_MAX_DIM + 1))
 def test_diag_indices_basic(ndim):
-    np_res = np.diag_indices(10, ndim)
-    cn_res = cn.diag_indices(10, ndim)
-    assert np.array_equal(np_res, cn_res)
+    a_np = np.diag_indices(10, ndim)
+    a_num = num.diag_indices(10, ndim)
+    assert np.array_equal(a_np, a_num)
 
 
 @pytest.mark.parametrize("n", [0, 0.0, 1, 10.5])
 @pytest.mark.parametrize("ndim", [-4, 0, 1])
 def test_diag_indices(n, ndim):
-    np_res = np.diag_indices(n, ndim)
-    cn_res = cn.diag_indices(n, ndim)
-    assert np.array_equal(np_res, cn_res)
+    a_np = np.diag_indices(n, ndim)
+    a_num = num.diag_indices(n, ndim)
+    assert np.array_equal(a_np, a_num)
 
 
 class TestDiagIndicesErrors:
     @pytest.mark.parametrize("n", [-10.5, -1])
     def test_negative_n(self, n):
         with pytest.raises(ValueError):
-            cn.diag_indices(n)
+            num.diag_indices(n)
 
     @pytest.mark.xfail
     @pytest.mark.parametrize("n", [-10.5, -1])
     def test_negative_n_DIVERGENCE(self, n):
         # np.diag_indices(-10.5) returns empty 2-D array, dtype=float64
         # np.diag_indices(-1) returns empty 2-D array, dtype=int32
-        # cn.diag_indices(-10.5) raises ValueError
-        # cn.diag_indices(-1) raises ValueError
-        np_res = np.diag_indices(n)
-        cn_res = cn.diag_indices(n)
-        assert np.array_equal(np_res, cn_res)
+        # num.diag_indices(-10.5) raises ValueError
+        # num.diag_indices(-1) raises ValueError
+        a_np = np.diag_indices(n)
+        a_num = num.diag_indices(n)
+        assert np.array_equal(a_np, a_num)
 
     def test_none_n(self):
         msg = "unsupported operand type"
         with pytest.raises(TypeError, match=msg):
-            cn.diag_indices(None)
+            num.diag_indices(None)
 
     @pytest.mark.parametrize("ndim", [-1.5, 0.0, 1.5])
     def test_float_ndim(self, ndim):
         msg = "can't multiply sequence by non-int of type 'float'"
         with pytest.raises(TypeError, match=msg):
-            cn.diag_indices(10, ndim)
+            num.diag_indices(10, ndim)
 
     def test_none_ndim(self):
         msg = "can't multiply sequence by non-int of type 'NoneType'"
         with pytest.raises(TypeError, match=msg):
-            cn.diag_indices(10, None)
+            num.diag_indices(10, None)
 
 
 @pytest.mark.parametrize("size", [(5,), (0,)], ids=str)
@@ -80,10 +80,10 @@ class TestDiagIndicesErrors:
 def test_diag_indices_from_basic(size, ndim):
     shape = size * ndim
     a = np.ones(shape, dtype=int)
-    a_cn = cn.array(a)
-    np_res = np.diag_indices_from(a)
-    cn_res = cn.diag_indices_from(a_cn)
-    assert np.array_equal(np_res, cn_res)
+    a_num = num.array(a)
+    a_np = np.diag_indices_from(a)
+    a_num = num.diag_indices_from(a_num)
+    assert np.array_equal(a_np, a_num)
 
 
 class TestDiagIndicesFromErrors:
@@ -92,13 +92,13 @@ class TestDiagIndicesFromErrors:
         a = np.ones(size, dtype=int)
         msg = "input array must be at least 2-d"
         with pytest.raises(ValueError, match=msg):
-            cn.diag_indices_from(a)
+            num.diag_indices_from(a)
 
     def test_0d(self):
         a = np.array(3)
         msg = "input array must be at least 2-d"
         with pytest.raises(ValueError, match=msg):
-            cn.diag_indices_from(a)
+            num.diag_indices_from(a)
 
     @pytest.mark.parametrize(
         "size",
@@ -115,7 +115,7 @@ class TestDiagIndicesFromErrors:
         a = np.ones(size, dtype=int)
         msg = "All dimensions of input must be of equal length"
         with pytest.raises(ValueError, match=msg):
-            cn.diag_indices_from(a)
+            num.diag_indices_from(a)
 
 
 if __name__ == "__main__":

--- a/tests/integration/test_einsum.py
+++ b/tests/integration/test_einsum.py
@@ -22,7 +22,7 @@ import pytest
 from utils.comparisons import allclose
 from utils.generators import mk_0to1_array, permutes_to
 
-import cunumeric as cn
+import cunumeric as num
 
 # Limits for exhaustive expression generation routines
 MAX_MODES = 3
@@ -213,48 +213,48 @@ def mk_typed_output(lib, shape):
     ]
 
 
-def check_np_vs_cn(expr, mk_input, mk_output=None, **kwargs):
+def check_np_vs_num(expr, mk_input, mk_output=None, **kwargs):
     lhs, rhs = expr.split("->")
     opers = lhs.split(",")
     in_shapes = [
         tuple(BASE_DIM_LEN + ord(m) - ord("a") for m in op) for op in opers
     ]
     out_shape = tuple(BASE_DIM_LEN + ord(m) - ord("a") for m in rhs)
-    for (np_inputs, cn_inputs) in zip(
+    for (np_inputs, num_inputs) in zip(
         product(*(mk_input(np, sh) for sh in in_shapes)),
-        product(*(mk_input(cn, sh) for sh in in_shapes)),
+        product(*(mk_input(num, sh) for sh in in_shapes)),
     ):
         np_res = np.einsum(expr, *np_inputs, **kwargs)
-        cn_res = cn.einsum(expr, *cn_inputs, **kwargs)
+        num_res = num.einsum(expr, *num_inputs, **kwargs)
         rtol = (
             1e-02
             if any(x.dtype == np.float16 for x in np_inputs)
             or kwargs.get("dtype") == np.float16
             else 1e-05
         )
-        assert allclose(np_res, cn_res, rtol=rtol)
+        assert allclose(np_res, num_res, rtol=rtol)
         if mk_output is not None:
-            for cn_out in mk_output(cn, out_shape):
-                cn.einsum(expr, *cn_inputs, out=cn_out, **kwargs)
-                rtol_out = 1e-02 if cn_out.dtype == np.float16 else rtol
-                assert allclose(cn_out, cn_res, rtol=rtol_out)
+            for num_out in mk_output(num, out_shape):
+                num.einsum(expr, *num_inputs, out=num_out, **kwargs)
+                rtol_out = 1e-02 if num_out.dtype == np.float16 else rtol
+                assert allclose(num_out, num_res, rtol=rtol_out)
 
 
 @pytest.mark.parametrize("expr", gen_expr())
 def test_small(expr):
-    check_np_vs_cn(expr, mk_input_that_permutes_to)
-    check_np_vs_cn(expr, mk_input_that_broadcasts_to)
+    check_np_vs_num(expr, mk_input_that_permutes_to)
+    check_np_vs_num(expr, mk_input_that_broadcasts_to)
 
 
 @pytest.mark.parametrize("expr", LARGE_EXPRS)
 def test_large(expr):
-    check_np_vs_cn(expr, mk_input_default)
+    check_np_vs_num(expr, mk_input_default)
 
 
 @pytest.mark.parametrize("expr", SMALL_EXPRS)
 @pytest.mark.parametrize("dtype", [None, np.float32])
 def test_cast(expr, dtype):
-    check_np_vs_cn(
+    check_np_vs_num(
         expr, mk_typed_input, mk_typed_output, dtype=dtype, casting="unsafe"
     )
 

--- a/tests/integration/test_einsum_path.py
+++ b/tests/integration/test_einsum_path.py
@@ -16,15 +16,15 @@
 import numpy as np
 import pytest
 
-import cunumeric as cn
+import cunumeric as num
 
 expr = "ij,jk,kl->il"
 np_a = np.empty((2, 2))
 np_b = np.empty((2, 5))
 np_c = np.empty((5, 2))
-cn_a = cn.empty((2, 2))
-cn_b = cn.empty((2, 5))
-cn_c = cn.empty((5, 2))
+num_a = num.empty((2, 2))
+num_b = num.empty((2, 5))
+num_c = num.empty((5, 2))
 
 OPTIMIZE = [
     True,
@@ -38,9 +38,9 @@ OPTIMIZE = [
 
 @pytest.mark.parametrize("optimize", OPTIMIZE)
 def test_einsum_path(optimize):
-    np_path, _ = np.einsum_path(expr, np_a, np_b, np_c, optimize=optimize)
-    cn_path, _ = cn.einsum_path(expr, cn_a, cn_b, cn_c, optimize=optimize)
-    assert np_path == cn_path
+    path_np, _ = np.einsum_path(expr, np_a, np_b, np_c, optimize=optimize)
+    path_num, _ = num.einsum_path(expr, num_a, num_b, num_c, optimize=optimize)
+    assert path_np == path_num
 
 
 if __name__ == "__main__":

--- a/tests/integration/test_indices.py
+++ b/tests/integration/test_indices.py
@@ -19,7 +19,7 @@ import numpy as np
 import pytest
 from legate.core import LEGATE_MAX_DIM
 
-import cunumeric as cn
+import cunumeric as num
 
 
 class TestIndicesErrors:
@@ -32,19 +32,19 @@ class TestIndicesErrors:
         dimensions = 3
         msg = r"'int' object is not iterable"
         with pytest.raises(TypeError, match=msg):
-            cn.indices(dimensions)
+            num.indices(dimensions)
 
     def test_negative_dimensions(self):
         dimensions = -3
         msg = r"'int' object is not iterable"
         with pytest.raises(TypeError, match=msg):
-            cn.indices(dimensions)
+            num.indices(dimensions)
 
     def test_float_dimensions(self):
         dimensions = 3.2
         msg = r"'float' object is not iterable"
         with pytest.raises(TypeError, match=msg):
-            cn.indices(dimensions)
+            num.indices(dimensions)
 
     def test_negative_tuple_dimensions(self):
         dimensions = (1, -1)
@@ -54,7 +54,7 @@ class TestIndicesErrors:
         # in other conditions, it raises
         # "ValueError: Invalid shape: Shape((2, 1, -1))"
         with pytest.raises(ValueError):
-            cn.indices(dimensions)
+            num.indices(dimensions)
 
     def test_float_tuple_dimensions(self):
         dimensions = (3.5, 2.5)
@@ -62,7 +62,7 @@ class TestIndicesErrors:
         # "TypeError: 'float' object cannot be interpreted as an integer"
         msg = r"expected a sequence of integers or a single integer"
         with pytest.raises(TypeError, match=msg):
-            cn.indices(dimensions)
+            num.indices(dimensions)
 
 
 class TestIndices:
@@ -73,40 +73,40 @@ class TestIndices:
     @pytest.mark.parametrize("dimensions", [(0,), (0, 0), (0, 1), (1, 1)])
     def test_indices_zero(self, dimensions):
         np_res = np.indices(dimensions)
-        cn_res = cn.indices(dimensions)
+        num_res = num.indices(dimensions)
 
-        assert np.array_equal(np_res, cn_res)
+        assert np.array_equal(np_res, num_res)
 
     @pytest.mark.parametrize("ndim", range(0, LEGATE_MAX_DIM))
     def test_indices_basic(self, ndim):
-        dimensions = tuple(random.randint(1, 5) for i in range(ndim))
+        dimensions = tuple(random.randint(1, 5) for _ in range(ndim))
 
         np_res = np.indices(dimensions)
-        cn_res = cn.indices(dimensions)
-        assert np.array_equal(np_res, cn_res)
+        num_res = num.indices(dimensions)
+        assert np.array_equal(np_res, num_res)
 
     @pytest.mark.parametrize("ndim", range(0, LEGATE_MAX_DIM))
     def test_indices_dtype_none(self, ndim):
-        dimensions = tuple(random.randint(1, 5) for i in range(ndim))
+        dimensions = tuple(random.randint(1, 5) for _ in range(ndim))
 
         np_res = np.indices(dimensions, dtype=None)
-        cn_res = cn.indices(dimensions, dtype=None)
-        assert np.array_equal(np_res, cn_res)
+        num_res = num.indices(dimensions, dtype=None)
+        assert np.array_equal(np_res, num_res)
 
     @pytest.mark.parametrize("ndim", range(0, LEGATE_MAX_DIM))
     def test_indices_dtype_float(self, ndim):
-        dimensions = tuple(random.randint(1, 5) for i in range(ndim))
+        dimensions = tuple(random.randint(1, 5) for _ in range(ndim))
         np_res = np.indices(dimensions, dtype=float)
-        cn_res = cn.indices(dimensions, dtype=float)
-        assert np.array_equal(np_res, cn_res)
+        num_res = num.indices(dimensions, dtype=float)
+        assert np.array_equal(np_res, num_res)
 
     @pytest.mark.parametrize("ndim", range(0, LEGATE_MAX_DIM))
     def test_indices_sparse(self, ndim):
-        dimensions = tuple(random.randint(1, 5) for i in range(ndim))
+        dimensions = tuple(random.randint(1, 5) for _ in range(ndim))
         np_res = np.indices(dimensions, sparse=True)
-        cn_res = cn.indices(dimensions, sparse=True)
+        num_res = num.indices(dimensions, sparse=True)
         for i in range(len(np_res)):
-            assert np.array_equal(np_res[i], cn_res[i])
+            assert np.array_equal(np_res[i], num_res[i])
 
 
 if __name__ == "__main__":

--- a/tests/integration/test_ingest.py
+++ b/tests/integration/test_ingest.py
@@ -25,7 +25,7 @@ from legate.core import (
     legion,
 )
 
-import cunumeric as lg
+import cunumeric as num
 
 tile_shape = (4, 7)
 colors = (5, 3)
@@ -80,7 +80,7 @@ def _ingest(custom_partitioning, custom_sharding):
         get_buffer,
         get_local_colors if custom_sharding else None,
     )
-    return lg.array(tab)
+    return num.array(tab)
 
 
 @pytest.mark.parametrize("custom_sharding", [True, False])
@@ -89,10 +89,10 @@ def test(custom_partitioning, custom_sharding):
     size = 1
     for d in shape:
         size *= d
-    np_arr = np.arange(size).reshape(shape)
-    lg_arr = _ingest(custom_partitioning, custom_sharding)
-    assert np.array_equal(np_arr, lg_arr)
-    assert np.array_equal(np_arr, lg_arr * 1.0)  # force a copy
+    a_np = np.arange(size).reshape(shape)
+    a_num = _ingest(custom_partitioning, custom_sharding)
+    assert np.array_equal(a_np, a_num)
+    assert np.array_equal(a_np, a_num * 1.0)  # force a copy
 
 
 if __name__ == "__main__":

--- a/tests/integration/test_lstm_simple_forward.py
+++ b/tests/integration/test_lstm_simple_forward.py
@@ -14,7 +14,7 @@
 #
 import pytest
 
-import cunumeric as np
+import cunumeric as num
 
 
 def test_basic():
@@ -22,27 +22,27 @@ def test_basic():
     hidden_size = 10
     sentence_length = 2
     batch_size = 3
-    X = np.random.randn(sentence_length, batch_size, hidden_size)
-    h0 = np.random.randn(1, hidden_size)
-    WLSTM = np.random.randn(
+    X = num.random.randn(sentence_length, batch_size, hidden_size)
+    h0 = num.random.randn(1, hidden_size)
+    WLSTM = num.random.randn(
         word_size + hidden_size, 4 * hidden_size
-    ) / np.sqrt(word_size + hidden_size)
+    ) / num.sqrt(word_size + hidden_size)
 
     xphpb = WLSTM.shape[0]
     d = hidden_size
     n = sentence_length
     b = batch_size
 
-    Hin = np.zeros((n, b, xphpb))
-    Hout = np.zeros((n, b, d))
-    IFOG = np.zeros((n, b, d * 4))
-    IFOGf = np.zeros((n, b, d * 4))
-    C = np.zeros((n, b, d))
-    Ct = np.zeros((n, b, d))
+    Hin = num.zeros((n, b, xphpb))
+    Hout = num.zeros((n, b, d))
+    IFOG = num.zeros((n, b, d * 4))
+    IFOGf = num.zeros((n, b, d * 4))
+    C = num.zeros((n, b, d))
+    Ct = num.zeros((n, b, d))
 
     for t in range(0, n):
         if t == 0:
-            prev = np.tile(h0, (b, 1))
+            prev = num.tile(h0, (b, 1))
         else:
             prev = Hout[t - 1]
 
@@ -52,14 +52,14 @@ def test_basic():
         IFOG[t] = Hin[t].dot(WLSTM)
         # non-linearities
         IFOGf[t, :, : 3 * d] = 1.0 / (
-            1.0 + np.exp(-IFOG[t, :, : 3 * d])
+            1.0 + num.exp(-IFOG[t, :, : 3 * d])
         )  # sigmoids these are the gates
-        IFOGf[t, :, 3 * d :] = np.tanh(IFOG[t, :, 3 * d :])  # tanh
+        IFOGf[t, :, 3 * d :] = num.tanh(IFOG[t, :, 3 * d :])  # tanh
         # compute the cell activation
         C[t] = IFOGf[t, :, :d] * IFOGf[t, :, 3 * d :]
         if t > 0:
             C[t] += IFOGf[t, :, d : 2 * d] * C[t - 1]
-        Ct[t] = np.tanh(C[t])
+        Ct[t] = num.tanh(C[t])
         Hout[t] = IFOGf[t, :, 2 * d : 3 * d] * Ct[t]
 
 

--- a/tests/integration/test_matrix_power.py
+++ b/tests/integration/test_matrix_power.py
@@ -19,7 +19,7 @@ from legate.core import LEGATE_MAX_DIM
 from utils.comparisons import allclose
 from utils.generators import mk_0to1_array
 
-import cunumeric as cn
+import cunumeric as num
 
 # TODO: add negative exponents here, once they become supported
 EXPONENTS = [0, 1, 3, 5]
@@ -29,11 +29,11 @@ EXPONENTS = [0, 1, 3, 5]
 @pytest.mark.parametrize("exp", EXPONENTS)
 def test_matrix_power(ndim, exp):
     shape = (3,) * ndim + (2, 2)
-    np_a = mk_0to1_array(np, shape)
-    cn_a = mk_0to1_array(cn, shape)
-    np_res = np.linalg.matrix_power(np_a, exp)
-    cn_res = cn.linalg.matrix_power(cn_a, exp)
-    assert allclose(np_res, cn_res)
+    a_np = mk_0to1_array(np, shape)
+    a_num = mk_0to1_array(num, shape)
+    res_np = np.linalg.matrix_power(a_np, exp)
+    res_num = num.linalg.matrix_power(a_num, exp)
+    assert allclose(res_np, res_num)
 
 
 if __name__ == "__main__":

--- a/tests/integration/test_min_on_gpu.py
+++ b/tests/integration/test_min_on_gpu.py
@@ -15,12 +15,12 @@
 
 import pytest
 
-import cunumeric as cn
+import cunumeric as num
 
 
 def test_min():
-    x = cn.array([1, 2, 3])
-    assert cn.min(x) == 1
+    x = num.array([1, 2, 3])
+    assert num.min(x) == 1
 
 
 if __name__ == "__main__":

--- a/tests/integration/test_moveaxis.py
+++ b/tests/integration/test_moveaxis.py
@@ -18,7 +18,7 @@ import pytest
 from legate.core import LEGATE_MAX_DIM
 from utils.generators import mk_0to1_array
 
-import cunumeric as cn
+import cunumeric as num
 
 AXES = (
     (0, 0),
@@ -34,26 +34,26 @@ AXES = (
 @pytest.mark.parametrize("axes", AXES)
 def test_moveaxis(ndim, axes):
     source, destination = axes
-    np_a = mk_0to1_array(np, (3,) * ndim)
-    cn_a = mk_0to1_array(cn, (3,) * ndim)
-    np_res = np.moveaxis(np_a, source, destination)
-    cn_res = cn.moveaxis(cn_a, source, destination)
-    assert np.array_equal(np_res, cn_res)
+    a_np = mk_0to1_array(np, (3,) * ndim)
+    a_num = mk_0to1_array(num, (3,) * ndim)
+    res_np = np.moveaxis(a_np, source, destination)
+    res_num = num.moveaxis(a_num, source, destination)
+    assert np.array_equal(res_np, res_num)
     # Check that the returned array is a view
-    cn_res[:] = 0
-    assert cn_a.sum() == 0
+    res_num[:] = 0
+    assert a_num.sum() == 0
 
 
 def test_moveaxis_with_empty_axis():
-    np_a = np.ones((3, 4, 5))
-    cn_a = cn.ones((3, 4, 5))
+    a_np = np.ones((3, 4, 5))
+    a_num = num.ones((3, 4, 5))
 
     axes = ([], [])
     source, destination = axes
 
-    np_res = np.moveaxis(np_a, source, destination)
-    cn_res = cn.moveaxis(cn_a, source, destination)
-    assert np.array_equal(np_res, cn_res)
+    res_np = np.moveaxis(a_np, source, destination)
+    res_num = num.moveaxis(a_num, source, destination)
+    assert np.array_equal(res_np, res_num)
 
 
 EMPTY_ARRAYS = (
@@ -68,57 +68,57 @@ def test_moveaxis_with_empty_array(a):
     axes = (0, -1)
     source, destination = axes
 
-    np_res = np.moveaxis(a, source, destination)
-    cn_res = cn.moveaxis(a, source, destination)
-    assert np.array_equal(np_res, cn_res)
+    res_np = np.moveaxis(a, source, destination)
+    res_num = num.moveaxis(a, source, destination)
+    assert np.array_equal(res_np, res_num)
 
 
 class TestMoveAxisErrors:
     def setup(self):
-        self.x = cn.ones((3, 4, 5))
+        self.x = num.ones((3, 4, 5))
 
     def test_repeated_axis(self):
         msg = "repeated axis"
         with pytest.raises(ValueError, match=msg):
-            cn.moveaxis(self.x, [0, 0], [1, 0])
+            num.moveaxis(self.x, [0, 0], [1, 0])
 
         with pytest.raises(ValueError, match=msg):
-            cn.moveaxis(self.x, [0, 1], [0, -3])
+            num.moveaxis(self.x, [0, 1], [0, -3])
 
     def test_axis_out_of_bound(self):
         msg = "out of bound"
         with pytest.raises(np.AxisError, match=msg):
-            cn.moveaxis(self.x, [0, 3], [0, 1])
+            num.moveaxis(self.x, [0, 3], [0, 1])
 
         with pytest.raises(np.AxisError, match=msg):
-            cn.moveaxis(self.x, [0, 1], [0, -4])
+            num.moveaxis(self.x, [0, 1], [0, -4])
 
         with pytest.raises(np.AxisError, match=msg):
-            cn.moveaxis(self.x, 4, 0)
+            num.moveaxis(self.x, 4, 0)
 
         with pytest.raises(np.AxisError, match=msg):
-            cn.moveaxis(self.x, 0, -4)
+            num.moveaxis(self.x, 0, -4)
 
     def test_axis_with_different_length(self):
         msg = "arguments must have the same number of elements"
         with pytest.raises(ValueError, match=msg):
-            cn.moveaxis(self.x, [0], [1, 0])
+            num.moveaxis(self.x, [0], [1, 0])
 
     def test_axis_float(self):
         msg = "integer argument expected, got float"
         with pytest.raises(TypeError, match=msg):
-            cn.moveaxis(self.x, [0.0, 1], [1, 0])
+            num.moveaxis(self.x, [0.0, 1], [1, 0])
 
         with pytest.raises(TypeError, match=msg):
-            cn.moveaxis(self.x, [0, 1], [1, 0.0])
+            num.moveaxis(self.x, [0, 1], [1, 0.0])
 
     def test_axis_none(self):
         msg = "'NoneType' object is not iterable"
         with pytest.raises(TypeError, match=msg):
-            cn.moveaxis(self.x, None, 0)
+            num.moveaxis(self.x, None, 0)
 
         with pytest.raises(TypeError, match=msg):
-            cn.moveaxis(self.x, 0, None)
+            num.moveaxis(self.x, 0, None)
 
 
 if __name__ == "__main__":

--- a/tests/integration/test_multi_dot.py
+++ b/tests/integration/test_multi_dot.py
@@ -18,7 +18,7 @@ import pytest
 from utils.comparisons import allclose
 from utils.generators import mk_0to1_array
 
-import cunumeric as cn
+import cunumeric as num
 
 SHAPES = [
     # 2 arrays
@@ -42,28 +42,28 @@ SHAPES = [
 @pytest.mark.parametrize("shapes", SHAPES)
 def test_multi_dot(shapes):
     np_arrays = [mk_0to1_array(np, shape) for shape in shapes]
-    cn_arrays = [mk_0to1_array(cn, shape) for shape in shapes]
-    np_res = np.linalg.multi_dot(np_arrays)
-    cn_res = cn.linalg.multi_dot(cn_arrays)
-    assert allclose(np_res, cn_res)
+    num_arrays = [mk_0to1_array(num, shape) for shape in shapes]
+    res_np = np.linalg.multi_dot(np_arrays)
+    res_num = num.linalg.multi_dot(num_arrays)
+    assert allclose(res_np, res_num)
 
     if len(shapes[0]) == 1:
         if len(shapes[-1]) == 1:
-            out = cn.zeros(())
+            out = num.zeros(())
         else:
-            out = cn.zeros((shapes[-1][1],))
+            out = num.zeros((shapes[-1][1],))
     else:
         if len(shapes[-1]) == 1:
-            out = cn.zeros((shapes[0][0],))
+            out = num.zeros((shapes[0][0],))
         else:
-            out = cn.zeros(
+            out = num.zeros(
                 (
                     shapes[0][0],
                     shapes[-1][1],
                 )
             )
-    cn_res = cn.linalg.multi_dot(cn_arrays, out=out)
-    assert allclose(np_res, out)
+    res_num = num.linalg.multi_dot(num_arrays, out=out)
+    assert allclose(res_np, out)
 
 
 if __name__ == "__main__":

--- a/tests/integration/test_norm.py
+++ b/tests/integration/test_norm.py
@@ -19,7 +19,7 @@ from legate.core import LEGATE_MAX_DIM
 from utils.comparisons import allclose
 from utils.generators import mk_0to1_array
 
-import cunumeric as cn
+import cunumeric as num
 
 VECTOR_ORDS = [None, np.inf, -np.inf, 0, 1, -1, 2, -2]
 
@@ -30,8 +30,8 @@ np_arrays = [
     mk_0to1_array(np, (3,) * ndim) - 0.5
     for ndim in range(0, LEGATE_MAX_DIM + 1)
 ]
-cn_arrays = [
-    mk_0to1_array(cn, (3,) * ndim) - 0.5
+num_arrays = [
+    mk_0to1_array(num, (3,) * ndim) - 0.5
     for ndim in range(0, LEGATE_MAX_DIM + 1)
 ]
 
@@ -40,24 +40,24 @@ cn_arrays = [
 @pytest.mark.parametrize("keepdims", [False, True])
 def test_noaxis_1d(ord, keepdims):
     np_res = np.linalg.norm(np_arrays[1], ord=ord, keepdims=keepdims)
-    cn_res = cn.linalg.norm(cn_arrays[1], ord=ord, keepdims=keepdims)
-    assert allclose(np_res, cn_res)
+    num_res = num.linalg.norm(num_arrays[1], ord=ord, keepdims=keepdims)
+    assert allclose(np_res, num_res)
 
 
 @pytest.mark.parametrize("ord", MATRIX_ORDS)
 @pytest.mark.parametrize("keepdims", [False, True])
 def test_noaxis_2d(ord, keepdims):
     np_res = np.linalg.norm(np_arrays[2], ord=ord, keepdims=keepdims)
-    cn_res = cn.linalg.norm(cn_arrays[2], ord=ord, keepdims=keepdims)
-    assert allclose(np_res, cn_res)
+    num_res = num.linalg.norm(num_arrays[2], ord=ord, keepdims=keepdims)
+    assert allclose(np_res, num_res)
 
 
 @pytest.mark.parametrize("ndim", [0] + list(range(3, LEGATE_MAX_DIM + 1)))
 @pytest.mark.parametrize("keepdims", [False, True])
 def test_noaxis_other(ndim, keepdims):
     np_res = np.linalg.norm(np_arrays[ndim], keepdims=keepdims)
-    cn_res = cn.linalg.norm(cn_arrays[ndim], keepdims=keepdims)
-    assert allclose(np_res, cn_res)
+    num_res = num.linalg.norm(num_arrays[ndim], keepdims=keepdims)
+    assert allclose(np_res, num_res)
 
 
 @pytest.mark.parametrize("ndim", range(1, LEGATE_MAX_DIM + 1))
@@ -67,10 +67,10 @@ def test_axis_1d(ndim, ord, keepdims):
     np_res = np.linalg.norm(
         np_arrays[ndim], ord=ord, axis=0, keepdims=keepdims
     )
-    cn_res = cn.linalg.norm(
-        cn_arrays[ndim], ord=ord, axis=0, keepdims=keepdims
+    num_res = num.linalg.norm(
+        num_arrays[ndim], ord=ord, axis=0, keepdims=keepdims
     )
-    assert allclose(np_res, cn_res)
+    assert allclose(np_res, num_res)
 
 
 @pytest.mark.parametrize("ndim", range(2, LEGATE_MAX_DIM + 1))
@@ -80,10 +80,10 @@ def test_axis_2d(ndim, ord, keepdims):
     np_res = np.linalg.norm(
         np_arrays[ndim], ord=ord, axis=(0, 1), keepdims=keepdims
     )
-    cn_res = cn.linalg.norm(
-        cn_arrays[ndim], ord=ord, axis=(0, 1), keepdims=keepdims
+    num_res = num.linalg.norm(
+        num_arrays[ndim], ord=ord, axis=(0, 1), keepdims=keepdims
     )
-    assert allclose(np_res, cn_res)
+    assert allclose(np_res, num_res)
 
 
 if __name__ == "__main__":

--- a/tests/integration/test_outer.py
+++ b/tests/integration/test_outer.py
@@ -18,7 +18,7 @@ import pytest
 from legate.core import LEGATE_MAX_DIM
 from utils.generators import mk_0to1_array
 
-import cunumeric as cn
+import cunumeric as num
 
 
 def _outer(a_ndim, b_ndim, lib):
@@ -31,12 +31,12 @@ def _outer(a_ndim, b_ndim, lib):
 @pytest.mark.parametrize("b_ndim", range(1, LEGATE_MAX_DIM + 1))
 def test_basic(a_ndim, b_ndim):
     assert np.array_equal(
-        _outer(a_ndim, b_ndim, np), _outer(a_ndim, b_ndim, cn)
+        _outer(a_ndim, b_ndim, np), _outer(a_ndim, b_ndim, num)
     )
 
 
 def test_empty():
-    assert np.array_equal(_outer(0, 0, np), _outer(0, 0, cn))
+    assert np.array_equal(_outer(0, 0, np), _outer(0, 0, num))
 
 
 if __name__ == "__main__":

--- a/tests/integration/test_random_creation.py
+++ b/tests/integration/test_random_creation.py
@@ -17,16 +17,18 @@ import numpy as np
 import pytest
 from utils.comparisons import allclose
 
-import cunumeric as cn
+import cunumeric as num
 
 
 @pytest.mark.xfail
 def test_randn():
-    cn.random.seed(42)
-    x = cn.random.randn(10)
     np.random.seed(42)
-    xn = np.random.randn(10)
-    assert allclose(x, xn)
+    num.random.seed(42)
+
+    a_np = np.random.randn(10)
+    a_num = num.random.randn(10)
+
+    assert allclose(a_num, a_np)
 
 
 if __name__ == "__main__":

--- a/tests/integration/test_reduction_axis.py
+++ b/tests/integration/test_reduction_axis.py
@@ -18,7 +18,7 @@ from itertools import permutations
 import numpy as np
 import pytest
 
-import cunumeric as cn
+import cunumeric as num
 
 
 def _sum(shape, axis, lib, dtype=None):
@@ -30,9 +30,9 @@ def _sum(shape, axis, lib, dtype=None):
 @pytest.mark.parametrize("axis", range(3), ids=str)
 @pytest.mark.parametrize("shape", permutations((3, 4, 5)), ids=str)
 def test_3d(shape, axis):
-    assert np.array_equal(_sum(shape, axis, np), _sum(shape, axis, cn))
+    assert np.array_equal(_sum(shape, axis, np), _sum(shape, axis, num))
     assert np.array_equal(
-        _sum(shape, axis, np, dtype="D"), _sum(shape, axis, cn, dtype="D")
+        _sum(shape, axis, np, dtype="D"), _sum(shape, axis, num, dtype="D")
     )
 
 

--- a/tests/integration/test_vdot.py
+++ b/tests/integration/test_vdot.py
@@ -18,7 +18,7 @@ import pytest
 from utils.comparisons import allclose
 from utils.generators import mk_0to1_array
 
-import cunumeric as cn
+import cunumeric as num
 
 DTYPES = [np.float32, np.complex64]
 
@@ -33,7 +33,7 @@ def _vdot(a_dtype, b_dtype, lib):
 @pytest.mark.parametrize("a_dtype", DTYPES)
 @pytest.mark.parametrize("b_dtype", DTYPES)
 def test(a_dtype, b_dtype):
-    assert allclose(_vdot(a_dtype, b_dtype, np), _vdot(a_dtype, b_dtype, cn))
+    assert allclose(_vdot(a_dtype, b_dtype, np), _vdot(a_dtype, b_dtype, num))
 
 
 if __name__ == "__main__":

--- a/tests/integration/test_window.py
+++ b/tests/integration/test_window.py
@@ -18,7 +18,7 @@ import numpy as np
 import pytest
 from utils.comparisons import allclose
 
-import cunumeric as cn
+import cunumeric as num
 
 window_functions = ("bartlett", "blackman", "hamming", "hanning")
 
@@ -27,18 +27,18 @@ window_functions = ("bartlett", "blackman", "hamming", "hanning")
 @pytest.mark.parametrize("fn", window_functions)
 def test_basic_window(fn, M):
     out_np = getattr(np, fn)(M)
-    out_cn = getattr(cn, fn)(M)
+    out_num = getattr(num, fn)(M)
 
-    assert allclose(out_np, out_cn)
+    assert allclose(out_np, out_num)
 
 
 @pytest.mark.parametrize("beta", (0, 6))
 @pytest.mark.parametrize("M", (0, 1, 10, 100))
 def test_kaiser_window(M, beta):
     out_np = np.kaiser(M, beta)
-    out_cn = cn.kaiser(M, beta)
+    out_num = num.kaiser(M, beta)
 
-    assert allclose(out_np, out_cn)
+    assert allclose(out_np, out_num)
 
 
 if __name__ == "__main__":

--- a/tests/integration/utils/contractions.py
+++ b/tests/integration/utils/contractions.py
@@ -16,7 +16,7 @@
 import numpy as np
 from legate.core import LEGATE_MAX_DIM
 
-import cunumeric as cn
+import cunumeric as num
 
 from .comparisons import allclose
 from .generators import mk_0to1_array
@@ -49,7 +49,7 @@ def gen_inputs_of_various_shapes(lib, modes):
     # making sure common modes appear with the same extent on both arrays
     (a_modes, b_modes, out_modes) = modes
     for (a_shape, b_shape) in gen_shapes(a_modes, b_modes):
-        if lib == cn:
+        if lib == num:
             print(f"  {a_shape} x {b_shape}")
         yield (mk_0to1_array(lib, a_shape), mk_0to1_array(lib, b_shape))
 
@@ -70,7 +70,7 @@ def gen_permuted_inputs(lib, modes):
     b = mk_0to1_array(lib, (5,) * len(b_modes))
     for a_axes in gen_permutations(len(a_modes)):
         for b_axes in gen_permutations(len(b_modes)):
-            if lib == cn:
+            if lib == num:
                 print(f"  transpose{a_axes} x transpose{b_axes}")
             yield (a.transpose(a_axes), b.transpose(b_axes))
 
@@ -85,7 +85,7 @@ def gen_inputs_of_various_types(lib, modes):
         (np.float32, np.float32),
         (np.complex64, np.complex64),
     ]:
-        if lib == cn:
+        if lib == num:
             print(f"  {a_dtype} x {b_dtype}")
         yield (
             mk_0to1_array(lib, a_shape, a_dtype),
@@ -97,7 +97,7 @@ def gen_output_of_various_types(lib, modes, a, b):
     (a_modes, b_modes, out_modes) = modes
     out_shape = (5,) * len(out_modes)
     for out_dtype in [np.float16, np.complex64]:
-        if lib == cn:
+        if lib == num:
             print(f"  -> {out_dtype}")
         yield lib.zeros(out_shape, out_dtype)
 
@@ -109,23 +109,23 @@ def _test(name, modes, operation, gen_inputs, gen_output=None, **kwargs):
         # because we may need to promote arrays so that one includes all modes.
         return
     print(name)
-    for (np_inputs, cn_inputs) in zip(
-        gen_inputs(np, modes), gen_inputs(cn, modes)
+    for (np_inputs, num_inputs) in zip(
+        gen_inputs(np, modes), gen_inputs(num, modes)
     ):
         np_res = operation(np, *np_inputs, **kwargs)
-        cn_res = operation(cn, *cn_inputs, **kwargs)
+        num_res = operation(num, *num_inputs, **kwargs)
         rtol = (
             1e-02
             if any(x.dtype == np.float16 for x in np_inputs)
             or kwargs.get("dtype") == np.float16
             else 1e-05
         )
-        assert allclose(np_res, cn_res, rtol=rtol)
+        assert allclose(np_res, num_res, rtol=rtol)
         if gen_output is not None:
-            for cn_out in gen_output(cn, modes, *cn_inputs):
-                operation(cn, *cn_inputs, out=cn_out, **kwargs)
-                rtol_out = 1e-02 if cn_out.dtype == np.float16 else rtol
-                assert allclose(cn_out, cn_res, rtol=rtol_out)
+            for num_out in gen_output(num, modes, *num_inputs):
+                operation(num, *num_inputs, out=num_out, **kwargs)
+                rtol_out = 1e-02 if num_out.dtype == np.float16 else rtol
+                assert allclose(num_out, num_res, rtol=rtol_out)
 
 
 def check_default(name, modes, operation):


### PR DESCRIPTION
Currently tests import `cunumeric` in a wide variety of ways:

```
import cunumeric as cn
import cunumeric as lg
import cunumeric as np
import cunumeric as num
```
This PR standardizes all the tests to use the latter, since it is already the most prevalent. [1] Having consistent imports for `cunumeric` means that copy-pasted code (which IME happens often in test code) is on better footing, and also just affords a consistent expectation when reading the code.

I will try to note any divergence from this in any future test file PRs.

I've also updated "np" vs "num" test values to generally be "name first", i.e. `arr_num` and `arr_np` instead of `num_arr` and `np_arr` but only in files already changed in this PR (I'd regard this as ongoing code-gardening, not worth a big update in and of itself)

[1] I personally prefer `cn` since it is the same two letter length as `np`, but starts with a distinct letter. However,  I don't think the work/disruption to move to that is worthwhile.