### PR TITLE
Update BUILD.md

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -77,4 +77,4 @@ The Python source tree and CMake build tree are now available with the environme
 for running cuNumeric programs. The diagram below illustrates the
 complete workflow for building both Legate core and cuNumeric.
 
-<img src="https://raw.githubusercontent.com/nv-legate/cunumeric/branch-23.05/docs/figures/developer-build.png" alt="drawing" width="600"/>
+<img src="https://raw.githubusercontent.com/nv-legate/cunumeric/branch-23.03/docs/figures/developer-build.png" alt="drawing" width="600"/>

--- a/BUILD.md
+++ b/BUILD.md
@@ -77,4 +77,4 @@ The Python source tree and CMake build tree are now available with the environme
 for running cuNumeric programs. The diagram below illustrates the
 complete workflow for building both Legate core and cuNumeric.
 
-<img src="docs/figures/developer-build.png" alt="drawing" width="600"/>
+<img src="https://raw.githubusercontent.com/nv-legate/cunumeric/branch-23.05/docs/figures/developer-build.png" alt="drawing" width="600"/>


### PR DESCRIPTION
Temp fix to get the image at the bottom of BUILD.md to appear both in the markdown on GitHub, and in the sphinx docs.

note: this is presently  against `branch-23.03` let me know if it should be re-targeted