### PR TITLE
Minor type improvements

### DIFF
--- a/cunumeric/__init__.py
+++ b/cunumeric/__init__.py
@@ -42,4 +42,4 @@ del _np
 
 from . import _version
 
-__version__ = _version.get_versions()["version"]  # type: ignore
+__version__ = _version.get_versions()["version"]  # type: ignore [no-untyped-call]

--- a/cunumeric/array.py
+++ b/cunumeric/array.py
@@ -33,10 +33,14 @@ from typing import (
 
 import legate.core.types as ty
 import numpy as np
-import pyarrow  # type: ignore
+import pyarrow  # type: ignore  [import]
 from legate.core import Array
-from numpy.core.multiarray import normalize_axis_index  # type: ignore
-from numpy.core.numeric import normalize_axis_tuple  # type: ignore
+from numpy.core.multiarray import (  # type: ignore [attr-defined]
+    normalize_axis_index,
+)
+from numpy.core.numeric import (  # type: ignore [attr-defined]
+    normalize_axis_tuple,
+)
 from typing_extensions import ParamSpec
 
 from .config import (

--- a/cunumeric/coverage.py
+++ b/cunumeric/coverage.py
@@ -78,7 +78,7 @@ class CuWrapperMetadata:
 
 class CuWrapped(AnyCallable, Protocol):
     _cunumeric: CuWrapperMetadata
-    __wrapped__: Any
+    __wrapped__: AnyCallable
     __name__: str
     __qualname__: str
 

--- a/cunumeric/deferred.py
+++ b/cunumeric/deferred.py
@@ -36,7 +36,9 @@ from typing import (
 import legate.core.types as ty
 import numpy as np
 from legate.core import Annotation, Future, ReductionOp, Store
-from numpy.core.numeric import normalize_axis_tuple  # type: ignore
+from numpy.core.numeric import (  # type: ignore [attr-defined]
+    normalize_axis_tuple,
+)
 from typing_extensions import ParamSpec
 
 from .config import (
@@ -710,7 +712,7 @@ class DeferredArray(NumPyThunk):
         shift = 0
         for dim, k in enumerate(key):
             if np.isscalar(k):
-                if k < 0:  # type: ignore
+                if k < 0:  # type: ignore [operator]
                     k += store.shape[dim + shift]
                 store = store.project(dim + shift, k)
                 shift -= 1
@@ -787,7 +789,7 @@ class DeferredArray(NumPyThunk):
             elif isinstance(k, slice):
                 k, store = self._slice_store(k, store, dim + shift)
             elif np.isscalar(k):
-                if k < 0:  # type: ignore
+                if k < 0:  # type: ignore [operator]
                     k += store.shape[dim + shift]
                 store = store.project(dim + shift, k)
                 shift -= 1
@@ -3032,7 +3034,7 @@ class DeferredArray(NumPyThunk):
         args: Any,
         initial: Any,
     ) -> None:
-        lhs_array = self
+        lhs_array: Union[NumPyThunk, DeferredArray] = self
         rhs_array = src
         assert lhs_array.ndim <= rhs_array.ndim
 
@@ -3040,7 +3042,7 @@ class DeferredArray(NumPyThunk):
 
         if argred:
             argred_dtype = self.runtime.get_arg_dtype(rhs_array.dtype)
-            lhs_array = self.runtime.create_empty_thunk(  # type: ignore
+            lhs_array = self.runtime.create_empty_thunk(
                 lhs_array.shape,
                 dtype=argred_dtype,
                 inputs=[self],
@@ -3060,7 +3062,7 @@ class DeferredArray(NumPyThunk):
 
             lhs_array.fill(np.array(fill_value, dtype=lhs_array.dtype))
 
-            lhs = lhs_array.base
+            lhs = lhs_array.base  # type: ignore
             while lhs.ndim > 1:
                 lhs = lhs.project(0, 0)
 
@@ -3094,7 +3096,7 @@ class DeferredArray(NumPyThunk):
             # If output dims is not 0, then we must have axes
             assert axes is not None
             # Reduction to a smaller array
-            result = lhs_array.base
+            result = lhs_array.base  # type: ignore
             if keepdims:
                 for axis in axes:
                     result = result.project(axis, 0)

--- a/cunumeric/eager.py
+++ b/cunumeric/eager.py
@@ -1471,6 +1471,9 @@ class EagerArray(NumPyThunk):
             return
         if op in _UNARY_RED_OPS:
             fn = _UNARY_RED_OPS[op]
+            # Need to be more careful here, Numpy does not use None to mean
+            # "was not passed in" in this instance
+            kws = {"initial": initial} if initial is not None else {}
             fn(
                 rhs.array,
                 out=self.array,
@@ -1479,6 +1482,7 @@ class EagerArray(NumPyThunk):
                 where=where
                 if not isinstance(where, EagerArray)
                 else where.array,
+                **kws,
             )
         elif op == UnaryRedCode.ARGMAX:
             np.argmax(

--- a/cunumeric/eager.py
+++ b/cunumeric/eager.py
@@ -300,7 +300,6 @@ class EagerArray(NumPyThunk):
                         shape=self.shape,
                     )
                 else:
-                    assert self.runtime is not None
                     self.deferred = self.runtime.find_or_create_array_thunk(
                         self.array,
                         share=self.escaped,

--- a/cunumeric/eager.py
+++ b/cunumeric/eager.py
@@ -215,14 +215,17 @@ class EagerArray(NumPyThunk):
         self.key: Optional[tuple[Any, ...]] = key
         #: if this ever becomes set (to a DeferredArray), we forward all
         #: operations to it
-        self.deferred: Optional[DeferredArray] = None
+        self.deferred: Optional[Union[DeferredArray, NumPyThunk]] = None
         self.escaped = False
 
     @property
     def storage(self) -> Union[Future, tuple[Region, FieldID]]:
         if self.deferred is None:
             self.to_deferred_array()
-        return self.deferred.storage  # type: ignore
+
+        assert self.deferred is not None
+
+        return self.deferred.storage
 
     @property
     def shape(self) -> NdShape:
@@ -265,10 +268,9 @@ class EagerArray(NumPyThunk):
         assert self.runtime.is_deferred_array(self.deferred)
         for child in self.children:
             if child.deferred is None:
-                # mypy can't deduce that children nodes will always have
-                # their .key attribute set.
-                func = getattr(self.deferred, child.key[0])  # type: ignore
-                args = child.key[1:]  # type: ignore
+                assert child.key is not None
+                func = getattr(self.deferred, child.key[0])
+                args = child.key[1:]
                 child.deferred = func(*args)
         # After we've made all the deferred views for each child then
         # we can traverse down. Do it this way so we can get partition
@@ -298,7 +300,8 @@ class EagerArray(NumPyThunk):
                         shape=self.shape,
                     )
                 else:
-                    self.deferred = self.runtime.find_or_create_array_thunk(  # type: ignore # noqa E501
+                    assert self.runtime is not None
+                    self.deferred = self.runtime.find_or_create_array_thunk(
                         self.array,
                         share=self.escaped,
                         defer=True,
@@ -334,7 +337,7 @@ class EagerArray(NumPyThunk):
             if self.ndim == 1:
                 out.array = np.convolve(self.array, v.array, mode)
             else:
-                from scipy.signal import convolve  # type: ignore
+                from scipy.signal import convolve  # type: ignore [import]
 
                 out.array = convolve(self.array, v.array, mode)
 
@@ -1468,10 +1471,6 @@ class EagerArray(NumPyThunk):
             return
         if op in _UNARY_RED_OPS:
             fn = _UNARY_RED_OPS[op]
-            if initial is None:
-                # NumPy starts using this predefined constant, instead of None,
-                # to mean no value was given by the caller
-                initial = np._NoValue  # type: ignore
             fn(
                 rhs.array,
                 out=self.array,

--- a/cunumeric/linalg/linalg.py
+++ b/cunumeric/linalg/linalg.py
@@ -17,8 +17,12 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Sequence, Union
 
 import numpy as np
-from numpy.core.multiarray import normalize_axis_index  # type: ignore
-from numpy.core.numeric import normalize_axis_tuple  # type: ignore
+from numpy.core.multiarray import (  # type: ignore [attr-defined]
+    normalize_axis_index,
+)
+from numpy.core.numeric import (  # type: ignore [attr-defined]
+    normalize_axis_tuple,
+)
 
 from cunumeric._ufunc.math import add, sqrt as _sqrt
 from cunumeric.array import add_boilerplate, convert_to_cunumeric_ndarray

--- a/cunumeric/module.py
+++ b/cunumeric/module.py
@@ -23,7 +23,9 @@ from typing import TYPE_CHECKING, Any, Literal, Optional, Sequence, Union, cast
 
 import numpy as np
 import opt_einsum as oe  # type: ignore [import]
-from numpy.core.multiarray import normalize_axis_index  # type: ignore
+from numpy.core.multiarray import (  # type: ignore [attr-defined]
+    normalize_axis_index,
+)
 from numpy.core.numeric import (  # type: ignore [attr-defined]
     normalize_axis_tuple,
 )
@@ -4012,9 +4014,13 @@ def tensordot(
 
 
 # Trivial multi-tensor contraction strategy: contract in input order
-class NullOptimizer(oe.paths.PathOptimizer):  # type: ignore
-    def __call__(  # type: ignore [no-untyped-def]
-        self, inputs, output, size_dict, memory_limit=None
+class NullOptimizer(oe.paths.PathOptimizer):  # type: ignore [misc,no-any-unimported] # noqa
+    def __call__(
+        self,
+        inputs: list[set[str]],
+        outputs: set[str],
+        size_dict: dict[str, int],
+        memory_limit: Union[int, None] = None,
     ) -> list[tuple[int, int]]:
         return [(0, 1)] + [(0, -1)] * (len(inputs) - 2)
 

--- a/cunumeric/sort.py
+++ b/cunumeric/sort.py
@@ -17,7 +17,9 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Union, cast
 
 from legate.core import types as ty
-from numpy.core.multiarray import normalize_axis_index  # type: ignore
+from numpy.core.multiarray import (  # type: ignore [attr-defined]
+    normalize_axis_index,
+)
 
 from .config import CuNumericOpCode
 

--- a/cunumeric/utils.py
+++ b/cunumeric/utils.py
@@ -114,7 +114,7 @@ def get_arg_dtype(dtype: np.dtype[Any]) -> np.dtype[Any]:
 
 def get_arg_value_dtype(dtype: np.dtype[Any]) -> np.dtype[Any]:
     dt = dtype.fields["arg_value"][0].type  # type: ignore [index]
-    return cast(Any, dt)
+    return cast(np.dtype[Any], dt)
 
 
 Modes = Tuple[List[str], List[str], List[str]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,6 @@ warn_no_return = true
 warn_return_any = false
 warn_unreachable = true
 
-show_none_errors = true
 ignore_errors = false
 
 allow_untyped_globals = false


### PR DESCRIPTION
This PR makes some minor type improvements across the code base:

* all `type: ignore` made fully specific (with one exception, see below)
* type ignores for optional values removed w/ assertions
* an obsolete `mypy` config value was removed

I left the generic `type: ignore` in `deferred.py` for all the `.base` cases. I think there is a larger issue to resolve here where some things claim to want `Union[DeferredArray, NumpyThink]` but then access `.base` which only exists on the `DeferredArray`

Somewhat related, I think the largest issue remaining is all the `Any` for thunk/array args (e.g. `rhs`, etc). This will requrie some thought and possibly some re-org. It should get a dedicated PR. 