### PR TITLE
handle numpy 'builtins' properly for coverage

### DIFF
--- a/cunumeric/coverage.py
+++ b/cunumeric/coverage.py
@@ -17,7 +17,13 @@ from __future__ import annotations
 import warnings
 from dataclasses import dataclass
 from functools import wraps
-from types import FunctionType, MethodDescriptorType, MethodType, ModuleType
+from types import (
+    BuiltinFunctionType,
+    FunctionType,
+    MethodDescriptorType,
+    MethodType,
+    ModuleType,
+)
 from typing import Any, Container, Mapping, Optional, cast
 
 import numpy as np
@@ -194,7 +200,9 @@ def unimplemented(
 
 
 def clone_module(
-    origin_module: ModuleType, new_globals: dict[str, Any]
+    origin_module: ModuleType,
+    new_globals: dict[str, Any],
+    include_builtin_function_type: bool = False,
 ) -> None:
     """Copy attributes from one module to another, excluding submodules
 
@@ -230,7 +238,10 @@ def clone_module(
         # Only need to wrap things that are in the origin module to begin with
         if attr not in origin_module.__dict__:
             continue
-        if isinstance(value, (FunctionType, lgufunc)):
+        if isinstance(value, (FunctionType, lgufunc)) or (
+            include_builtin_function_type
+            and isinstance(value, BuiltinFunctionType)
+        ):
             wrapped = implemented(
                 cast(AnyCallable, value), mod_name, attr, reporting=reporting
             )
@@ -239,7 +250,10 @@ def clone_module(
     from numpy import ufunc as npufunc
 
     for attr, value in missing.items():
-        if isinstance(value, (FunctionType, npufunc)):
+        if isinstance(value, (FunctionType, npufunc)) or (
+            include_builtin_function_type
+            and isinstance(value, BuiltinFunctionType)
+        ):
             wrapped = unimplemented(value, mod_name, attr, reporting=reporting)
             new_globals[attr] = wrapped
         else:

--- a/cunumeric/random/__init__.py
+++ b/cunumeric/random/__init__.py
@@ -25,7 +25,7 @@ if runtime.has_curand:
 else:
     from cunumeric.random.legacy import *
 
-clone_module(_nprandom, globals())
+clone_module(_nprandom, globals(), include_builtin_function_type=True)
 
 del clone_module
 del _nprandom


### PR DESCRIPTION
fixes #761 

Some functions in `numpy.random` were being missed by `clone_module` because their type is `BuiltinFunctionType` which was not previously included by the `coverage` machinery. Presumably the functions have this type because they are implemented in C. Unfortunately, we cannot just add this new type unconditionally everywhere, since it will pick up actual built-in functions, which causes problems. As a compromise, the addition of this type was put behind a flag, which is now turned on only when `numpy.random` is cloned. 

With this change:
```
dev310 ❯ legate ~/tmp/foo.py 
/home/bryan/tmp/foo.py:2: RuntimeWarning: cuNumeric has not implemented numpy.random.permutation and is falling back to canonical numpy. You may notice significantly decreased performance for this function call.
  np.random.permutation(5)
```

I don't really love this, but also can't think of any other way to handle this. I did try to find other ways to distinguish these functions that could be used instead of an explicit flag, but did not find anything usable. I am also not really sure how to effectively unit test this yet. 

### Other modules 

I only applied this change to `numpy.random` which reports many "builtin" functions that were not getting coverage wrappers added. There is nothing in `numpy.fft` that this applies to, and the only thing in `numpy.linalg` is:
```
normalize_axis_index <class 'builtin_function_or_method'>
```
which I don't think we need to worry about (it's just a help function)