### PR TITLE
Update Availability annotations

### DIFF
--- a/cunumeric/array.py
+++ b/cunumeric/array.py
@@ -537,6 +537,10 @@ class ndarray:
         --------
         flatten : Return a copy of the array collapsed into one dimension.
 
+        Availability
+        --------
+        Single CPU
+
         """
         return self.__array__().flat
 
@@ -2641,7 +2645,7 @@ class ndarray:
 
         Availability
         --------
-        Multiple GPUs, Multiple CPUs
+        Single CPU
 
         """
         self.__array__().dump(file=file)
@@ -3641,7 +3645,7 @@ class ndarray:
 
         Availability
         --------
-        Multiple GPUs, Multiple CPUs
+        Single CPU
 
         """
         return self.__array__().tofile(fid=fid, sep=sep, format=format)

--- a/cunumeric/array.py
+++ b/cunumeric/array.py
@@ -3817,11 +3817,45 @@ class ndarray:
     def view(
         self,
         dtype: Union[npt.DTypeLike, None] = None,
-        type: Union[Any, None] = None,
+        type: Union[type, None] = None,
     ) -> ndarray:
+        """
+        New view of array with the same data.
+
+        Parameters
+        ----------
+        dtype : data-type or ndarray sub-class, optional
+            Data-type descriptor of the returned view, e.g., float32 or int16.
+            Omitting it results in the view having the same data-type as the
+            input array. This argument can also be specified as an ndarray
+            sub-class, which then specifies the type of the returned object
+            (this is equivalent to setting the ``type`` parameter).
+        type : ndarray sub-class, optional
+            Type of the returned view, e.g., ndarray or matrix. Again, omission
+            of the parameter results in type preservation.
+
+        Notes
+        -----
+        cuNumeric does not currently support type reinterpretation, or
+        conversion to ndarray sub-classes; use :func:`ndarray.__array__()` to
+        convert to `numpy.ndarray`.
+
+        See Also
+        --------
+        numpy.ndarray.view
+
+        Availability
+        --------
+        Multiple GPUs, Multiple CPUs
+        """
         if dtype is not None and dtype != self.dtype:
             raise NotImplementedError(
                 "cuNumeric does not currently support type reinterpretation"
+            )
+        if type is not None:
+            raise NotImplementedError(
+                "cuNumeric does not currently support conversion to ndarray "
+                "sub-classes; use __array__() to convert to numpy.ndarray"
             )
         return ndarray(shape=self.shape, dtype=self.dtype, thunk=self._thunk)
 

--- a/cunumeric/logic.py
+++ b/cunumeric/logic.py
@@ -176,7 +176,7 @@ def iscomplexobj(x: Union[ndarray, npt.NDArray[Any]]) -> bool:
 
     Availability
     --------
-    Single CPU
+    Multiple GPUs, Multiple CPUs
     """
     if isinstance(x, ndarray):
         return x.dtype.kind == "c"
@@ -244,7 +244,7 @@ def isrealobj(x: ndarray) -> bool:
 
     Availability
     --------
-    Single CPU
+    Multiple GPUs, Multiple CPUs
     """
     return not iscomplexobj(x)
 
@@ -275,7 +275,7 @@ def isscalar(x: Union[ndarray, npt.NDArray[Any]]) -> bool:
 
     Availability
     --------
-    Single CPU
+    Multiple GPUs, Multiple CPUs
     """
 
     # Since the input can be any value, we can't just convert it to cunumeric

--- a/cunumeric/random/random.py
+++ b/cunumeric/random/random.py
@@ -37,6 +37,10 @@ def seed(init: Union[int, None] = None) -> None:
 
     This function is effective only when cuRAND is NOT used in the build
     and is a no-op otherwise.
+
+    Availability
+    --------
+    Multiple GPUs, Multiple CPUs
     """
     if init is None:
         init = 0


### PR DESCRIPTION
Inspired by https://github.com/nv-legate/cunumeric/issues/464, I took a look at some "contentious" Availability annotations. I updated some to follow this policy, that I suggest going forward:

A function implementation gets full marks ("Multiple CPUs, Multiple GPUs") if it does not impede multi-CPU and multi-GPU execution, more than the function's semantics require.

Examples:

* `cn.add`: has data-parallel CPU and GPU implementations => full marks
* `cn.iscomplexobj`: only checks the `dtype` of the array object, therefore it doesn't impede distributed execution => full marks (doesn't matter that it falls back to `np.iscomplexobj` in the case of vanilla NumPy arrays, since that array is already local, and thus doing so doesn't impede distributed execution; doesn't matter that it doesn't actually run anything on an accelerator)
* `cn.linalg.solve`: has single-CPU and single-GPU implementations, but could have a distributed implementation => Single CPU, Single GPU
* `cn.ndarray.tostring()`: the user asked to access the entire array using a single memory buffer => there is nothing better we can do than collect the entire array onto a single node => full marks
* `cn.ndarray.tofile()`: we currently fall back to collecting the entire array into one node and dumping the local buffer into a file, but could theoretically have a distributed implementation (where the different ranks output their own subset into different blocks of a common file) => Single CPU

Please let me know if these changes make sense, or suggest an alternative interpretation. I am looking to be accurate when advertising our feature completeness, while not dinging us when there is nothing better we could do.