### PR TITLE
Forward parallelism level to dependencies when building with cmake in conda

### DIFF
--- a/conda/conda-build/build.sh
+++ b/conda/conda-build/build.sh
@@ -14,6 +14,7 @@ if [ -z "$CPU_ONLY" ]; then
   CMAKE_ARGS+="
 -Dcutensor_DIR=$PREFIX
 -DCMAKE_CUDA_ARCHITECTURES:LIST=60-real;70-real;75-real;80-real;90
+-DBUILD_MARCH=haswell
 "
 else
   # When we build without cuda, we need to provide the location of curand

--- a/conda/conda-build/build.sh
+++ b/conda/conda-build/build.sh
@@ -32,7 +32,7 @@ export CUDAHOSTCXX=${CXX}
 
 echo "Build starting on $(date)"
 
-cmake -S . -B build ${CMAKE_ARGS}
+cmake -S . -B build ${CMAKE_ARGS} -DCMAKE_BUILD_PARALLEL_LEVEL=$CPU_COUNT
 cmake --build build -j$CPU_COUNT
 cmake --install build
 


### PR DESCRIPTION
Because the build of dependencies is configured during the configure stage of cmake, we need to set parallelism during that stage as well.