### PR TITLE
Regenerate `install_info.py` on every build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,24 +79,23 @@ endif()
 if(CMAKE_GENERATOR STREQUAL "Ninja")
   function(add_touch_cunumeric_ninja_build_target)
     set(_suf )
-    set(_depends )
     if(SKBUILD)
       set(_suf "_python")
     endif()
+    add_custom_target("touch_cunumeric${_suf}_ninja_build" ALL
+      COMMAND ${CMAKE_COMMAND} -E touch_nocreate "${CMAKE_CURRENT_BINARY_DIR}/build.ninja"
+      COMMENT "touch build.ninja so ninja doesn't re-run CMake on rebuild"
+      VERBATIM
+    )
     foreach(_dep IN ITEMS cunumeric cunumeric_python
                           legion_core legion_core_python
                           Legion LegionRuntime
                           Realm RealmRuntime
                           Regent)
       if(TARGET ${_dep})
-        list(APPEND _depends ${_dep})
+        add_dependencies("touch_cunumeric${_suf}_ninja_build" ${_dep})
       endif()
     endforeach()
-    add_custom_target("touch_cunumeric${_suf}_ninja_build" ALL
-      COMMAND ${CMAKE_COMMAND} -E touch_nocreate "${CMAKE_CURRENT_BINARY_DIR}/build.ninja"
-      COMMENT "touch build.ninja so ninja doesn't re-run CMake on rebuild"
-      VERBATIM DEPENDS ${_depends}
-    )
   endfunction()
   add_touch_cunumeric_ninja_build_target()
 endif()

--- a/cmake/generate_install_info_py.cmake
+++ b/cmake/generate_install_info_py.cmake
@@ -1,0 +1,31 @@
+#=============================================================================
+# Copyright 2022 NVIDIA Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+
+execute_process(
+  COMMAND ${CMAKE_C_COMPILER}
+    -E -DLEGATE_USE_PYTHON_CFFI
+    -I "${CMAKE_CURRENT_LIST_DIR}/../src/cunumeric"
+    -P "${CMAKE_CURRENT_LIST_DIR}/../src/cunumeric/cunumeric_c.h"
+  ECHO_ERROR_VARIABLE
+  OUTPUT_VARIABLE header
+  COMMAND_ERROR_IS_FATAL ANY
+)
+
+set(libpath "")
+configure_file(
+  "${CMAKE_CURRENT_LIST_DIR}/../cunumeric/install_info.py.in"
+  "${CMAKE_CURRENT_LIST_DIR}/../cunumeric/install_info.py"
+@ONLY)

--- a/cunumeric_python.cmake
+++ b/cunumeric_python.cmake
@@ -43,21 +43,13 @@ if(NOT cunumeric_FOUND)
   set(SKBUILD ON)
 endif()
 
-execute_process(
-  COMMAND ${CMAKE_C_COMPILER}
-    -E -DLEGATE_USE_PYTHON_CFFI
-    -I "${CMAKE_CURRENT_SOURCE_DIR}/src/cunumeric"
-    -P "${CMAKE_CURRENT_SOURCE_DIR}/src/cunumeric/cunumeric_c.h"
-  ECHO_ERROR_VARIABLE
-  OUTPUT_VARIABLE header
-  COMMAND_ERROR_IS_FATAL ANY
+add_custom_target("generate_install_info_py" ALL
+  COMMAND ${CMAKE_COMMAND}
+          -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+          -P "${CMAKE_CURRENT_SOURCE_DIR}/cmake/generate_install_info_py.cmake"
+  COMMENT "Generate install_info.py"
+  VERBATIM
 )
-
-set(libpath "")
-configure_file(
-  "${CMAKE_CURRENT_SOURCE_DIR}/cunumeric/install_info.py.in"
-  "${CMAKE_CURRENT_SOURCE_DIR}/cunumeric/install_info.py"
-@ONLY)
 
 add_library(cunumeric_python INTERFACE)
 add_library(cunumeric::cunumeric_python ALIAS cunumeric_python)

--- a/scripts/build-install.sh
+++ b/scripts/build-install.sh
@@ -16,7 +16,7 @@ rm -rf ./{build,_skbuild,dist,cunumeric.egg-info}
 cmake_args="${CMAKE_ARGS:-}"
 
 # Use ninja-build if installed
-if [[ -n "$(which ninja)" ]]; then cmake_args+="-GNinja"; fi
+if [[ -n "$(which ninja)" ]]; then cmake_args+=" -GNinja"; fi
 
 # Add other build options here as desired
 cmake_args+="

--- a/scripts/build-no-install.sh
+++ b/scripts/build-no-install.sh
@@ -14,7 +14,7 @@ rm -rf ./{build,_skbuild,dist,cunumeric.egg-info}
 cmake_args="${CMAKE_ARGS:-}"
 
 # Use ninja-build if installed
-if [[ -n "$(which ninja)" ]]; then cmake_args+="-GNinja"; fi
+if [[ -n "$(which ninja)" ]]; then cmake_args+=" -GNinja"; fi
 
 # Add other build options here as desired
 cmake_args+="

--- a/scripts/build-separately-no-install.sh
+++ b/scripts/build-separately-no-install.sh
@@ -14,7 +14,7 @@ rm -rf ./{build,_skbuild,dist,cunumeric.egg-info}
 cmake_args="${CMAKE_ARGS:-}"
 
 # Use ninja-build if installed
-if [[ -n "$(which ninja)" ]]; then cmake_args+="-GNinja"; fi
+if [[ -n "$(which ninja)" ]]; then cmake_args+=" -GNinja"; fi
 
 # Add other build options here as desired
 cmake_args+="

--- a/scripts/build-with-legate-no-install.sh
+++ b/scripts/build-with-legate-no-install.sh
@@ -16,7 +16,7 @@ rm -rf ./{build,_skbuild,dist,cunumeric.egg-info}
 cmake_args="${CMAKE_ARGS:-}"
 
 # Use ninja-build if installed
-if [[ -n "$(which ninja)" ]]; then cmake_args+="-GNinja"; fi
+if [[ -n "$(which ninja)" ]]; then cmake_args+=" -GNinja"; fi
 
 # Add other build options here as desired
 cmake_args+="

--- a/scripts/build-with-legate-separately-no-install.sh
+++ b/scripts/build-with-legate-separately-no-install.sh
@@ -16,7 +16,7 @@ rm -rf ./{build,_skbuild,dist,cunumeric.egg-info}
 cmake_args="${CMAKE_ARGS:-}"
 
 # Use ninja-build if installed
-if [[ -n "$(which ninja)" ]]; then cmake_args+="-GNinja"; fi
+if [[ -n "$(which ninja)" ]]; then cmake_args+=" -GNinja"; fi
 
 # Add other build options here as desired
 cmake_args+="


### PR DESCRIPTION
This PR adds a custom target to generate `install_info.py` on every build, not just the initial configure.

```shell
# <after configuring and building successfully once>
$ ninja -C cunumeric/_skbuild/linux-x86_64-3.9/cmake-build/
ninja: Entering directory `cunumeric/_skbuild/linux-x86_64-3.9/cmake-build/'
[2/2] Generate install_info.py
```