### PR TITLE
Avoid following compiler symlinks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,14 @@ if(POLICY CMP0135)
   set(CMAKE_POLICY_DEFAULT_CMP0135 NEW)
 endif()
 
+if(POLICY CMP0132)
+  # Avoid an inconsistency, where cmake would only set the CC/CXX env vars on
+  # the first run, but not subsequent ones. This would come up when building
+  # TBLIS.
+  cmake_policy(SET CMP0132 NEW)
+  set(CMAKE_POLICY_DEFAULT_CMP0132 NEW)
+endif()
+
 ##############################################################################
 # - Download and initialize RAPIDS CMake helpers -----------------------------
 

--- a/cmake/thirdparty/get_tblis.cmake
+++ b/cmake/thirdparty/get_tblis.cmake
@@ -84,24 +84,24 @@ function(find_or_configure_tblis)
 
       set(CC_ORIG "$ENV{CC}")
       set(CXX_ORIG "$ENV{CXX}")
-      set(_CC "${CMAKE_C_COMPILER}")
-      set(_CXX "${CMAKE_CXX_COMPILER}")
+      set(_CC "${CC_ORIG}")
+      set(_CXX "${CXX_ORIG}")
 
       if(CC_ORIG MATCHES "^.*\/cc$")
-        file(REAL_PATH "${_CC}" _CC EXPAND_TILDE)
-        file(REAL_PATH "${_CXX}" _CXX EXPAND_TILDE)
-        set(ENV{CC} "${_CC}")
-        set(ENV{CXX} "${_CXX}")
+        set(_CC "${CMAKE_C_COMPILER}")
+        set(_CXX "${CMAKE_CXX_COMPILER}")
       endif()
 
       # Use the caching compiler (if provided) to speed up tblis builds
       if(CMAKE_C_COMPILER_LAUNCHER)
-        set(ENV{CC} "${CMAKE_C_COMPILER_LAUNCHER} ${_CC}")
+        set(_CC "${CMAKE_C_COMPILER_LAUNCHER} ${_CC}")
       endif()
       if(CMAKE_CXX_COMPILER_LAUNCHER)
-        set(ENV{CXX} "${CMAKE_CXX_COMPILER_LAUNCHER} ${_CXX}")
+        set(_CXX "${CMAKE_CXX_COMPILER_LAUNCHER} ${_CXX}")
       endif()
 
+      set(ENV{CC} "${_CC}")
+      set(ENV{CXX} "${_CXX}")
       message(VERBOSE "cunumeric: ENV{CC}=\"$ENV{CC}\"")
       message(VERBOSE "cunumeric: ENV{CXX}=\"$ENV{CXX}\"")
 

--- a/cmake/thirdparty/get_tblis.cmake
+++ b/cmake/thirdparty/get_tblis.cmake
@@ -77,20 +77,11 @@ function(find_or_configure_tblis)
         set(tblis_thread_model "--enable-thread-model=openmp")
       endif()
 
-      # CMake sets `ENV{CC}` to /usr/bin/cc if it's not set. This causes tblis'
-      # `./configure` to fail. For now, detect this case and reset ENV{CC/CXX}.
-      # Remove this workaround when we can use `cmake_policy(SET CMP0132 NEW)`:
-      # https://gitlab.kitware.com/cmake/cmake/-/merge_requests/7108
-
-      set(CC_ORIG "$ENV{CC}")
-      set(CXX_ORIG "$ENV{CXX}")
-      set(_CC "${CC_ORIG}")
-      set(_CXX "${CXX_ORIG}")
-
-      if(CC_ORIG MATCHES "^.*\/cc$")
-        set(_CC "${CMAKE_C_COMPILER}")
-        set(_CXX "${CMAKE_CXX_COMPILER}")
-      endif()
+      # Use ENV{CC/CXX} to tell TBLIS to use the same compilers as the
+      # rest of the build.
+      # TODO: Consider doing the same for CMAKE_C/CXX_FLAGS
+      set(_CC "${CMAKE_C_COMPILER}")
+      set(_CXX "${CMAKE_CXX_COMPILER}")
 
       # Use the caching compiler (if provided) to speed up tblis builds
       if(CMAKE_C_COMPILER_LAUNCHER)

--- a/cmake/thirdparty/get_tblis.cmake
+++ b/cmake/thirdparty/get_tblis.cmake
@@ -82,16 +82,8 @@ function(find_or_configure_tblis)
       # TODO: Consider doing the same for CMAKE_C/CXX_FLAGS
       set(CC_ORIG "$ENV{CC}")
       set(CXX_ORIG "$ENV{CXX}")
