### PR TITLE
Also build CPU-only packages for haswell

### DIFF
--- a/conda/conda-build/build.sh
+++ b/conda/conda-build/build.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
-  
+
 # Rewrite conda's -DCMAKE_FIND_ROOT_PATH_MODE_INCLUDE=ONLY to
 #                 -DCMAKE_FIND_ROOT_PATH_MODE_INCLUDE=BOTH
 CMAKE_ARGS="$(echo "$CMAKE_ARGS" | sed -r "s@_INCLUDE=ONLY@_INCLUDE=BOTH@g")"
 
 # Add our options to conda's CMAKE_ARGS
 CMAKE_ARGS+="
---log-level=VERBOSE"
+--log-level=VERBOSE
+-DBUILD_MARCH=haswell"
 
 # We rely on an environment variable to determine if we need to build cpu-only bits
 if [ -z "$CPU_ONLY" ]; then
@@ -14,7 +15,6 @@ if [ -z "$CPU_ONLY" ]; then
   CMAKE_ARGS+="
 -Dcutensor_DIR=$PREFIX
 -DCMAKE_CUDA_ARCHITECTURES:LIST=60-real;70-real;75-real;80-real;90
--DBUILD_MARCH=haswell
 "
 else
   # When we build without cuda, we need to provide the location of curand


### PR DESCRIPTION
Thanks to @syamajala for discovering that our CPU-only packages contain AVX-512 instructions:

```
> wget https://anaconda.org/legate/cunumeric/23.03.00/download/linux-64/cunumeric-23.03.00-cuda11_py39_g9ac887b8_50_cpu.tar.bz2
> tar -xjvf cunumeric-23.03.00-cuda11_py39_g9ac887b8_50_cpu.tar.bz2
> objdump -d lib/libcunumeric.so  | grep vcvtusi2sd
  25b96b:	62 d1 67 08 7b d7    	vcvtusi2sd %r15d,%xmm3,%xmm2
  25b996:	62 f1 67 08 7b c8    	vcvtusi2sd %eax,%xmm3,%xmm1
```