### PR TITLE
Fix timing for CuPy tests

### DIFF
--- a/examples/black_scholes.py
+++ b/examples/black_scholes.py
@@ -17,7 +17,7 @@
 
 import argparse
 
-from benchmark import parse_args, run_benchmark, time
+from benchmark import parse_args, run_benchmark
 
 
 def generate_random(N, min, max, D):
@@ -71,11 +71,10 @@ def black_scholes(S, X, T, R, V):
 def run_black_scholes(N, D):
     print("Running black scholes on %dK options..." % N)
     N *= 1000
-    start = time()
+    timer.start()
     S, X, T, R, V = initialize(N, D)
     _, _ = black_scholes(S, X, T, R, V)
-    stop = time()
-    total = (stop - start) / 1000.0
+    total = timer.stop()
     print("Elapsed Time: " + str(total) + " ms")
     return total
 
@@ -99,7 +98,7 @@ if __name__ == "__main__":
         help="precision of the computation in bits",
     )
 
-    args, np = parse_args(parser)
+    args, np, timer = parse_args(parser)
 
     if args.P == 16:
         run_benchmark(

--- a/examples/cg.py
+++ b/examples/cg.py
@@ -17,7 +17,7 @@
 
 import argparse
 
-from benchmark import parse_args, run_benchmark, time
+from benchmark import parse_args, run_benchmark
 
 
 # This is technically dead code right now, but we'll keep it around in
@@ -100,10 +100,10 @@ def run_cg(
         min(max_iters, b.shape[0]) if max_iters is not None else b.shape[0]
     )
 
-    start = time()
+    timer.start()
     for i in range(-warmup, max_iters):
         if i == 0:
-            start = time()
+            timer.start()
         Ap = A.dot(p)
         alpha = rsold / (p.dot(Ap))
         x = x + alpha * p
@@ -123,7 +123,7 @@ def run_cg(
         beta = rsnew / rsold
         p = r + beta * p
         rsold = rsnew
-    stop = time()
+    total = timer.stop()
 
     if converged < 0:
         print("Convergence FAILURE!")
@@ -132,7 +132,6 @@ def run_cg(
     if perform_check:
         check(A, x, b)
 
-    total = (stop - start) / 1000.0
     if timing:
         print(f"Elapsed Time: {total} ms")
     return total
@@ -174,10 +173,10 @@ def run_preconditioned_cg(
         min(max_iters, b.shape[0]) if max_iters is not None else b.shape[0]
     )
 
-    start = time()
+    timer.start()
     for i in range(-warmup, max_iters):
         if i == 0:
-            start = time()
+            timer.start()
         Ap = A.dot(p)
         alpha = rzold / (p.dot(Ap))
         x = x + alpha * p
@@ -199,7 +198,7 @@ def run_preconditioned_cg(
         beta = rznew / rzold
         p = z + beta * p
         rzold = rznew
-    stop = time()
+    total = timer.stop()
 
     if converged < 0:
         print("Convergence FAILURE!")
@@ -208,7 +207,6 @@ def run_preconditioned_cg(
     if perform_check:
         check(A, x, b)
 
-    total = (stop - start) / 1000.0
     if timing:
         print(f"Elapsed Time: {total} ms")
     return total
@@ -290,7 +288,7 @@ if __name__ == "__main__":
         help="convergence check threshold",
     )
 
-    args, np = parse_args(parser)
+    args, np, timer = parse_args(parser)
 
     run_benchmark(
         run_preconditioned_cg if args.precondition else run_cg,

--- a/examples/einsum.py
+++ b/examples/einsum.py
@@ -18,7 +18,7 @@
 import argparse
 import re
 
-from benchmark import parse_args, run_benchmark, time
+from benchmark import parse_args, run_benchmark
 
 
 def run_einsum(expr, N, iters, warmup, dtype, cupy_compatibility):
@@ -82,10 +82,10 @@ def run_einsum(expr, N, iters, warmup, dtype, cupy_compatibility):
     C = np.zeros((N,) * len(c_modes), dtype=dtype)
 
     # Run contraction
-    start = time()
+    timer.start()
     for idx in range(iters + warmup):
         if idx == warmup:
-            start = time()
+            timer.start()
         if cupy_compatibility:
             C = np.einsum(expr, A, B)
         else:
@@ -102,10 +102,9 @@ def run_einsum(expr, N, iters, warmup, dtype, cupy_compatibility):
             A, C = C, A
         else:
             B, C = C, B
-    stop = time()
+    total = timer.stop()
 
     # Print statistics
-    total = (stop - start) / 1000.0
     average = total / iters
     print(f"Elapsed Time: {total:.3f} ms")
     print(f"Average Iteration: {average:.3f} ms")
@@ -162,7 +161,7 @@ if __name__ == "__main__":
              else, use einsum(expr, A, B, out=C)""",
     )
 
-    args, np = parse_args(parser)
+    args, np, timer = parse_args(parser)
 
     cupy_compatibility = args.cupy_compatibility or args.package == "cupy"
     if cupy_compatibility:

--- a/examples/gemm.py
+++ b/examples/gemm.py
@@ -17,7 +17,7 @@
 
 import argparse
 
-from benchmark import parse_args, run_benchmark, time
+from benchmark import parse_args, run_benchmark
 
 
 def initialize(M, N, K, ft):
@@ -44,20 +44,19 @@ def run_gemm(N, I, warmup, ft):  # noqa: E741
     print("Total Size:       " + str(space / 1e6) + " MB")
     A, B, C = initialize(N, N, N, ft)
 
-    start = time()
+    timer.start()
     # Run for as many iterations as was requested
     for idx in range(I + warmup):
         if idx == warmup:
-            start = time()
+            timer.start()
         np.dot(A, B, out=C)
         # We need to rotate the matrices to keep Legate honest
         # about moving data so it can't just duplicate A and B
         # on the first iteration and reuse them, this means
         # that A, B, C all need to be square
         A, B, C = B, C, A
-    stop = time()
+    total = timer.stop()
 
-    total = (stop - start) / 1000.0
     print("Elapsed Time:     " + str(total) + " ms")
     average = total / I
     print("Average GEMM:     " + str(average) + " ms")
@@ -101,7 +100,7 @@ if __name__ == "__main__":
         "(16,32,64)",
     )
 
-    args, np = parse_args(parser)
+    args, np, timer = parse_args(parser)
 
     if args.P == 16:
         run_benchmark(

--- a/examples/indexing_routines.py
+++ b/examples/indexing_routines.py
@@ -19,7 +19,7 @@ import argparse
 import gc
 import math
 
-from benchmark import parse_args, run_benchmark, time
+from benchmark import parse_args, run_benchmark
 
 
 def compute_diagonal(steps, N, timing, warmup):
@@ -27,11 +27,10 @@ def compute_diagonal(steps, N, timing, warmup):
     print("measuring diagonal")
     for step in range(steps + warmup):
         if step == warmup:
-            start = time()
+            timer.start()
         A2 = np.diag(A1)
         A1 = np.diag(A2)
-    stop = time()
-    total = (stop - start) / 1000.0
+    total = timer.stop()
     if timing:
         space = (N * N + N) * np.dtype(int).itemsize / 1073741824
         print("Total Size:       " + str(space) + " GB")
@@ -52,10 +51,9 @@ def compute_choose(steps, N, timing, warmup):
     C1 = np.arange(N, dtype=int) % 10
     for step in range(steps + warmup):
         if step == warmup:
-            start = time()
+            timer.start()
         C1 = np.choose(C1, A, mode="wrap")
-    stop = time()
-    total = (stop - start) / 1000.0
+    total = timer.stop()
     if timing:
         space = N * np.dtype(int).itemsize / 1073741824
         print("Total Size:       " + str(space) + " GB")
@@ -82,10 +80,9 @@ def compute_repeat(steps, N, timing, warmup):
     print("measuring repeat")
     for step in range(steps + warmup):
         if step == warmup:
-            start = time()
+            timer.start()
         A2 = np.repeat(A2, R, axis=1)
-    stop = time()
-    total = (stop - start) / 1000.0
+    total = timer.stop()
     if timing:
         space = (N * N) * np.dtype(int).itemsize / 1073741824
         print("Total Size:       " + str(space) + " GB")
@@ -108,11 +105,10 @@ def compute_advanced_indexing_1d(steps, N, timing, warmup):
     indx_bool = (B % 2).astype(bool)
     for step in range(steps + warmup):
         if step == warmup:
-            start = time()
+            timer.start()
         A1[indx] = 10  # 1 copy
         A1[indx_bool] = 12  # 1 AI and 1 copy
-    stop = time()
-    total = (stop - start) / 1000.0
+    total = timer.stop()
     if timing:
         space = (3 * N) * np.dtype(int).itemsize / 1073741824
         print("Total Size:       " + str(space) + " GB")
@@ -136,12 +132,11 @@ def compute_advanced_indexing_2d(steps, N, timing, warmup):
     indx2d_bool = (A2 % 2).astype(bool)
     for step in range(steps + warmup):
         if step == warmup:
-            start = time()
+            timer.start()
         A2[indx_bool, indx_bool] = 11  # one ZIP and 1 copy = N+N*N
         A2[:, indx] = 12  # one ZIP and 3 copies = N+3*N*N
         A2[indx2d_bool] = 13  # 1 copy and one AI task = 2* N*N
-    stop = time()
-    total = (stop - start) / 1000.0
+    total = timer.stop()
     if timing:
         space = (6 * N * N + 2 * N) * np.dtype(int).itemsize / 1073741824
         print("Total Size:       " + str(space) + " GB")
@@ -171,11 +166,10 @@ def compute_advanced_indexing_3d(steps, N, timing, warmup):
     indx3d_bool = (A3 % 2).astype(bool)
     for step in range(steps + warmup):
         if step == warmup:
-            start = time()
+            timer.start()
         A3[indx, :, indx] = 15  # 1 ZIP and 3 copy = N+3N*N
         A3[indx3d_bool] = 16  # 1 copy and 1 AI task = 2*N*N
-    stop = time()
-    total = (stop - start) / 1000.0
+    total = timer.stop()
     if timing:
         space = (5 * N * N + N) * np.dtype(int).itemsize / 1073741824
         print("Total Size:       " + str(space) + " GB")
@@ -268,7 +262,7 @@ if __name__ == "__main__":
         help="name of the index routine to test",
     )
 
-    args, np = parse_args(parser)
+    args, np, timer = parse_args(parser)
 
     run_benchmark(
         run_indexing_routines,

--- a/examples/jacobi.py
+++ b/examples/jacobi.py
@@ -18,7 +18,7 @@
 import argparse
 import math
 
-from benchmark import parse_args, run_benchmark, time
+from benchmark import parse_args, run_benchmark
 
 
 def generate_random(N):
@@ -45,12 +45,12 @@ def run_jacobi(N, iters, warmup, perform_check, timing, verbose):
     d = np.diag(A)
     R = A - np.diag(d)
 
-    start = time()
+    timer.start()
     for i in range(iters + warmup):
         if i == warmup:
-            start = time()
+            timer.start()
         x = (b - np.dot(R, x)) / d
-    stop = time()
+    total = timer.stop()
 
     if perform_check:
         assert check(A, x, b)
@@ -59,7 +59,6 @@ def run_jacobi(N, iters, warmup, perform_check, timing, verbose):
             np.sum(x)
         ), f"{np.count_nonzero(~np.isnan(x))} NaNs in x"
 
-    total = (stop - start) / 1000.0
     if timing:
         print(f"Elapsed Time: {total} ms")
     return total
@@ -112,7 +111,7 @@ if __name__ == "__main__":
         help="print verbose output",
     )
 
-    args, np = parse_args(parser)
+    args, np, timer = parse_args(parser)
 
     run_benchmark(
         run_jacobi,

--- a/examples/kmeans.py
+++ b/examples/kmeans.py
@@ -19,7 +19,7 @@
 
 import argparse
 
-from benchmark import parse_args, run_benchmark, time
+from benchmark import parse_args, run_benchmark
 
 
 def initialize(N, D, C, T):
@@ -77,7 +77,7 @@ def run_kmeans(C, D, T, I, N, S, benchmarking):  # noqa: E741
     print("Number of dimensions: " + str(D))
     print("Number of centroids: " + str(C))
     print("Max iterations: " + str(I))
-    start = time()
+    timer.start()
     data, centroids = initialize(N, D, C, T)
 
     data_dots = np.square(np.linalg.norm(data, ord=2, axis=1))
@@ -125,8 +125,7 @@ def run_kmeans(C, D, T, I, N, S, benchmarking):  # noqa: E741
         + ": "
         + str(prior_distance_sum)
     )
-    stop = time()
-    total = (stop - start) / 1000.0
+    total = timer.stop()
     print("Elapsed Time: " + str(total) + " ms")
     return total
 
@@ -181,7 +180,7 @@ if __name__ == "__main__":
         help="number of iterations between sampling the log likelihood",
     )
 
-    args, np = parse_args(parser)
+    args, np, timer = parse_args(parser)
 
     if args.P == 16:
         run_benchmark(

--- a/examples/kmeans_slow.py
+++ b/examples/kmeans_slow.py
@@ -19,7 +19,7 @@
 
 import argparse
 
-from benchmark import parse_args, run_benchmark, time
+from benchmark import parse_args, run_benchmark
 
 
 def initialize(N, D, C, T):
@@ -78,7 +78,7 @@ def run_kmeans(C, D, T, I, N, S, benchmarking):  # noqa: E741
     print("Number of dimensions: " + str(D))
     print("Number of centroids: " + str(C))
     print("Max iterations: " + str(I))
-    start = time()
+    timer.start()
     data, centroids = initialize(N, D, C, T)
 
     data_dots = np.square(np.linalg.norm(data, ord=2, axis=1))
@@ -126,8 +126,7 @@ def run_kmeans(C, D, T, I, N, S, benchmarking):  # noqa: E741
         + ": "
         + str(prior_distance_sum)
     )
-    stop = time()
-    total = (stop - start) / 1000.0
+    total = timer.stop()
     print("Elapsed Time: " + str(total) + " ms")
     return total
 
@@ -182,7 +181,7 @@ if __name__ == "__main__":
         help="number of iterations between sampling the log likelihood",
     )
 
-    args, np = parse_args(parser)
+    args, np, timer = parse_args(parser)
 
     if args.P == 16:
         run_benchmark(

--- a/examples/kmeans_sort.py
+++ b/examples/kmeans_sort.py
@@ -19,7 +19,7 @@
 
 import argparse
 
-from benchmark import parse_args, run_benchmark, time
+from benchmark import parse_args, run_benchmark
 
 
 def initialize(N, D, C, T):
@@ -75,7 +75,7 @@ def run_kmeans(C, D, T, I, N, S, benchmarking):  # noqa: E741
     print("Number of dimensions: " + str(D))
     print("Number of centroids: " + str(C))
     print("Max iterations: " + str(I))
-    start = time()
+    timer.start()
     data, centroids = initialize(N, D, C, T)
 
     data_dots = np.square(np.linalg.norm(data, ord=2, axis=1))
@@ -122,8 +122,7 @@ def run_kmeans(C, D, T, I, N, S, benchmarking):  # noqa: E741
         + ": "
         + str(prior_distance_sum)
     )
-    stop = time()
-    total = (stop - start) / 1000.0
+    total = timer.stop()
     print("Elapsed Time: " + str(total) + " ms")
     return total
 
@@ -179,7 +178,7 @@ if __name__ == "__main__":
         help="number of iterations between sampling the log likelihood",
     )
 
-    args, np = parse_args(parser)
+    args, np, timer = parse_args(parser)
 
     if args.P == 16:
         run_benchmark(

--- a/examples/linreg.py
+++ b/examples/linreg.py
@@ -17,7 +17,7 @@
 
 import argparse
 
-from benchmark import parse_args, run_benchmark, time
+from benchmark import parse_args, run_benchmark
 
 
 def initialize(N, F, T):
@@ -41,10 +41,10 @@ def run_linear_regression(N, F, T, I, warmup, S, B):  # noqa: E741
         features = np.hstack((intercept, features))
     weights = np.zeros(features.shape[1], dtype=T)
 
-    start = time()
+    timer.start()
     for step in range(-warmup, I):
         if step == 0:
-            start = time()
+            timer.start()
         scores = np.dot(features, weights)
         error = scores - target
         gradient = -(1.0 / len(features)) * error.dot(features)
@@ -56,9 +56,8 @@ def run_linear_regression(N, F, T, I, warmup, S, B):  # noqa: E741
                 + ": "
                 + str(np.sum(np.power(error, 2)))
             )
-    stop = time()
+    total = timer.stop()
 
-    total = (stop - start) / 1000.0
     print("Elapsed Time: " + str(total) + " ms")
     return total
 
@@ -121,7 +120,7 @@ if __name__ == "__main__":
         help="number of iterations between sampling the log likelihood",
     )
 
-    args, np = parse_args(parser)
+    args, np, timer = parse_args(parser)
 
     if args.P == 16:
         run_benchmark(

--- a/examples/logreg.py
+++ b/examples/logreg.py
@@ -18,7 +18,7 @@
 import argparse
 import math
 
-from benchmark import parse_args, run_benchmark, time
+from benchmark import parse_args, run_benchmark
 
 
 def initialize(N, F, T):
@@ -52,10 +52,10 @@ def run_logistic_regression(N, F, T, I, warmup, S, B):  # noqa: E741
         features = np.hstack((intercept, features))
     weights = np.zeros(features.shape[1], dtype=T)
 
-    start = time()
+    timer.start()
     for step in range(-warmup, I):
         if step == 0:
-            start = time()
+            timer.start()
         scores = np.dot(features, weights)
         predictions = sigmoid(scores)
         error = target - predictions
@@ -68,13 +68,12 @@ def run_logistic_regression(N, F, T, I, warmup, S, B):  # noqa: E741
                 + ": "
                 + str(log_likelihood(features, target, weights))
             )
-    stop = time()
+    total = timer.stop()
 
     assert not math.isnan(
         np.sum(weights)
     ), f"{np.count_nonzero(~np.isnan(weights))} NaNs in weights"
 
-    total = (stop - start) / 1000.0
     print(f"Elapsed Time: {total} ms")
     return total
 
@@ -137,7 +136,7 @@ if __name__ == "__main__":
         help="number of iterations between sampling the log likelihood",
     )
 
-    args, np = parse_args(parser)
+    args, np, timer = parse_args(parser)
 
     if args.P == 16:
         run_benchmark(

--- a/examples/lstm_backward.py
+++ b/examples/lstm_backward.py
@@ -17,11 +17,11 @@
 
 import argparse
 
-from benchmark import parse_args, run_benchmark, time
+from benchmark import parse_args, run_benchmark
 
 
 def run_lstm(batch_size, hidden_size, sentence_length, word_size, timing):
-    start = time()
+    timer.start()
 
     WLSTM = np.random.randn(
         word_size + hidden_size, 4 * hidden_size
@@ -73,8 +73,7 @@ def run_lstm(batch_size, hidden_size, sentence_length, word_size, timing):
         else:
             dh0[0] += np.sum(dHin[t, :, word_size:], 0)
 
-    stop = time()
-    total = (stop - start) / 1000.0
+    total = timer.stop()
     if timing:
         print("Elapsed Time: " + str(total) + " ms")
     return total
@@ -107,7 +106,7 @@ if __name__ == "__main__":
         help="perform timing",
     )
 
-    args, np = parse_args(parser)
+    args, np, timer = parse_args(parser)
 
     run_benchmark(
         run_lstm,

--- a/examples/lstm_forward.py
+++ b/examples/lstm_forward.py
@@ -17,11 +17,11 @@
 
 import argparse
 
-from benchmark import parse_args, run_benchmark, time
+from benchmark import parse_args, run_benchmark
 
 
 def run_lstm(batch_size, hidden_size, sentence_length, word_size, timing):
-    start = time()
+    timer.start()
 
     X = np.random.randn(sentence_length, batch_size, hidden_size)
     h0 = np.random.randn(1, hidden_size)
@@ -63,8 +63,7 @@ def run_lstm(batch_size, hidden_size, sentence_length, word_size, timing):
         Ct[t] = np.tanh(C[t])
         Hout[t] = IFOGf[t, :, 2 * d : 3 * d] * Ct[t]
 
-    stop = time()
-    total = (stop - start) / 1000.0
+    total = timer.stop()
     if timing:
         print("Elapsed Time: " + str(total) + " ms")
     return total
@@ -97,7 +96,7 @@ if __name__ == "__main__":
         help="perform timing",
     )
 
-    args, np = parse_args(parser)
+    args, np, timer = parse_args(parser)
 
     run_benchmark(
         run_lstm,

--- a/examples/lstm_full.py
+++ b/examples/lstm_full.py
@@ -17,7 +17,7 @@
 
 import argparse
 
-from benchmark import parse_args, run_benchmark, time
+from benchmark import parse_args, run_benchmark
 
 
 class Param:
@@ -290,7 +290,7 @@ def run_lstm(
 
     pointer = 0
 
-    start = time()
+    timer.start()
 
     for iteration in range(max_iters):
         # Reset
@@ -325,8 +325,7 @@ def run_lstm(
         pointer += T_steps
     update_status(max_iters, smooth_loss)
 
-    stop = time()
-    total = (stop - start) / 1000.0
+    total = timer.stop()
     if timing:
         print("Elapsed Time: " + str(total) + " ms")
     return total
@@ -397,7 +396,7 @@ if __name__ == "__main__":
         help="standard deviation of weights for initialization",
     )
 
-    args, np = parse_args(parser)
+    args, np, timer = parse_args(parser)
 
     run_benchmark(
         run_lstm,

--- a/examples/richardson_lucy.py
+++ b/examples/richardson_lucy.py
@@ -15,7 +15,7 @@
 
 import argparse
 
-from benchmark import parse_args, run_benchmark, time
+from benchmark import parse_args, run_benchmark
 
 float_type = "float32"
 
@@ -28,17 +28,16 @@ def run_richardson_lucy(shape, filter_shape, num_iter, warmup, timing):
     im_deconv = np.full(image.shape, 0.5, dtype=float_type)
     psf_mirror = np.flip(psf)
 
-    start = time()
+    timer.start()
 
     for idx in range(num_iter + warmup):
         if idx == warmup:
-            start = time()
+            timer.start()
         conv = np.convolve(im_deconv, psf, mode="same")
         relative_blur = image / conv
         im_deconv *= np.convolve(relative_blur, psf_mirror, mode="same")
 
-    stop = time()
-    total = (stop - start) / 1000.0
+    total = timer.stop()
     if timing:
         print("Elapsed Time: " + str(total) + " ms")
 
@@ -111,7 +110,7 @@ if __name__ == "__main__":
         help="perform timing",
     )
 
-    args, np = parse_args(parser)
+    args, np, timer = parse_args(parser)
 
     run_benchmark(
         run_richardson_lucy,

--- a/examples/scan.py
+++ b/examples/scan.py
@@ -18,7 +18,7 @@
 import argparse
 
 import numpy as np
-from benchmark import parse_args, run_benchmark, time
+from benchmark import parse_args, run_benchmark
 
 
 def initialize(shape, dt, axis):
@@ -74,13 +74,12 @@ def run_scan(OP, shape, dt, ax, check):
     print(f"Axis:            axis={ax}")
     print(f"Data type:       dtype={dt}32")
     A, B = initialize(shape=shape, dt=dt, axis=ax)
-    start = time()
+    timer.start()
 
     # op handling
     getattr(num, OP)(A, out=B, axis=ax)
 
-    stop = time()
-    total = (stop - start) / 1000.0
+    total = timer.stop()
     print(f"Elapsed Time:  {total}ms")
     # error checking
     if check:
@@ -130,7 +129,7 @@ if __name__ == "__main__":
         help="check the result of the solve",
     )
 
-    args, num = parse_args(parser)
+    args, num, timer = parse_args(parser)
 
     run_benchmark(
         run_scan,

--- a/examples/solve.py
+++ b/examples/solve.py
@@ -17,18 +17,17 @@
 
 import argparse
 
-from benchmark import parse_args, run_benchmark, time
+from benchmark import parse_args, run_benchmark
 
 
 def solve(m, n, nrhs, dtype):
     a = np.random.rand(m, n).astype(dtype=dtype)
     b = np.random.rand(n, nrhs).astype(dtype=dtype)
 
-    start = time()
+    timer.start()
     np.linalg.solve(a, b)
-    stop = time()
+    total = timer.stop()
 
-    total = (stop - start) / 1000.0
     print(f"Elapsed Time: {total} ms")
 
 
@@ -66,7 +65,7 @@ if __name__ == "__main__":
         dest="dtype",
         help="data type",
     )
-    args, np = parse_args(parser)
+    args, np, timer = parse_args(parser)
 
     run_benchmark(
         solve,

--- a/examples/sort.py
+++ b/examples/sort.py
@@ -18,7 +18,7 @@
 import argparse
 
 import numpy as np
-from benchmark import parse_args, run_benchmark, time
+from benchmark import parse_args, run_benchmark
 
 
 def check_sorted(a, a_sorted, package, axis=-1):
@@ -73,19 +73,18 @@ def run_sort(
         print("UNKNOWN type " + str(newtype))
         assert False
 
-    start = time()
+    timer.start()
     if argsort:
         a_sorted = num.argsort(a, axis)
     else:
         a_sorted = num.sort(a, axis)
-    stop = time()
+    total = timer.stop()
 
     if perform_check and not argsort:
         check_sorted(a, a_sorted, package, axis)
     else:
         # do we need to synchronize?
         assert True
-    total = (stop - start) * 1e-3
     if timing:
         print("Elapsed Time: " + str(total) + " ms")
     return total
@@ -155,7 +154,7 @@ if __name__ == "__main__":
         help="use argsort",
     )
 
-    args, num = parse_args(parser)
+    args, num, timer = parse_args(parser)
 
     run_benchmark(
         run_sort,

--- a/examples/stencil.py
+++ b/examples/stencil.py
@@ -17,7 +17,7 @@
 
 import argparse
 
-from benchmark import parse_args, run_benchmark, time
+from benchmark import parse_args, run_benchmark
 
 
 def initialize(N):
@@ -40,16 +40,15 @@ def run_stencil(N, I, warmup, timing):  # noqa: E741
     west = grid[1:-1, 0:-2]
     south = grid[2:, 1:-1]
 
-    start = time()
+    timer.start()
     for i in range(I + warmup):
         if i == warmup:
-            start = time()
+            timer.start()
         average = center + north + east + west + south
         work = 0.2 * average
         center[:] = work
-    stop = time()
+    total = timer.stop()
 
-    total = (stop - start) / 1000.0
     if timing:
         print(f"Elapsed Time: {total} ms")
     return total
@@ -89,7 +88,7 @@ if __name__ == "__main__":
         help="perform timing",
     )
 
-    args, np = parse_args(parser)
+    args, np, timer = parse_args(parser)
 
     run_benchmark(
         run_stencil,


### PR DESCRIPTION
CuPy launches work asynchronously on the GPU, so we need to block until all work finishes before taking a measurement.