### PR TITLE
Update Conda build scripts

### DIFF
--- a/conda/conda-build/conda_build_config.yaml
+++ b/conda/conda-build/conda_build_config.yaml
@@ -3,8 +3,9 @@ gpu_enabled:
   - false
 
 python:
-  - "3.9,!=3.9.7"
+  - 3.9
   - 3.10
+  - 3.11
 
 numpy_version:
   - ">=1.22"

--- a/conda/conda-build/meta.yaml
+++ b/conda/conda-build/meta.yaml
@@ -10,7 +10,7 @@
 ## The placeholder version is strictly for making two-pass conda build process.
 ## It should not be used for any other purpose, and this is not a default version.
 {% set placeholder_version = '0.0.0.dev' %}
-{% set default_cuda_version = '11.5' %}
+{% set default_cuda_version = '11.8' %}
 {% set cuda_version='.'.join(environ.get('CUDA', default_cuda_version).split('.')[:2]) %}
 {% set cuda_major=cuda_version.split('.')[0] %}
 {% set py_version=environ.get('CONDA_PY', '') %}
@@ -149,6 +149,7 @@ requirements:
 
   run_constrained:
     - __glibc >=2.17  # [linux]
+    - python != 3.9.7
 {% if gpu_enabled_bool %}
     - __cuda >={{ cuda_version }}
 {% endif %}


### PR DESCRIPTION
This includes three changes for the conda build scripts:
1) Updates how the restriction on python 3.9.7 is done through run_constrains
2) Adds py311 to the build matrix
3) Updates to 11.8 since SM90 is included in the build command