-      set(_CC "${CC_ORIG}")
-      set(_CXX "${CXX_ORIG}")
-
-      # Don't override these env vars if the user has set them.
-      if ("${_CC}" STREQUAL "")
-        set(_CC "${CMAKE_C_COMPILER}")
-      endif()
-      if ("${_CXX}" STREQUAL "")
-        set(_CXX "${CMAKE_CXX_COMPILER}")
-      endif()
+      set(_CC "${CMAKE_C_COMPILER}")
+      set(_CXX "${CMAKE_CXX_COMPILER}")
 
       # Use the caching compiler (if provided) to speed up tblis builds
       if(CMAKE_C_COMPILER_LAUNCHER)

--- a/cmake/thirdparty/get_tblis.cmake
+++ b/cmake/thirdparty/get_tblis.cmake
@@ -80,8 +80,18 @@ function(find_or_configure_tblis)
       # Use ENV{CC/CXX} to tell TBLIS to use the same compilers as the
       # rest of the build.
       # TODO: Consider doing the same for CMAKE_C/CXX_FLAGS
-      set(_CC "${CMAKE_C_COMPILER}")
-      set(_CXX "${CMAKE_CXX_COMPILER}")
+      set(CC_ORIG "$ENV{CC}")
+      set(CXX_ORIG "$ENV{CXX}")
+      set(_CC "${CC_ORIG}")
+      set(_CXX "${CXX_ORIG}")
+
+      # Don't override these env vars if the user has set them.
+      if ("${_CC}" STREQUAL "")
+        set(_CC "${CMAKE_C_COMPILER}")
+      endif()
+      if ("${_CXX}" STREQUAL "")
+        set(_CXX "${CMAKE_CXX_COMPILER}")
+      endif()
 
       # Use the caching compiler (if provided) to speed up tblis builds
       if(CMAKE_C_COMPILER_LAUNCHER)

--- a/cmake/thirdparty/get_tblis.cmake
+++ b/cmake/thirdparty/get_tblis.cmake
@@ -96,10 +96,20 @@ function(find_or_configure_tblis)
       message(VERBOSE "cunumeric: ENV{CC}=\"$ENV{CC}\"")
       message(VERBOSE "cunumeric: ENV{CXX}=\"$ENV{CXX}\"")
 
+      set(tblis_verbosity "--enable-silent-rules")
+      if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.25")
+        cmake_language(GET_MESSAGE_LOG_LEVEL log_level)
+        if(${log_level} STREQUAL "VERBOSE" OR
+           ${log_level} STREQUAL "DEBUG" OR
+           ${log_level} STREQUAL "TRACE")
+             set(tblis_verbosity "--disable-silent-rules")
+        endif()
+      endif()
+
       execute_process(
         COMMAND ./configure
           ${tblis_thread_model}
-          --enable-silent-rules
+          ${tblis_verbosity}
           --disable-option-checking
           --with-label-type=int32_t
           --with-length-type=int64_t


### PR DESCRIPTION
Certain vendors (e.g. Apple, HPE Cray) have the bad habit of providing a single compiler entrypoint (`clang` in the case of Apple's XCode), and a bunch of symlinks to that one entrypoint for the various languages (e.g. `cc` and `c++` both link to `clang`). That is fine, however inside the shared entrypoint the code is taking cases depending on which symlink was used to invoke it. In the case of XCode, invoking `clang` through `cxx` will activate C++-mode, whereas invoking it through `cc` (or simply using the shared entrypoint directly) will activate C-mode, which will not link against the standard C++ library:

```
~/Desktop> /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ must-be-compiled-with-cpp.cc
~/Desktop> /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc must-be-compiled-with-cpp.cc
Undefined symbols for architecture x86_64:
  "std::__1::locale::use_facet(std::__1::locale::id&) const", referenced from:
      std::__1::ctype<char> const& std::__1::use_facet[abi:v15006]<std::__1::ctype<char>>(std::__1::locale const&) in must-be-compiled-with-cpp-5cff82.o
  "std::__1::ios_base::getloc() const", referenced from:
      std::__1::basic_ios<char, std::__1::char_traits<char>>::widen[abi:v15006](char) const in must-be-compiled-with-cpp-5cff82.o
  "std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>::__init(unsigned long, char)", referenced from:
      std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>::basic_string[abi:v15006](unsigned long, char) in must-be-compiled-with-cpp-5cff82.o
  ...
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
~/Desktop> ls -alh /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc
lrwxr-xr-x  1 root  wheel     5B Apr 11 10:13 /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc -> clang
~/Desktop> ls -alh /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++
lrwxr-xr-x  1 root  wheel     5B Apr 11 10:13 /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ -> clang
```

What this all means is that we need to avoid following symlinks on compiler executables.

If there was a fundamental reason why we were doing this in this file, my case would also be solved if we changed the fuzzy matching for `*/cc` to explicitly match only `/usr/bin/cc`.

This change also makes sure ccache will be applied on the propagated value of `CC`/`CXX`, if it exists.