### PR TITLE
Fix bugs in concatenate and stack APIs.

### DIFF
--- a/cunumeric/module.py
+++ b/cunumeric/module.py
@@ -1761,6 +1761,12 @@ def concatenate(
     --------
     Multiple GPUs, Multiple CPUs
     """
+    if dtype is not None and out is not None:
+        raise TypeError(
+            "concatenate() only takes `out` or `dtype` as an argument,"
+            "but both were provided."
+        )
+
     # flatten arrays if axis == None and concatenate arrays on the first axis
     if axis is None:
         inputs = list(inp.ravel() for inp in inputs)

--- a/cunumeric/module.py
+++ b/cunumeric/module.py
@@ -56,6 +56,13 @@ _builtin_max = max
 _builtin_min = min
 _builtin_sum = sum
 
+casting_kinds: tuple[CastingKind, ...] = (
+    "no",
+    "equiv",
+    "safe",
+    "same_kind",
+    "unsafe",
+)
 
 #########################
 # Array creation routines
@@ -1765,6 +1772,12 @@ def concatenate(
         raise TypeError(
             "concatenate() only takes `out` or `dtype` as an argument,"
             "but both were provided."
+        )
+
+    if casting not in casting_kinds:
+        raise ValueError(
+            "casting must be one of 'no', 'equiv', "
+            "'safe', 'same_kind', or 'unsafe'"
         )
 
     # flatten arrays if axis == None and concatenate arrays on the first axis

--- a/tests/integration/test_concatenate_stack.py
+++ b/tests/integration/test_concatenate_stack.py
@@ -227,7 +227,6 @@ class TestConcatenateErrors:
                 dtype=dtype,
             )
 
-    @pytest.mark.xfail
     def test_invalid_casting(self):
         # In Numpy, raise ValueError
         # In cuNumeric, pass

--- a/tests/integration/test_concatenate_stack.py
+++ b/tests/integration/test_concatenate_stack.py
@@ -180,16 +180,11 @@ class TestConcatenateErrors:
         (
             ([[1, 2], [3, 4]], [5, 6]),
             ([[1, 2], [3, 4], [5, 6]], [[7, 8], [9, 10]]),
-            pytest.param(
-                ([[1, 2], [3, 4]], [[5, 6]]), marks=pytest.mark.xfail
-            ),
+            ([[1, 2], [3, 4]], [[5, 6]]),
         ),
         ids=lambda arrays: f"(arrays={arrays})",
     )
     def test_arrays_mismatched_shape(self, arrays):
-        # for ([[1, 2], [3, 4]], [[5, 6]]),
-        # In Numpy, it raises ValueError
-        # In cuNumeric, it pass
         expected_exc = ValueError
         axis = 1
         with pytest.raises(expected_exc):
@@ -197,16 +192,12 @@ class TestConcatenateErrors:
         with pytest.raises(expected_exc):
             num.concatenate(arrays, axis=axis)
 
-    @pytest.mark.xfail
     @pytest.mark.parametrize(
         "axis",
         (1, -2),
         ids=lambda axis: f"(axis={axis})",
     )
     def test_axis_out_of_bound(self, axis):
-        # For axis=-2 or 1,
-        # In Numpy, it raises ValueError
-        # In cuNumeric, it raises IndexError
         expected_exc = ValueError
         a = [1, 2]
         b = [5, 6]
@@ -215,10 +206,7 @@ class TestConcatenateErrors:
         with pytest.raises(expected_exc):
             num.concatenate((num.array(a), num.array(b)), axis=axis)
 
-    @pytest.mark.xfail
     def test_both_out_dtype_are_provided(self):
-        # In Numpy, it raises TypeError
-        # In cuNumeric, it pass
         expected_exc = TypeError
         a = [[1, 2], [3, 4]]
         b = [[5, 6]]
@@ -278,11 +266,10 @@ def test_stack_with_out():
 
 @pytest.mark.parametrize(
     "axis",
-    (-3, pytest.param(-1, marks=pytest.mark.xfail)),
+    (-3, -1),
     ids=lambda axis: f"(axis={axis})",
 )
 def test_stack_axis_is_negative(axis):
-    # for -1, the output by Numpy and cuNumeric is not equal
     a = [[1, 2], [3, 4]]
     b = [[5, 6], [7, 8]]
     res_np = np.stack((np.array(a), np.array(b)), axis=axis)
@@ -328,13 +315,10 @@ class TestStackErrors:
 
     @pytest.mark.parametrize(
         "axis",
-        (2, pytest.param(-3, marks=pytest.mark.xfail)),
+        (2, -3),
         ids=lambda axis: f"(axis={axis})",
     )
     def test_axis_out_of_bound(self, axis):
-        # For axis=-3,
-        # In Numpy, it raises ValueError
-        # In cuNumeric, it raises IndexError
         expected_exc = ValueError
         a = [1, 2]
         b = [5, 6]
@@ -381,16 +365,11 @@ class TestHStackErrors:
         "arrays",
         (
             ([[1, 2], [3, 4]], [5, 6]),
-            pytest.param(
-                ([[1, 2], [3, 4]], [[5, 6]]), marks=pytest.mark.xfail
-            ),
+            ([[1, 2], [3, 4]], [[5, 6]]),
         ),
         ids=lambda arrays: f"(arrays={arrays})",
     )
     def test_arrays_mismatched_shape(self, arrays):
-        # for ([[1, 2], [3, 4]], [[5, 6]])
-        # In Numpy, it raises ValueError
-        # In cuNumeric, it pass
         expected_exc = ValueError
         with pytest.raises(expected_exc):
             np.hstack(arrays)
@@ -417,16 +396,13 @@ class TestColumnStackErrors:
         "arrays",
         (
             (1, []),
-            pytest.param(([1, 2], [3]), marks=pytest.mark.xfail),
+            ([1, 2], [3]),
             ([[1, 2]], [3, 4]),
             ([[1, 2]], [[3], [4]]),
         ),
         ids=lambda arrays: f"(arrays={arrays})",
     )
     def test_arrays_mismatched_shape(self, arrays):
-        # for ([1, 2], [3]),
-        # In Numpy, it raises ValueError
-        # In cuNumeric, it pass
         expected_exc = ValueError
         with pytest.raises(expected_exc):
             np.column_stack(arrays)
@@ -455,17 +431,14 @@ class TestVStackErrors:
     @pytest.mark.parametrize(
         "arrays",
         (
-            pytest.param((1, []), marks=pytest.mark.xfail),
-            pytest.param(([1, 2], [3]), marks=pytest.mark.xfail),
-            pytest.param(([[1, 2], [3, 4]], [5]), marks=pytest.mark.xfail),
+            (1, []),
+            ([1, 2], [3]),
+            ([[1, 2], [3, 4]], [5]),
             ([[[1, 2], [3, 4]]], [5, 6]),
         ),
         ids=lambda arrays: f"(arrays={arrays})",
     )
     def test_arrays_mismatched_shape(self, arrays):
-        # for (1, []), ([1, 2], [3]), ([[1, 2], [3, 4]], [5])
-        # In Numpy, it raises ValueError
-        # In cuNumeric, it pass
         expected_exc = ValueError
         with pytest.raises(expected_exc):
             np.vstack(arrays)
@@ -494,17 +467,14 @@ class TestRowStackErrors:
     @pytest.mark.parametrize(
         "arrays",
         (
-            pytest.param((1, []), marks=pytest.mark.xfail),
-            pytest.param(([1, 2], [3]), marks=pytest.mark.xfail),
-            pytest.param(([[1, 2], [3, 4]], [5]), marks=pytest.mark.xfail),
+            (1, []),
+            ([1, 2], [3]),
+            ([[1, 2], [3, 4]], [5]),
             ([[[1, 2], [3, 4]]], [5, 6]),
         ),
         ids=lambda arrays: f"(arrays={arrays})",
     )
     def test_arrays_mismatched_shape(self, arrays):
-        # for (1, []), ([1, 2], [3]), ([[1, 2], [3, 4]], [5])
-        # In Numpy, it raises ValueError
-        # In cuNumeric, it pass
         expected_exc = ValueError
         with pytest.raises(expected_exc):
             np.row_stack(arrays)
@@ -530,7 +500,6 @@ class TestDStackErrors:
         with pytest.raises(expected_exc):
             num.dstack(arrays)
 
-    @pytest.mark.xfail
     @pytest.mark.parametrize(
         "arrays",
         (
@@ -542,9 +511,6 @@ class TestDStackErrors:
         ids=lambda arrays: f"(arrays={arrays})",
     )
     def test_arrays_mismatched_shape(self, arrays):
-        # for all cases,
-        # In Numpy, it raises ValueError
-        # In cuNumeric, it pass
         expected_exc = ValueError
         with pytest.raises(expected_exc):
             np.dstack(arrays)


### PR DESCRIPTION
Change list:
1. In check_shape_dtype, and should be replaced by or.
2. In check_shape_dtype, check shapes of all input arrays for stack. This is necessary for stack.
3. In check_shape_dtype, if ndim==1, set axis to be 0 for hstack. The default axis value from def hstack in module.py is 1.
4. In check_shape_dtype, change ndim > 1 to ndim >= 1. This is necessary for checking 1-D array size for column_stack.
5. In check_shape_dtype, change shape[1:axis] to shape[:axis]. I think the first size of shape should also be checked. Or is it omitted purposefully?
6. In check_shape_dtype, normalize axis if axis < 0 and axis >= -ndim. Otherwise, axis=-1 would cause bugs in shape[axis+1:] for append API. We don't use normalize_axis_index here because it raises error for the column_stack case where axis=1 and ndim=1. 
7. In def stack, add normalize_axis_index . This is necessary for the case where axis < 0 and axis >= -(ndim+1)