### PR TITLE
Change the default CPU architecture to haswell

### DIFF
--- a/install.py
+++ b/install.py
@@ -529,7 +529,7 @@ def driver():
         "--march",
         dest="march",
         required=False,
-        default="native",
+        default=("haswell" if platform.machine() == "x86_64" else "native"),
         help="Specify the target CPU architecture.",
     )
     parser.add_argument(


### PR DESCRIPTION
Change the default architecture to haswell. Currently, we build our conda packages with haswell to avoid compatibility issues. Changing the default architecture to haswell will make default builds comparable to the conda packages and it will allow developers to share sccache with CI builds.