### PR TITLE
Expose command args for legate driver help. 

### DIFF
--- a/cunumeric/__init__.py
+++ b/cunumeric/__init__.py
@@ -24,21 +24,31 @@ with GPU acceleration.
 """
 from __future__ import annotations
 
-import numpy as _np
+import os
 
-from cunumeric import linalg, random, fft
-from cunumeric.array import ndarray
-from cunumeric.bits import packbits, unpackbits
-from cunumeric.module import *
-from cunumeric._ufunc import *
-from cunumeric.logic import *
-from cunumeric.window import bartlett, blackman, hamming, hanning, kaiser
-from cunumeric.coverage import clone_module
+# This is somewhat ugly, but it is to allow the legate driver to access
+# cunumeric's library-specific arguments, so that better help information
+# can be provided to users.
+if os.environ.get("_LEGATE_PROJECT_HELP_ARGS_") == "1":
+    from .args import ARGS
 
-clone_module(_np, globals())
+else:
 
-del clone_module
-del _np
+    import numpy as _np
+
+    from cunumeric import linalg, random, fft
+    from cunumeric.array import ndarray
+    from cunumeric.bits import packbits, unpackbits
+    from cunumeric.module import *
+    from cunumeric._ufunc import *
+    from cunumeric.logic import *
+    from cunumeric.window import bartlett, blackman, hamming, hanning, kaiser
+    from cunumeric.coverage import clone_module
+
+    clone_module(_np, globals())
+
+    del clone_module
+    del _np
 
 from . import _version
 

--- a/cunumeric/args.py
+++ b/cunumeric/args.py
@@ -1,0 +1,76 @@
+# Copyright 2021-2022 NVIDIA Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from __future__ import annotations
+
+from legate.util.args import ArgSpec, Argument
+
+ARGS = [
+    Argument(
+        "test",
+        ArgSpec(
+            action="store_true",
+            default=False,
+            dest="test_mode",
+            help="Enable test mode. In test mode, all cuNumeric ndarrays are managed by the distributed runtime and the NumPy fallback for small arrays is turned off.",  # noqa E501
+        ),
+    ),
+    Argument(
+        "preload-cudalibs",
+        ArgSpec(
+            action="store_true",
+            default=False,
+            dest="preload_cudalibs",
+            help="Preload and initialize handles of all CUDA libraries (cuBLAS, cuSOLVER, etc.) used in cuNumericLoad CUDA libs early",  # noqa E501
+        ),
+    ),
+    Argument(
+        "warn",
+        ArgSpec(
+            action="store_true",
+            default=False,
+            dest="warning",
+            help="Turn on warnings",
+        ),
+    ),
+    Argument(
+        "report:coverage",
+        ArgSpec(
+            action="store_true",
+            default=False,
+            dest="report_coverage",
+            help="Print an overall percentage of cunumeric coverage",
+        ),
+    ),
+    Argument(
+        "report:dump-callstack",
+        ArgSpec(
+            action="store_true",
+            default=False,
+            dest="report_dump_callstack",
+            help="Print an overall percentage of cunumeric coverage with call stack details",  # noqa E501
+        ),
+    ),
+    Argument(
+        "report:dump-csv",
+        ArgSpec(
+            action="store",
+            type=str,
+            nargs="?",
+            default=None,
+            dest="report_dump_csv",
+            help="Save a coverage report to a specified CSV file",
+        ),
+    ),
+]

--- a/cunumeric/runtime.py
+++ b/cunumeric/runtime.py
@@ -23,9 +23,10 @@ import legate.core.types as ty
 import numpy as np
 from legate.core import LEGATE_MAX_DIM, Rect, get_legate_runtime, legion
 from legate.core.context import Context as LegateContext
-from legate.util.args import ArgSpec, Argument, parse_library_command_args
+from legate.util.args import parse_library_command_args
 from typing_extensions import TypeGuard
 
+from .args import ARGS
 from .config import (
     _CUNUMERIC_DTYPES,
     BitGeneratorOperation,
@@ -52,65 +53,6 @@ if TYPE_CHECKING:
     from legate.core.operation import AutoTask, ManualTask
 
     from .array import ndarray
-
-ARGS = [
-    Argument(
-        "test",
-        ArgSpec(
-            action="store_true",
-            default=False,
-            dest="test_mode",
-            help="Enable test mode. In test mode, all cuNumeric ndarrays are managed by the distributed runtime and the NumPy fallback for small arrays is turned off.",  # noqa E501
-        ),
-    ),
-    Argument(
-        "preload-cudalibs",
-        ArgSpec(
-            action="store_true",
-            default=False,
-            dest="preload_cudalibs",
-            help="Preload and initialize handles of all CUDA libraries (cuBLAS, cuSOLVER, etc.) used in cuNumericLoad CUDA libs early",  # noqa E501
-        ),
-    ),
-    Argument(
-        "warn",
-        ArgSpec(
-            action="store_true",
-            default=False,
-            dest="warning",
-            help="Turn on warnings",
-        ),
-    ),
-    Argument(
-        "report:coverage",
-        ArgSpec(
-            action="store_true",
-            default=False,
-            dest="report_coverage",
-            help="Print an overall percentage of cunumeric coverage",
-        ),
-    ),
-    Argument(
-        "report:dump-callstack",
-        ArgSpec(
-            action="store_true",
-            default=False,
-            dest="report_dump_callstack",
-            help="Print an overall percentage of cunumeric coverage with call stack details",  # noqa E501
-        ),
-    ),
-    Argument(
-        "report:dump-csv",
-        ArgSpec(
-            action="store",
-            type=str,
-            nargs="?",
-            default=None,
-            dest="report_dump_csv",
-            help="Save a coverage report to a specified CSV file",
-        ),
-    ),
-]
 
 
 class Runtime(object):

--- a/cunumeric/runtime.py
+++ b/cunumeric/runtime.py
@@ -23,7 +23,7 @@ import legate.core.types as ty
 import numpy as np
 from legate.core import LEGATE_MAX_DIM, Rect, get_legate_runtime, legion
 from legate.core.context import Context as LegateContext
-from legate.rc import ArgSpec, Argument, parse_command_args
+from legate.util.args import ArgSpec, Argument, parse_library_command_args
 from typing_extensions import TypeGuard
 
 from .config import (
@@ -149,7 +149,7 @@ class Runtime(object):
         self.has_curand = cunumeric_lib.shared_object.cunumeric_has_curand()
         self._register_dtypes()
 
-        self.args = parse_command_args("cunumeric", ARGS)
+        self.args = parse_library_command_args("cunumeric", ARGS)
         self.args.warning = self.args.warning or self.args.test_mode
 
         if self.num_gpus > 0 and self.args.preload_cudalibs:


### PR DESCRIPTION
This PR has prefactory work to allow the legate driver help to include command-line flags for known, installed downstream projects e.g. cunumeric.

In order to allow `cunumeric.ARGS` to importable form plain-python apps like the driver, an environment variable "override" can be set to suppress all the API imports. This is clunky, but is only utilized in the driver's `print_help` function