### PR TITLE
Add a linkcheck target to docs build

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,11 +6,11 @@ CuNumeric is an open-source project released under the [Apache license, version 
 
 Most of the time, the best thing is to begin by [opening an issue](https://github.com/nv-legate/cunumeric/issues).  This gives us a chance to discuss the contribution and to define the problem or feature that it addresses.   Often, opening of the issue first may help prevent you from doing unnecessary work or to enhance and further develop your idea.
 
-Once you are ready to start development, we ask you to work on a [fork](https://help.github.com/en/articles/fork-a-repo) of our repository.  The next step is to create a (pull request)[https://help.github.com/en/articles/about-pull-requests].  Feel free to open the pull request as soon as you begin your development (just mark it [as a draft](https://github.blog/2019-02-14-introducing-draft-pull-requests/)) or when you are ready to have your contribution merged.
+Once you are ready to start development, we ask you to work on a [fork](https://docs.github.com/en/get-started/quickstart/fork-a-repo) of our repository.  The next step is to create a (pull request)[https://help.github.com/en/articles/about-pull-requests].  Feel free to open the pull request as soon as you begin your development (just mark it [as a draft](https://github.blog/2019-02-14-introducing-draft-pull-requests/)) or when you are ready to have your contribution merged.
 
 ## The Legalese: Developer Certificate of Origin
 
-CuNumeric is released under the open-source [Apache license, version 2.0](https://www.apache.org/licenses/LICENSE-2.0), and is free to use, modify, and redistribute.  To ensure that the license can be exercised without encumbrance, we ask you that you only contribute your own work or work to which you have the intellectual rights.  To that end, we employ the Developer's Certificate of Origin (DCO), which is the lightweight mechanism for you to certify that you are legally able to make your contribution. Here is the full text of the certificate (also available at [DeveloperCertificate.org](https://DeveloperCertificate.org)):
+CuNumeric is released under the open-source [Apache license, version 2.0](https://www.apache.org/licenses/LICENSE-2.0), and is free to use, modify, and redistribute.  To ensure that the license can be exercised without encumbrance, we ask you that you only contribute your own work or work to which you have the intellectual rights.  To that end, we employ the Developer's Certificate of Origin (DCO), which is the lightweight mechanism for you to certify that you are legally able to make your contribution. Here is the full text of the certificate (also available at [DeveloperCertificate.org](https://developercertificate.org/):
 
 ````
 Developer Certificate of Origin
@@ -61,7 +61,7 @@ Please use your real name and a valid email address at which you can be reached.
 
 ## Review Process
 
-We are really grateful that you are thinking of contributing to cuNumeric.  We will make every effort to review your contributions as soon as possible.  
+We are really grateful that you are thinking of contributing to cuNumeric.  We will make every effort to review your contributions as soon as possible.
 
 As we suggested at the beginning of this document, it will be really helpful to start with an issue unless your proposed change is really trivial.  An issue will help to save work in the review process (e.g., maybe somebody is already working on exactly the same thing you want to work on).  After you open your pull request (PR), there usually will be a community feedback that often will require further changes to your contribution (the usual open-source process).  Usually, this will conclude in the PR being merged by a maintainer, but on rare occasions a PR may be rejected.  This may happen, for example, if the PR appears abandoned (no response to the community feedback) or if the PR does not seem to be approaching community acceptance in a reasonable time frame.  In any case, an explanation will always be given why a PR is closed.  Even if a PR is closed for some reason, it may always be reopened if the situation evolves (feel free to comment on closed PRs to discuss reopening them).
 

--- a/docs/cunumeric/Makefile
+++ b/docs/cunumeric/Makefile
@@ -20,21 +20,35 @@
 # from the environment for the first two.
 SPHINXOPTS     ?= -v -W
 PARALLEL_BUILD ?= 1
-SPHINXBUILD    ?= legate $(shell which sphinx-build)
+SPHINXBUILD    ?= $(shell which sphinx-build)
 SOURCEDIR      = source
 BUILDDIR       = build
 
-# Put it first so that "make" without argument is like "make help".
+.PHONY: help clean html linkcheck
+
 help:
-	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	@echo "Please use 'make <target>' where <target> is one of"
+	@echo "  all              to clean build standalone HTML files and run linkcheck"
+	@echo "  clean            to clear all built documentation files"
+	@echo "  html             to make standalone (non-gallery) HTML files"
+	@echo "  linkcheck        to run the link checker on built docs"
 
-.PHONY: help Makefile
+all: clean html linkcheck
 
-# Catch-all target: route all unknown targets to Sphinx using the new
-# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
-%: Makefile
-	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O) -j $(PARALLEL_BUILD)
+clean:
 	rm -rf build/html/docs
-	mkdir -p build/html/docs
-	cp -r ../figures build/html/docs/
 	find source/ -name "generated" | xargs rm -rf
+
+html:
+	@start=$$(date +%s) \
+	; $(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) -j $(PARALLEL_BUILD) \
+	&& mkdir -p build/html/docs \
+	&& cp -r ../figures build/html/docs/ \
+	&& echo "\nBuild finished in $$(($$(date +%s)-start)) seconds\n"
+
+linkcheck: html
+	@start=$$(date +%s) \
+	; $(SPHINXBUILD) "$(SOURCEDIR)" "$(BUILDDIR)" -b linkcheck \
+	; echo "\nLink check finished in $$(($$(date +%s)-start)) seconds. Any broken links are listed below:\n" \
+	&& [ -f "$(BUILDDIR)/output.txt" ] && cat "$(BUILDDIR)/output.txt"
+


### PR DESCRIPTION
This PR adds a new `linkcheck` target to the Makefile, to run the built-in Sphinx [`CheckExternalLinksBuilder`](https://www.sphinx-doc.org/en/master/usage/builders/index.html#sphinx.builders.linkcheck.CheckExternalLinksBuilder) by invoking `sphinx-build -b linkcheck`.  This feature has several [configurable options](https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-the-linkcheck-builder) however the defaults all seem approprtiate. This check will cover all external links, including intersphinx links to numpy, etc. Presumably we trust Sphinx not generate bad internal links. 

cc @manopapad for some questions:

* This PR also removes the `legate` invocation for `sphinx-build` in the Makefile. Since the "standard Python" work, this is no longer necessary
* The existing Makefile targets honestly did not make sense to me. I have rearranged them to have explicit targets for `help`, `all`, `clean`, `html`, and `linkcheck`. Please let me know if these changes make sense. 
  
  Note: this does mean that as it is now, `make html` no longer runs `clean` first. Instead `make clean html` for that.
* fixes two redirects that the link checker found

Lastly, currently the `linkcheck` is only *advisory*. i.e. it will print out any bad links at the end, but not result in an error exit in that case. Do we want to change that to be more "strict", i.e. to simply have it error exit in case there are bad links?  I imagine the main use case here is to run `make linkcheck` in CI rather than having devs run it locally. It takes maybe a minute to run on my machine, which is why I split it out into a separate target. 