### PR TITLE
Separate cunumeric CI from legate.core CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
           /data/github-runner/legate-bin/setup.sh
           cd legate-ci/github-ci/cunumeric
           rm -rf ngc-artifacts || true
-          ./build-conda.sh > ${COMMIT}-build.log 2>&1
+          ./build-separate.sh > ${COMMIT}-build.log 2>&1
       - name: Process Output
         run: |
           cd legate-ci/github-ci/cunumeric

--- a/cmake/versions.json
+++ b/cmake/versions.json
@@ -1,8 +1,11 @@
 {
   "packages" : {
     "legate_core" : {
+      "version": "23.03.00",
       "git_url" : "https://github.com/nv-legate/legate.core.git",
-      "git_tag" : "37596159b1f8f06439fdc95d6090bbc4315c302c"
+      "git_tag" : "37596159b1f8f06439fdc95d6090bbc4315c302c",
+      "git_shallow": false,
+      "always_download": false
     }
   }
 }

--- a/cmake/versions.json
+++ b/cmake/versions.json
@@ -5,7 +5,7 @@
       "git_url" : "https://github.com/nv-legate/legate.core.git",
       "git_shallow": false,
       "always_download": false,
-      "git_tag" : "78c61d836906611bf18348b4335f6e039f944340"
+      "git_tag" : "2afa4c7"
     }
   }
 }

--- a/cmake/versions.json
+++ b/cmake/versions.json
@@ -4,7 +4,7 @@
       "version": "23.03.00",
       "git_url" : "https://github.com/nv-legate/legate.core.git",
       "git_shallow": false,
-      "always_download": false
+      "always_download": false,
       "git_tag" : "78c61d836906611bf18348b4335f6e039f944340"
     }
   }

--- a/cunumeric_cpp.cmake
+++ b/cunumeric_cpp.cmake
@@ -45,7 +45,7 @@ rapids_cmake_support_conda_env(conda_env MODIFY_PREFIX_PATH)
 # - Dependencies -------------------------------------------------------------
 
 # add third party dependencies using CPM
-rapids_cpm_init()
+rapids_cpm_init(OVERRIDE ${CMAKE_CURRENT_SOURCE_DIR}/cmake/versions.json)
 
 find_package(OpenMP)
 


### PR DESCRIPTION
Currently, the cunumeric CI relies on the legate.core artifacts. However, recently, the version of legate.core has been explicitly hardcoded into cunumeric. To account for this, we will stop using legate.core generated packages, and instead we will build legate.core using the cunumeric build system.