### PR TITLE
Fix a typo in unique.cu indexing

### DIFF
--- a/src/cunumeric/set/unique.cu
+++ b/src/cunumeric/set/unique.cu
@@ -40,7 +40,7 @@ __global__ static void __launch_bounds__(THREADS_PER_BLOCK, MIN_CTAS_PER_SM)
   size_t offset = blockIdx.x * blockDim.x + threadIdx.x;
   if (offset >= volume) return;
   auto point  = pitches.unflatten(offset, lo);
-  out[offset] = accessor[lo + point];
+  out[offset] = accessor[point];
 }
 
 template <typename VAL>


### PR DESCRIPTION
It looks like the code adds `lo` twice.

I was not able to actually exercise this code to verify the issue, because some part of the stack, likely the core's handling of output regions, always seemed to squash any non-compact arrays I produced (and ran the task on 1 GPU), in which case the copy kernel is skipped altogether:

```
print(cn.unique(cn.ones((20,)))) # naturally dense, code runs on all GPUs
print(cn.unique(cn.ones((20,))[3:])) # naturally dense, code runs on all GPUs
print(cn.unique(cn.ones((4,5))[1,:])) # naturally dense, code runs on all GPUs
print(cn.unique(cn.ones((4,5))[:,2])) # someone densifies the input, code runs on 1 GPU only
print(cn.unique(cn.ones((4,5))[1:3,2:4])) # someone densifies the input, code runs on 1 GPU only
```