### PR TITLE
Pin `scikit-build` to `v0.16.4`

### DIFF
--- a/conda/conda-build/meta.yaml
+++ b/conda/conda-build/meta.yaml
@@ -111,7 +111,7 @@ requirements:
     # cudart needed for CPU and GPU builds because of curand
     - cuda-cudart-dev ={{ cuda_version }}
     - python
-    - scikit-build
+    - scikit-build >=0.13.1,<0.16.5
     - openblas =* =*openmp*
 {% if not gpu_enabled_bool %}
     - legate-core ={{ core_version }} =*_cpu

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ requires = [
     "wheel",
     "ninja",
     "setuptools",
-    "scikit-build>=0.13.1",
+    "scikit-build>=0.13.1,<0.16.5",
     "cmake>=3.22.1,!=3.23.0,!=3.25.0",
 ]
 


### PR DESCRIPTION
Pin `scikit-build` to `v0.16.4` to workaround https://github.com/scikit-build/scikit-build/issues/845.

Related legate PR: https://github.com/nv-legate/legate.core/pull/540