### PR TITLE
Pass `CMAKE_GENERATOR` to scikit-build

### DIFF
--- a/install.py
+++ b/install.py
@@ -490,7 +490,10 @@ def driver():
         "--cmake-generator",
         dest="cmake_generator",
         required=False,
-        default=os.environ.get("CMAKE_GENERATOR", "Unix Makefiles" if shutil.which("ninja") is None else "Ninja"),
+        default=os.environ.get(
+            "CMAKE_GENERATOR",
+            "Unix Makefiles" if shutil.which("ninja") is None else "Ninja",
+        ),
         choices=["Ninja", "Unix Makefiles", None],
         help="The CMake makefiles generator",
     )

--- a/install.py
+++ b/install.py
@@ -350,18 +350,18 @@ def install_cunumeric(
     cmake_flags += ["-Dlegate_core_ROOT=%s" % legate_dir]
 
     cmake_flags += extra_flags
-    ninja_flags = [f"-j{str(thread_count)}"]
+    build_flags = [f"-j{str(thread_count)}"]
     if verbose:
         if cmake_generator == "Unix Makefiles":
-            ninja_flags += ["VERBOSE=1"]
+            build_flags += ["VERBOSE=1"]
         else:
-            ninja_flags += ["--verbose"]
+            build_flags += ["--verbose"]
 
     cmd_env.update(
         {
             "CMAKE_ARGS": " ".join(cmake_flags),
             "CMAKE_GENERATOR": cmake_generator,
-            "SKBUILD_BUILD_OPTIONS": " ".join(ninja_flags),
+            "SKBUILD_BUILD_OPTIONS": " ".join(build_flags),
         }
     )
 


### PR DESCRIPTION
This PR ensures scikit-build uses the desired generator for all CMake invocations. This short-circuits scikit-build's internal generator "detection" logic, which caused failures if they detected a different generator than the one we were specifying.