### PR TITLE
Doing in-place updates in cblas/cublas calls (for reduction reuse case)

### DIFF
--- a/src/cunumeric/matrix/matmul.cc
+++ b/src/cunumeric/matrix/matmul.cc
@@ -53,7 +53,7 @@ struct MatMulImplBody<VariantKind::CPU, LegateTypeCode::FLOAT_LT> {
                 rhs1_stride,
                 rhs2,
                 rhs2_stride,
-                0,
+                1,
                 lhs,
                 lhs_stride);
   }
@@ -84,7 +84,7 @@ struct MatMulImplBody<VariantKind::CPU, LegateTypeCode::DOUBLE_LT> {
                 rhs1_stride,
                 rhs2,
                 rhs2_stride,
-                0,
+                1,
                 lhs,
                 lhs_stride);
   }
@@ -128,7 +128,7 @@ struct MatMulImplBody<VariantKind::CPU, LegateTypeCode::HALF_LT> {
                 rhs1_transposed ? m : k,
                 rhs2_copy,
                 rhs2_transposed ? k : n,
-                0,
+                1,
                 lhs,
                 lhs_stride);
   }
@@ -152,7 +152,7 @@ struct MatMulImplBody<VariantKind::CPU, LegateTypeCode::COMPLEX64_LT> {
     const __complex__ float* rhs1 = reinterpret_cast<const __complex__ float*>(rhs1_);
     const __complex__ float* rhs2 = reinterpret_cast<const __complex__ float*>(rhs2_);
     __complex__ float alpha       = 1.0;
-    __complex__ float beta        = 0.0;
+    __complex__ float beta        = 1.0;
 
     cblas_cgemm(CblasRowMajor,
                 rhs1_transposed ? CblasTrans : CblasNoTrans,
@@ -189,7 +189,7 @@ struct MatMulImplBody<VariantKind::CPU, LegateTypeCode::COMPLEX128_LT> {
     const __complex__ double* rhs1 = reinterpret_cast<const __complex__ double*>(rhs1_);
     const __complex__ double* rhs2 = reinterpret_cast<const __complex__ double*>(rhs2_);
     __complex__ double alpha       = 1.0;
-    __complex__ double beta        = 0.0;
+    __complex__ double beta        = 1.0;
 
     cblas_zgemm(CblasRowMajor,
                 rhs1_transposed ? CblasTrans : CblasNoTrans,

--- a/src/cunumeric/matrix/matmul.cu
+++ b/src/cunumeric/matrix/matmul.cu
@@ -48,7 +48,7 @@ struct MatMulImplBody<VariantKind::GPU, LegateTypeCode::FLOAT_LT> {
     CHECK_CUBLAS(cublasSetStream(cublas_handle, task_stream));
 
     const float alpha = 1.0;
-    const float beta  = 0.0;
+    const float beta  = 1.0;
 
     CHECK_CUBLAS(cublasSgemmEx(cublas_handle,
                                rhs2_transposed ? CUBLAS_OP_T : CUBLAS_OP_N,
@@ -91,7 +91,7 @@ struct MatMulImplBody<VariantKind::GPU, LegateTypeCode::DOUBLE_LT> {
     CHECK_CUBLAS(cublasSetStream(cublas_handle, task_stream));
 
     const double alpha = 1.0;
-    const double beta  = 0.0;
+    const double beta  = 1.0;
 
     CHECK_CUBLAS(cublasDgemm(cublas_handle,
                              rhs2_transposed ? CUBLAS_OP_T : CUBLAS_OP_N,
@@ -131,7 +131,7 @@ struct MatMulImplBody<VariantKind::GPU, LegateTypeCode::HALF_LT> {
     CHECK_CUBLAS(cublasSetStream(cublas_handle, task_stream));
 
     const float alpha = 1.0;
-    const float beta  = 0.0;
+    const float beta  = 1.0;
 
     CHECK_CUBLAS(cublasSgemmEx(cublas_handle,
                                rhs2_transposed ? CUBLAS_OP_T : CUBLAS_OP_N,
@@ -178,7 +178,7 @@ struct MatMulImplBody<VariantKind::GPU, LegateTypeCode::COMPLEX64_LT> {
     CHECK_CUBLAS(cublasSetStream(cublas_handle, task_stream));
 
     const cuComplex alpha = make_float2(1.0, 0.0);
-    const cuComplex beta  = make_float2(0.0, 0.0);
+    const cuComplex beta  = make_float2(1.0, 0.0);
 
     CHECK_CUBLAS(cublasCgemmEx(cublas_handle,
                                rhs2_transposed ? CUBLAS_OP_T : CUBLAS_OP_N,
@@ -225,7 +225,7 @@ struct MatMulImplBody<VariantKind::GPU, LegateTypeCode::COMPLEX128_LT> {
     CHECK_CUBLAS(cublasSetStream(cublas_handle, task_stream));
 
     const cuDoubleComplex alpha = make_double2(1.0, 0.0);
-    const cuDoubleComplex beta  = make_double2(0.0, 0.0);
+    const cuDoubleComplex beta  = make_double2(1.0, 0.0);
 
     CHECK_CUBLAS(cublasZgemm(cublas_handle,
                              rhs2_transposed ? CUBLAS_OP_T : CUBLAS_OP_N,

--- a/src/cunumeric/matrix/matmul_omp.cc
+++ b/src/cunumeric/matrix/matmul_omp.cc
@@ -52,7 +52,7 @@ struct MatMulImplBody<VariantKind::OMP, LegateTypeCode::FLOAT_LT> {
                 rhs1_stride,
                 rhs2,
                 rhs2_stride,
-                0,
+                1,
                 lhs,
                 lhs_stride);
   }
@@ -83,7 +83,7 @@ struct MatMulImplBody<VariantKind::OMP, LegateTypeCode::DOUBLE_LT> {
                 rhs1_stride,
                 rhs2,
                 rhs2_stride,
-                0,
+                1,
                 lhs,
                 lhs_stride);
   }
@@ -127,7 +127,7 @@ struct MatMulImplBody<VariantKind::OMP, LegateTypeCode::HALF_LT> {
                 rhs1_transposed ? m : k,
                 rhs2_copy,
                 rhs2_transposed ? k : n,
-                0,
+                1,
                 lhs,
                 lhs_stride);
   }
@@ -151,7 +151,7 @@ struct MatMulImplBody<VariantKind::OMP, LegateTypeCode::COMPLEX64_LT> {
     const __complex__ float* rhs1 = reinterpret_cast<const __complex__ float*>(rhs1_);
     const __complex__ float* rhs2 = reinterpret_cast<const __complex__ float*>(rhs2_);
     __complex__ float alpha       = 1.0;
-    __complex__ float beta        = 0.0;
+    __complex__ float beta        = 1.0;
 
     cblas_cgemm(CblasRowMajor,
                 rhs1_transposed ? CblasTrans : CblasNoTrans,
@@ -188,7 +188,7 @@ struct MatMulImplBody<VariantKind::OMP, LegateTypeCode::COMPLEX128_LT> {
     const __complex__ double* rhs1 = reinterpret_cast<const __complex__ double*>(rhs1_);
     const __complex__ double* rhs2 = reinterpret_cast<const __complex__ double*>(rhs2_);
     __complex__ double alpha       = 1.0;
-    __complex__ double beta        = 0.0;
+    __complex__ double beta        = 1.0;
 
     cblas_zgemm(CblasRowMajor,
                 rhs1_transposed ? CblasTrans : CblasNoTrans,

--- a/src/cunumeric/matrix/matvecmul.cc
+++ b/src/cunumeric/matrix/matvecmul.cc
@@ -39,7 +39,7 @@ struct MatVecMulImplBody<VariantKind::CPU, LegateTypeCode::FLOAT_LT> {
                   bool transpose_mat)
   {
     auto trans = transpose_mat ? CblasTrans : CblasNoTrans;
-    cblas_sgemv(CblasRowMajor, trans, m, n, 1, mat, mat_stride, vec, 1, 0, lhs, 1);
+    cblas_sgemv(CblasRowMajor, trans, m, n, 1, mat, mat_stride, vec, 1, 1, lhs, 1);
   }
 };
 
@@ -54,7 +54,7 @@ struct MatVecMulImplBody<VariantKind::CPU, LegateTypeCode::DOUBLE_LT> {
                   bool transpose_mat)
   {
     auto trans = transpose_mat ? CblasTrans : CblasNoTrans;
-    cblas_dgemv(CblasRowMajor, trans, m, n, 1, mat, mat_stride, vec, 1, 0, lhs, 1);
+    cblas_dgemv(CblasRowMajor, trans, m, n, 1, mat, mat_stride, vec, 1, 1, lhs, 1);
   }
 };
 
@@ -95,7 +95,7 @@ struct MatVecMulImplBody<VariantKind::CPU, LegateTypeCode::COMPLEX64_LT> {
     const __complex__ float* mat = reinterpret_cast<const __complex__ float*>(mat_);
     const __complex__ float* vec = reinterpret_cast<const __complex__ float*>(vec_);
     __complex__ float alpha      = 1.0;
-    __complex__ float beta       = 0.0;
+    __complex__ float beta       = 1.0;
 
     auto trans = transpose_mat ? CblasTrans : CblasNoTrans;
     cblas_cgemv(CblasRowMajor, trans, m, n, &alpha, mat, mat_stride, vec, 1, &beta, lhs, 1);
@@ -116,7 +116,7 @@ struct MatVecMulImplBody<VariantKind::CPU, LegateTypeCode::COMPLEX128_LT> {
     const __complex__ double* mat = reinterpret_cast<const __complex__ double*>(mat_);
     const __complex__ double* vec = reinterpret_cast<const __complex__ double*>(vec_);
     __complex__ double alpha      = 1.0;
-    __complex__ double beta       = 0.0;
+    __complex__ double beta       = 1.0;
 
     auto trans = transpose_mat ? CblasTrans : CblasNoTrans;
     cblas_zgemv(CblasRowMajor, trans, m, n, &alpha, mat, mat_stride, vec, 1, &beta, lhs, 1);

--- a/src/cunumeric/matrix/matvecmul.cu
+++ b/src/cunumeric/matrix/matvecmul.cu
@@ -38,7 +38,7 @@ struct MatVecMulImplBody<VariantKind::GPU, LegateTypeCode::FLOAT_LT> {
     CHECK_CUBLAS(cublasSetStream(cublas_handle, task_stream));
 
     const float alpha = 1.0;
-    const float beta  = 0.0;
+    const float beta  = 1.0;
 
     auto trans = transpose_mat ? CUBLAS_OP_N : CUBLAS_OP_T;
 
@@ -89,7 +89,7 @@ struct MatVecMulImplBody<VariantKind::GPU, LegateTypeCode::DOUBLE_LT> {
     CHECK_CUBLAS(cublasSetStream(cublas_handle, task_stream));
 
     const double alpha = 1.0;
-    const double beta  = 0.0;
+    const double beta  = 1.0;
 
     auto trans = transpose_mat ? CUBLAS_OP_N : CUBLAS_OP_T;
 
@@ -135,7 +135,7 @@ struct MatVecMulImplBody<VariantKind::GPU, LegateTypeCode::HALF_LT> {
     CHECK_CUBLAS(cublasSetStream(cublas_handle, task_stream));
 
     const float alpha = 1.0;
-    const float beta  = 0.0;
+    const float beta  = 1.0;
 
     auto trans = transpose_mat ? CUBLAS_OP_N : CUBLAS_OP_T;
     // Use SgemmEx here since there is no half precision gemv yet
@@ -180,7 +180,7 @@ struct MatVecMulImplBody<VariantKind::GPU, LegateTypeCode::COMPLEX64_LT> {
     CHECK_CUBLAS(cublasSetStream(cublas_handle, task_stream));
 
     const cuComplex alpha = make_float2(1.0, 0.0);
-    const cuComplex beta  = make_float2(0.0, 0.0);
+    const cuComplex beta  = make_float2(1.0, 0.0);
 
     auto trans = transpose_mat ? CUBLAS_OP_N : CUBLAS_OP_T;
 
@@ -233,7 +233,7 @@ struct MatVecMulImplBody<VariantKind::GPU, LegateTypeCode::COMPLEX128_LT> {
     CHECK_CUBLAS(cublasSetStream(cublas_handle, task_stream));
 
     const cuDoubleComplex alpha = make_double2(1.0, 0.0);
-    const cuDoubleComplex beta  = make_double2(0.0, 0.0);
+    const cuDoubleComplex beta  = make_double2(1.0, 0.0);
 
     auto trans = transpose_mat ? CUBLAS_OP_N : CUBLAS_OP_T;
 

--- a/src/cunumeric/matrix/matvecmul_omp.cc
+++ b/src/cunumeric/matrix/matvecmul_omp.cc
@@ -38,7 +38,7 @@ struct MatVecMulImplBody<VariantKind::OMP, LegateTypeCode::FLOAT_LT> {
                   bool transpose_mat)
   {
     auto trans = transpose_mat ? CblasTrans : CblasNoTrans;
-    cblas_sgemv(CblasRowMajor, trans, m, n, 1, mat, mat_stride, vec, 1, 0, lhs, 1);
+    cblas_sgemv(CblasRowMajor, trans, m, n, 1, mat, mat_stride, vec, 1, 1, lhs, 1);
   }
 };
 
@@ -53,7 +53,7 @@ struct MatVecMulImplBody<VariantKind::OMP, LegateTypeCode::DOUBLE_LT> {
                   bool transpose_mat)
   {
     auto trans = transpose_mat ? CblasTrans : CblasNoTrans;
-    cblas_dgemv(CblasRowMajor, trans, m, n, 1, mat, mat_stride, vec, 1, 0, lhs, 1);
+    cblas_dgemv(CblasRowMajor, trans, m, n, 1, mat, mat_stride, vec, 1, 1, lhs, 1);
   }
 };
 
@@ -94,7 +94,7 @@ struct MatVecMulImplBody<VariantKind::OMP, LegateTypeCode::COMPLEX64_LT> {
     const __complex__ float* mat = reinterpret_cast<const __complex__ float*>(mat_);
     const __complex__ float* vec = reinterpret_cast<const __complex__ float*>(vec_);
     __complex__ float alpha      = 1.0;
-    __complex__ float beta       = 0.0;
+    __complex__ float beta       = 1.0;
 
     auto trans = transpose_mat ? CblasTrans : CblasNoTrans;
     cblas_cgemv(CblasRowMajor, trans, m, n, &alpha, mat, mat_stride, vec, 1, &beta, lhs, 1);
@@ -115,7 +115,7 @@ struct MatVecMulImplBody<VariantKind::OMP, LegateTypeCode::COMPLEX128_LT> {
     const __complex__ double* mat = reinterpret_cast<const __complex__ double*>(mat_);
     const __complex__ double* vec = reinterpret_cast<const __complex__ double*>(vec_);
     __complex__ double alpha      = 1.0;
-    __complex__ double beta       = 0.0;
+    __complex__ double beta       = 1.0;
 
     auto trans = transpose_mat ? CblasTrans : CblasNoTrans;
     cblas_zgemv(CblasRowMajor, trans, m, n, &alpha, mat, mat_stride, vec, 1, &beta, lhs, 1);


### PR DESCRIPTION
This PR is needed for https://github.com/nv-legate/legate.core/pull/511
In case reduction instances are reused, they can be used by several index point of the same index launch. Therefore, in purpose to avoid overwriting data in each cblas/cublas call we need to set `beta=1` to do in-place updates.