### PR TITLE
Fix concatenate and *stack APIs to support scalars(#818, #839)

### DIFF
--- a/cunumeric/module.py
+++ b/cunumeric/module.py
@@ -1286,7 +1286,7 @@ def _reshape_recur(ndim: int, arr: ndarray) -> tuple[int, ...]:
 
 
 def _atleast_nd(
-    ndim: int, arys: tuple[ndarray, ...]
+    ndim: int, arys: Sequence[ndarray]
 ) -> Union[list[ndarray], ndarray]:
     inputs = list(convert_to_cunumeric_ndarray(arr) for arr in arys)
     # 'reshape' change the shape of arrays
@@ -1806,7 +1806,7 @@ def concatenate(
     # flatten arrays if axis == None and concatenate arrays on the first axis
     if axis is None:
         # Reshape arrays in the `array_list` to handle scalars
-        reshaped = _atleast_nd(1, tuple(inputs))
+        reshaped = _atleast_nd(1, inputs)
         if not isinstance(reshaped, list):
             reshaped = [reshaped]
         inputs = list(inp.ravel() for inp in reshaped)
@@ -1875,9 +1875,6 @@ def stack(
     if len(shapes) != 1:
         raise ValueError("all input arrays must have the same shape for stack")
 
-    # handle scalar inputs
-    if type(common_info.ndim) is not int:
-        common_info.ndim = 0
     axis = normalize_axis_index(axis, common_info.ndim + 1)
     shape = common_info.shape[:axis] + (1,) + common_info.shape[axis:]
     arrays = [arr.reshape(shape) for arr in arrays]
@@ -1919,7 +1916,7 @@ def vstack(tup: Sequence[ndarray]) -> ndarray:
     Multiple GPUs, Multiple CPUs
     """
     # Reshape arrays in the `array_list` if needed before concatenation
-    reshaped = _atleast_nd(2, tuple(tup))
+    reshaped = _atleast_nd(2, tup)
     if not isinstance(reshaped, list):
         reshaped = [reshaped]
     tup, common_info = check_shape_dtype_without_axis(
@@ -1968,7 +1965,7 @@ def hstack(tup: Sequence[ndarray]) -> ndarray:
     Multiple GPUs, Multiple CPUs
     """
     # Reshape arrays in the `array_list` to handle scalars
-    reshaped = _atleast_nd(1, tuple(tup))
+    reshaped = _atleast_nd(1, tup)
     if not isinstance(reshaped, list):
         reshaped = [reshaped]
 
@@ -2022,7 +2019,7 @@ def dstack(tup: Sequence[ndarray]) -> ndarray:
     Multiple GPUs, Multiple CPUs
     """
     # Reshape arrays to (1,N,1) for ndim ==1 or (M,N,1) for ndim == 2:
-    reshaped = _atleast_nd(3, tuple(tup))
+    reshaped = _atleast_nd(3, tup)
     if not isinstance(reshaped, list):
         reshaped = [reshaped]
     tup, common_info = check_shape_dtype_without_axis(
@@ -2067,7 +2064,7 @@ def column_stack(tup: Sequence[ndarray]) -> ndarray:
     Multiple GPUs, Multiple CPUs
     """
     # Reshape arrays in the `array_list` to handle scalars
-    reshaped = _atleast_nd(1, tuple(tup))
+    reshaped = _atleast_nd(1, tup)
     if not isinstance(reshaped, list):
         reshaped = [reshaped]
 

--- a/tests/integration/test_concatenate_stack.py
+++ b/tests/integration/test_concatenate_stack.py
@@ -74,9 +74,7 @@ DIM = 10
 NUM_ARR = [1, 3]
 
 SIZES = [
-    # In Numpy, hstack and column_stack PASS
-    # In cuNumeric, hstack and column_stack raise IndexError
-    pytest.param((), marks=pytest.mark.xfail),  # for scalar.
+    (),
     (0,),
     (0, 10),
     (1,),
@@ -86,6 +84,11 @@ SIZES = [
     (DIM, DIM),
     (DIM, DIM, DIM),
 ]
+
+SCALARS = (
+    (10,),
+    (10, 20, 30),
+)
 
 
 @pytest.fixture(autouse=False)
@@ -97,6 +100,13 @@ def a(size, num):
 @pytest.mark.parametrize("size", SIZES, ids=str)
 def test_concatenate(size, num, a):
     run_test(tuple(a), "concatenate", size)
+
+
+@pytest.mark.parametrize("arrays", SCALARS, ids=str)
+def test_concatenate_scalar(arrays):
+    res_np = np.concatenate(arrays, axis=None)
+    res_num = num.concatenate(arrays, axis=None)
+    assert np.array_equal(res_np, res_num)
 
 
 def test_concatenate_with_out():
@@ -158,16 +168,13 @@ class TestConcatenateErrors:
     @pytest.mark.parametrize(
         "arrays",
         (
-            pytest.param((1,), marks=pytest.mark.xfail),
-            pytest.param((1, 2), marks=pytest.mark.xfail),
+            (1,),
+            (1, 2),
             (1, [3, 4]),
         ),
         ids=lambda arrays: f"(arrays={arrays})",
     )
     def test_scalar_axis_is_not_none(self, arrays):
-        # For (1,) and (1, 2),
-        # In Numpy, it raises ValueError
-        # In cuNumeric, it raises IndexError
         expected_exc = ValueError
         axis = 0
         with pytest.raises(expected_exc):
@@ -228,8 +235,6 @@ class TestConcatenateErrors:
             )
 
     def test_invalid_casting(self):
-        # In Numpy, raise ValueError
-        # In cuNumeric, pass
         expected_exc = ValueError
         a = [[1, 2], [3, 4]]
         b = [[5, 6]]
@@ -249,6 +254,13 @@ class TestConcatenateErrors:
 @pytest.mark.parametrize("size", SIZES, ids=str)
 def test_stack(size, num, a):
     run_test(tuple(a), "stack", size)
+
+
+@pytest.mark.parametrize("arrays", SCALARS, ids=str)
+def test_stack_scalar(arrays):
+    res_np = np.stack(arrays)
+    res_num = num.stack(arrays)
+    assert np.array_equal(res_np, res_num)
 
 
 def test_stack_with_out():
@@ -351,6 +363,13 @@ def test_hstack(size, num, a):
     run_test(tuple(a), "hstack", size)
 
 
+@pytest.mark.parametrize("arrays", SCALARS, ids=str)
+def test_hstack_scalar(arrays):
+    res_np = np.hstack(arrays)
+    res_num = num.hstack(arrays)
+    assert np.array_equal(res_np, res_num)
+
+
 class TestHStackErrors:
     def test_zero_arrays(self):
         expected_exc = ValueError
@@ -380,6 +399,13 @@ class TestHStackErrors:
 @pytest.mark.parametrize("size", SIZES, ids=str)
 def test_column_stack(size, num, a):
     run_test(tuple(a), "column_stack", size)
+
+
+@pytest.mark.parametrize("arrays", SCALARS, ids=str)
+def test_column_stack_scalar(arrays):
+    res_np = np.column_stack(arrays)
+    res_num = num.column_stack(arrays)
+    assert np.array_equal(res_np, res_num)
 
 
 class TestColumnStackErrors:
@@ -418,6 +444,13 @@ def test_vstack(size, num, a):
     run_test(tuple(a), "vstack", size)
 
 
+@pytest.mark.parametrize("arrays", SCALARS, ids=str)
+def test_vstack_scalar(arrays):
+    res_np = np.vstack(arrays)
+    res_num = num.vstack(arrays)
+    assert np.array_equal(res_np, res_num)
+
+
 class TestVStackErrors:
     def test_zero_arrays(self):
         expected_exc = ValueError
@@ -454,6 +487,13 @@ def test_rowstack(size, num, a):
     run_test(tuple(a), "row_stack", size)
 
 
+@pytest.mark.parametrize("arrays", SCALARS, ids=str)
+def test_row_stack_scalar(arrays):
+    res_np = np.row_stack(arrays)
+    res_num = num.row_stack(arrays)
+    assert np.array_equal(res_np, res_num)
+
+
 class TestRowStackErrors:
     def test_zero_arrays(self):
         expected_exc = ValueError
@@ -488,6 +528,13 @@ def test_dstack(size, num, a):
     if len(size) == 2 and size == (1, DIM):
         a.append(np.random.randint(low=0, high=100, size=(DIM,)))
     run_test(tuple(a), "dstack", size)
+
+
+@pytest.mark.parametrize("arrays", SCALARS, ids=str)
+def test_dstack_scalar(arrays):
+    res_np = np.dstack(arrays)
+    res_num = num.dstack(arrays)
+    assert np.array_equal(res_np, res_num)
 
 
 class TestDStackErrors:


### PR DESCRIPTION
1. In module.py, reshape inputs to at least 1-D array for concatenate(axis=None), hstack and column_stack
2. In module.py, in stack, set ndim to 0 for scalar inputs
3. In module.py, call ```normalize_axis_index``` for scalar inputs
4. In test code, add scalar tests for each API
5. In test code, remove xfails