### PR TITLE
Fix CI failures due to numpy 1.24 upgrade

### DIFF
--- a/cunumeric/eager.py
+++ b/cunumeric/eager.py
@@ -504,7 +504,7 @@ class EagerArray(NumPyThunk):
                 elif nan_op is ConvertCode.PROD and np.isnan(rhs.array.item()):
                     self.array.fill(1)
                 else:
-                    self.array.fill(rhs.array.item())
+                    self.array.fill(rhs.array.astype(self.array.dtype).item())
             else:
                 if nan_op is ConvertCode.SUM:
                     self.array[:] = np.where(np.isnan(rhs.array), 0, rhs.array)

--- a/tests/integration/test_ndim.py
+++ b/tests/integration/test_ndim.py
@@ -44,9 +44,7 @@ def test_ndarray_empty(input):
     assert np.ndim(input) == num.ndim(input)
 
 
-@pytest.mark.parametrize(
-    "input", (([0], [1, 2], [3, 4, 5]), ([1, 2], [3.3, 4.4]))
-)
+@pytest.mark.parametrize("input", [([1, 2], [3.3, 4.4])])
 def test_python_values_diff_dim(input):
     assert np.ndim(input) == num.ndim(input)
 


### PR DESCRIPTION
@bryevdv Previously NumPy would accept this input, but as of 1.24 it doesn't:

```
np.ndim( ([0], [1, 2], [3, 4, 5]) )
```

So I don't know how to mark the test that compares NumPy and cuNumeric behavior on this input. On NumPy 1.23 it would be a test that's expected to pass, whereas on 1.24 it would be an xfail, since NumPy will exit with a failure. So I just removed that test for now.