### PR TITLE
Avoid an internal use of np.result_type

### DIFF
--- a/cunumeric/module.py
+++ b/cunumeric/module.py
@@ -710,11 +710,8 @@ def linspace(
         raise ValueError("Number of samples, %s, must be non-negative." % num)
     div = (num - 1) if endpoint else num
 
-    dt = (
-        np.complex128
-        if np.find_common_type((start.dtype, stop.dtype), ()).kind == "c"
-        else np.float64
-    )
+    common_kind = np.find_common_type((start.dtype, stop.dtype), ()).kind
+    dt = np.complex128 if common_kind == "c" else np.float64
     if dtype is None:
         dtype = dt
 

--- a/cunumeric/module.py
+++ b/cunumeric/module.py
@@ -710,7 +710,11 @@ def linspace(
         raise ValueError("Number of samples, %s, must be non-negative." % num)
     div = (num - 1) if endpoint else num
 
-    dt = np.result_type(start, stop, float(num))
+    dt = (
+        np.complex128
+        if np.find_common_type((start.dtype, stop.dtype), ()).kind == "c"
+        else np.float64
+    )
     if dtype is None:
         dtype = dt
 

--- a/tests/integration/test_linspace.py
+++ b/tests/integration/test_linspace.py
@@ -316,11 +316,11 @@ class TestLinspaceErrors:
             num.linspace(self.start, stop)
 
     def test_start_none(self):
-        with pytest.raises(TypeError):
+        with pytest.raises(Exception):
             num.linspace(None, 10, num=5)
 
     def test_stop_none(self):
-        with pytest.raises(TypeError):
+        with pytest.raises(Exception):
             num.linspace(0, None, num=5)
 
 


### PR DESCRIPTION
Did some quick runs to ascertain the casting behavior:

```
>>> for dtype in [np.int8, np.int16, np.int32, np.int64, np.uint8, np.uint16, np.uint32, np.uint64, np.float16, np.float32, np.float64, np.complex64, np.complex128]:
...     print(dtype, np.linspace(dtype(0),dtype(100),3).dtype)
...
<class 'numpy.int8'> float64
<class 'numpy.int16'> float64
<class 'numpy.int32'> float64
<class 'numpy.int64'> float64
<class 'numpy.uint8'> float64
<class 'numpy.uint16'> float64
<class 'numpy.uint32'> float64
<class 'numpy.uint64'> float64
<class 'numpy.float16'> float64
<class 'numpy.float32'> float64
<class 'numpy.float64'> float64
<class 'numpy.complex64'> complex128
<class 'numpy.complex128'> complex128
>>> np.linspace(np.int32(0),np.float32(100),3).dtype
dtype('float64')
>>> np.linspace(np.complex64(0),np.float32(100),3).dtype
dtype('complex128')
```

This also agrees with the operation documentation:

```
The type of the output array. If [dtype](https://numpy.org/doc/stable/reference/generated/numpy.dtype.html#numpy.dtype) is not given, the data type is inferred from start and stop. The inferred dtype will never be an integer; float is chosen even if the arguments would produce an array of integers.
```

Since `None` is not an expected input for this operation, I think it's fine to not worry about the specific exception type that gets thrown in that case, but happy to adjust if you suggest otherwise.