### PR TITLE
cunumeric/runtime: don't take a reference to the core.Runtime in Runtime

### DIFF
--- a/cunumeric/runtime.py
+++ b/cunumeric/runtime.py
@@ -45,6 +45,7 @@ if TYPE_CHECKING:
     import numpy.typing as npt
     from legate.core._legion.future import Future
     from legate.core.operation import AutoTask, ManualTask
+    from legate.core.runtime import Runtime as CoreRuntime
 
 _supported_dtypes = {
     np.bool_: ty.bool_,
@@ -129,7 +130,6 @@ ARGS = [
 class Runtime(object):
     def __init__(self, legate_context: LegateContext) -> None:
         self.legate_context = legate_context
-        self.legate_runtime = get_legate_runtime()
         self.current_random_epoch = 0
         self.current_random_bitgenid = 0
         self.current_random_bitgen_zombies: tuple[Any, ...] = ()
@@ -167,6 +167,10 @@ class Runtime(object):
 
         if self.num_gpus > 0 and self.args.preload_cudalibs:
             self._load_cudalibs()
+
+    @property
+    def legate_runtime(self) -> CoreRuntime:
+        return get_legate_runtime()
 
     def _register_dtypes(self) -> None:
         type_system = self.legate_context.type_system


### PR DESCRIPTION
This commit makes sure that the cunumeric runtime doesn't take a reference to the core runtime. This can lead to problems as there are cycles in the object graph created by `EagerArray` types, which hold a reference to the cunumeric runtime. As a result, this can cause the core runtime to not be collected, leaking regions and futures.

Example of such a cycle:

```
found cycle!
  tail:
    0x7f8dd13c4b80: <class 'legate.core.store.RegionField'>
     ^ ["_data"]
    0x7f8e2045e780: <class 'dict'>
     ^ .__dict__
    0x7f8dd13be4f0: <class 'legate.core.store.Storage'>
     ^ ["_storage"]
    0x7f8dd13c2400: <class 'dict'>
     ^ .__dict__
    0x7f8dd13be550: <class 'legate.core.store.Store'>
     ^ ["_store"]
    0x7f8dd13c2ac0: <class 'dict'>
     ^ .__dict__
    0x7f8dd15368e0: <class 'sparse.partition.CompressedImagePartition'>
     ^ [1]
    0x7f8dd152a8c0: <class 'tuple'>
     ^
    0x7f8e2045e3c0: <class 'dict'>
     ^ ["_index_partitions"]
    0x7f8e2045e680: <class 'dict'>
     ^ .__dict__
    0x7f8df1233760: <class 'legate.core.runtime.PartitionManager'>
     ^ ["_partition_manager"]
    0x7f8ddff66dc0: <class 'dict'>
     ^ .__dict__
    0x7f8df129c430: <class 'legate.core.runtime.Runtime'>
     ^ ["legate_runtime"]
    0x7f8dd24f9d40: <class 'dict'>
     ^ .__dict__
    0x7f8dd2509a90: <class 'cunumeric.runtime.Runtime'>
     ^ ["runtime"]
    0x7f8e20019c40: <class 'dict'>
  cycle:
    0x7f8e20019c40: <class 'dict'>
     ^ .__dict__
    0x7f8dd1313b20: <class 'cunumeric.eager.EagerArray'>
     ^ [0]
    0x7f8dd13d4b80: <class 'list'>
     ^ ["children"]
    0x7f8dd28b8180: <class 'dict'>
     ^ .__dict__
    0x7f8dd1313790: <class 'cunumeric.eager.EagerArray'>
     ^ ["parent"]
    0x7f8e20019c40: <class 'dict'>
```

Signed-off-by: Rohan Yadav <rohany@alumni.cmu.edu>