### PR TITLE
Rename setup to setup_method

### DIFF
--- a/tests/integration/test_append.py
+++ b/tests/integration/test_append.py
@@ -59,7 +59,7 @@ def test_append_axis_none(size_a, size_b):
 
 
 class TestAppendErrors:
-    def setup(self):
+    def setup_method(self):
         size_a = (1, DIM)
         self.a = np.random.randint(low=0, high=100, size=size_a)
 

--- a/tests/integration/test_array_creation.py
+++ b/tests/integration/test_array_creation.py
@@ -90,7 +90,7 @@ SHAPES_NEGATIVE = [
 
 
 class TestCreationErrors:
-    def setup(self):
+    def setup_method(self):
         self.bad_type_shape = (2, 3.0)
 
     @pytest.mark.parametrize("shape", SHAPES_NEGATIVE, ids=str)

--- a/tests/integration/test_flatten.py
+++ b/tests/integration/test_flatten.py
@@ -44,7 +44,7 @@ def test_basic(order, size):
 
 
 class TestNdarrayFlattenErrors:
-    def setup(self):
+    def setup_method(self):
         size_a = (1, DIM)
         anp = np.random.randint(low=0, high=100, size=size_a)
         self.anum = num.array(anp)

--- a/tests/integration/test_moveaxis.py
+++ b/tests/integration/test_moveaxis.py
@@ -74,7 +74,7 @@ def test_moveaxis_with_empty_array(a):
 
 
 class TestMoveAxisErrors:
-    def setup(self):
+    def setup_method(self):
         self.x = num.ones((3, 4, 5))
 
     def test_repeated_axis(self):

--- a/tests/integration/test_put_along_axis.py
+++ b/tests/integration/test_put_along_axis.py
@@ -121,7 +121,7 @@ def test_empty_indice():
 
 
 class TestPutAlongAxisErrors:
-    def setup(self):
+    def setup_method(self):
         self.a = num.ones((3, 3))
         self.ai = num.ones((3, 3), dtype=int)
 

--- a/tests/integration/test_take_along_axis.py
+++ b/tests/integration/test_take_along_axis.py
@@ -72,7 +72,7 @@ def test_empty_indice():
 
 
 class TestTakeAlongAxisErrors:
-    def setup(self):
+    def setup_method(self):
         self.a = num.ones((3, 3))
         self.ai = num.ones((3, 3), dtype=int)
 


### PR DESCRIPTION
Happened to notice that some of our tests use a deprecated form of defining a setup method:
```
tests/integration/test_put_along_axis.py::TestPutAlongAxisErrors::test_values_bad_shape[(shape=(1, 0))]
  /home/bryan/anaconda3/envs/dev310/lib/python3.10/site-packages/_pytest/fixtures.py:900: PytestRemovedIn8Warning: Support for nose tests is deprecated and will be removed in a future release.
  tests/integration/test_put_along_axis.py::TestPutAlongAxisErrors::test_values_bad_shape[(shape=(1, 0))] is using nose-specific method: `setup(self)`
  To remove this warning, rename it to `setup_method(self)`
```

This PR performs the rename wherever appropriate in order to avoid surprise failures with a future version of `pytest`