### PR TITLE
src/cunumeric/item: add openmp variants for write/read tasks

### DIFF
--- a/src/cunumeric/item/read.h
+++ b/src/cunumeric/item/read.h
@@ -26,6 +26,9 @@ class ReadTask : public CuNumericTask<ReadTask> {
 
  public:
   static void cpu_variant(legate::TaskContext& context);
+#ifdef LEGATE_USE_OPENMP
+  static void omp_variant(legate::TaskContext& context) { ReadTask::cpu_variant(context); }
+#endif
 #ifdef LEGATE_USE_CUDA
   static void gpu_variant(legate::TaskContext& context);
 #endif

--- a/src/cunumeric/item/write.h
+++ b/src/cunumeric/item/write.h
@@ -26,6 +26,9 @@ class WriteTask : public CuNumericTask<WriteTask> {
 
  public:
   static void cpu_variant(legate::TaskContext& context);
+#ifdef LEGATE_USE_OPENMP
+  static void omp_variant(legate::TaskContext& context) { WriteTask::cpu_variant(context); }
+#endif
 #ifdef LEGATE_USE_CUDA
   static void gpu_variant(legate::TaskContext& context);
 #endif


### PR DESCRIPTION
This commit adds OMP variants for the write and read tasks so that they can be used in resource-scoped settings where openmp processors are desired.

Signed-off-by: Rohan Yadav <rohany@alumni.cmu.edu>