### PR TITLE
Resolve some current xfail tests

### DIFF
--- a/cunumeric/module.py
+++ b/cunumeric/module.py
@@ -2864,6 +2864,9 @@ def diag_indices(n: int, ndim: int = 2) -> tuple[ndarray, ...]:
     --------
     Multiple GPUs, Multiple CPUs
     """
+    if n is not None and n < 0:
+        return (arange(0, dtype=type(n)),) * ndim
+
     idx = arange(n, dtype=int)
     return (idx,) * ndim
 

--- a/cunumeric/module.py
+++ b/cunumeric/module.py
@@ -903,6 +903,11 @@ def tri(
 
 @add_boilerplate("m")
 def trilu(m: ndarray, k: int, lower: bool) -> ndarray:
+    # Internally, numpy uses k in an arange with an int dtype, resulting in
+    # truncation of float values. This cast accomplishes the same outcome.
+    # Additionally, this produces the expected TypeError for None inputs
+    k = int(k)
+
     if m.ndim < 1:
         raise TypeError("Array must be at least 1-D")
     shape = m.shape if m.ndim >= 2 else m.shape * 2

--- a/cunumeric/module.py
+++ b/cunumeric/module.py
@@ -5515,6 +5515,9 @@ def convolve(a: ndarray, v: ndarray, mode: ConvolveMode = "full") -> ndarray:
     if mode != "same":
         raise NotImplementedError("Need to implement other convolution modes")
 
+    if a is None or v is None:
+        raise TypeError("Unsupported operand type None")
+
     if a.ndim != v.ndim:
         raise RuntimeError("Arrays should have the same dimensions")
     elif a.ndim > 3:

--- a/cunumeric/module.py
+++ b/cunumeric/module.py
@@ -1392,6 +1392,8 @@ def squeeze(a: ndarray, axis: Optional[NdShapeLike] = None) -> ndarray:
     --------
     Multiple GPUs, Multiple CPUs
     """
+    if a is None:
+        return ndarray((), dtype=object)  # type: ignore [unreachable]
     return a.squeeze(axis=axis)
 
 

--- a/tests/integration/test_convolve.py
+++ b/tests/integration/test_convolve.py
@@ -25,11 +25,8 @@ SHAPES = [(100,), (10, 10), (10, 10, 10)]
 FILTER_SHAPES = [(5,), (3, 5), (3, 5, 3)]
 
 
-@pytest.mark.xfail
 def test_none():
-    # Numpy raises:
-    # TypeError: unsupported operand type(s) for *: 'NoneType' and 'NoneType'
-    with pytest.raises(AttributeError):
+    with pytest.raises(TypeError):
         num.convolve(None, None, mode="same")
 
 

--- a/tests/integration/test_diag_indices.py
+++ b/tests/integration/test_diag_indices.py
@@ -41,23 +41,14 @@ def test_diag_indices(n, ndim):
     assert np.array_equal(a_np, a_num)
 
 
+@pytest.mark.parametrize("n", [-10.5, -1])
+def test_negative_n(n):
+    a_np = np.diag_indices(n)
+    a_num = num.diag_indices(n)
+    assert np.array_equal(a_np, a_num)
+
+
 class TestDiagIndicesErrors:
-    @pytest.mark.parametrize("n", [-10.5, -1])
-    def test_negative_n(self, n):
-        with pytest.raises(ValueError):
-            num.diag_indices(n)
-
-    @pytest.mark.xfail
-    @pytest.mark.parametrize("n", [-10.5, -1])
-    def test_negative_n_DIVERGENCE(self, n):
-        # np.diag_indices(-10.5) returns empty 2-D array, dtype=float64
-        # np.diag_indices(-1) returns empty 2-D array, dtype=int32
-        # num.diag_indices(-10.5) raises ValueError
-        # num.diag_indices(-1) raises ValueError
-        a_np = np.diag_indices(n)
-        a_num = num.diag_indices(n)
-        assert np.array_equal(a_np, a_num)
-
     def test_none_n(self):
         msg = "unsupported operand type"
         with pytest.raises(TypeError, match=msg):

--- a/tests/integration/test_eye.py
+++ b/tests/integration/test_eye.py
@@ -71,10 +71,7 @@ class TestEyeErrors:
         with pytest.raises(TypeError, match=msg):
             num.eye(5, 5.0)
 
-    @pytest.mark.xfail
     def testBadK(self):
-        # numpy: raises TypeError
-        # cunumeric: the error is found by legate.core, raises struct.error
         with pytest.raises(TypeError):
             num.eye(5, k=0.0)
 

--- a/tests/integration/test_squeeze.py
+++ b/tests/integration/test_squeeze.py
@@ -40,18 +40,10 @@ SIZES = [
 ]
 
 
-@pytest.mark.xfail
-def test_none_array_compare():
-    res_num = num.squeeze(None)  # AttributeError: 'NoneType'
-    res_np = np.squeeze(None)  # return None
-    assert np.array_equal(res_num, res_np, equal_nan=True)
-
-
 def test_none_array():
-    # numpy returned None
-    msg = r"NoneType"
-    with pytest.raises(AttributeError, match=msg):
-        num.squeeze(None)
+    res_num = num.squeeze(None)
+    res_np = np.squeeze(None)
+    assert np.array_equal(res_num, res_np)
 
 
 def test_num_invalid_axis():

--- a/tests/integration/test_trilu.py
+++ b/tests/integration/test_trilu.py
@@ -57,12 +57,9 @@ def test_trilu(func, shape, dtype, k):
     _test(func, anp, a, k)
 
 
-@pytest.mark.xfail
 @pytest.mark.parametrize("k", (-2.5, 0.0, 2.5), ids=lambda k: f"(k={k})")
 @pytest.mark.parametrize("func", FUNCTIONS)
 def test_trilu_float_k(func, k):
-    # cuNumeric: struct.error: required argument is not an integer
-    # Numpy: pass
     shape = (10, 10)
     anp = np.ones(shape)
     a = num.ones(shape)
@@ -76,12 +73,7 @@ class TestTriluErrors:
         with pytest.raises(AttributeError, match=msg):
             num.tril(None)
 
-    @pytest.mark.xfail
     def test_k_none(self):
-        # In cuNumeric, it raises struct.error,
-        # msg is required argument is not an integer
-        # In Numpy, it raises TypeError,
-        # msg is bad operand type for unary -: 'NoneType'
         a = num.ones((3, 3))
         with pytest.raises(TypeError):
             num.tril(a, k=None)


### PR DESCRIPTION
This PR resolves some of the tests currently marked as `xfail` by adding appropriate checks/conversions at the outermost python API.  I wanted to get some feedback on a small PR about resolving things at this level. Also note the need to ignore "unreachable" code in some cases (where we want to mirror numpy's handling of a bad type, but don't want to actually include bad types in the func signature) 

 