### PR TITLE
Temporarily switch to conda builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
           /data/github-runner/legate-bin/setup.sh
           cd legate-ci/github-ci/cunumeric
           rm -rf ngc-artifacts || true
-          ./build-separate.sh > ${COMMIT}-build.log 2>&1
+          ./build-conda.sh > ${COMMIT}-build.log 2>&1
       - name: Process Output
         run: |
           cd legate-ci/github-ci/cunumeric


### PR DESCRIPTION
Separate builds are broken now. We will temporarily switch to conda builds until separate build can be fixed.