### PR TITLE
Changes for sphinx theme 0.13

### DIFF
--- a/docs/cunumeric/source/conf.py
+++ b/docs/cunumeric/source/conf.py
@@ -53,8 +53,10 @@ html_static_path = ["_static"]
 html_theme = "pydata_sphinx_theme"
 
 html_theme_options = {
-    "footer_items": ["copyright"],
+    "footer_start": ["copyright"],
     "github_url": "https://github.com/nv-legate/cunumeric",
+    # https://github.com/pydata/pydata-sphinx-theme/issues/1220
+    "icon_links": [],
     "logo": {"text": project, "link": "https://nv-legate.github.io/cunumeric"},
     "navbar_align": "left",
     "navbar_end": ["navbar-icon-links", "theme-switcher"],


### PR DESCRIPTION
Recently released pydata-sphinx theme 0.13 has some issues:

* deprecation warning causes build fail with strict warnings enabled
* https://github.com/pydata/pydata-sphinx-theme/issues/1220 

We could also cap the theme version to 0.12 but as long as we have to update three repos to set a version I'd rather set 0.13 as new min. 

@magnatelee I did verify that legate docs PR builds with 0.13