### PR TITLE
Fix for some binary operators on float16

### DIFF
--- a/src/cunumeric/binary/binary_op_util.h
+++ b/src/cunumeric/binary/binary_op_util.h
@@ -618,7 +618,7 @@ struct BinaryOp<BinaryOpCode::LOGADDEXP2, CODE> {
   using T                     = legate::legate_type_of<CODE>;
   static constexpr bool valid = legate::is_floating_point<CODE>::value;
 
-  BinaryOp() {}
+  __CUDA_HD__ BinaryOp() {}
   BinaryOp(const std::vector<legate::Store>& args) {}
 
   constexpr decltype(auto) operator()(const T& a, const T& b) const

--- a/src/cunumeric/binary/binary_op_util.h
+++ b/src/cunumeric/binary/binary_op_util.h
@@ -138,6 +138,14 @@ constexpr decltype(auto) op_dispatch(BinaryOpCode op_code, Functor f, Fnargs&&..
   return f.template operator()<BinaryOpCode::ADD>(std::forward<Fnargs>(args)...);
 }
 
+template <typename FloatFunc>
+__CUDA_HD__ __half lift(const __half& _a, const __half& _b, FloatFunc func)
+{
+  float a = _a;
+  float b = _b;
+  return __half{func(a, b)};
+}
+
 template <typename Functor, typename... Fnargs>
 constexpr decltype(auto) reduce_op_dispatch(BinaryOpCode op_code, Functor f, Fnargs&&... args)
 {
@@ -168,6 +176,7 @@ struct BinaryOp<BinaryOpCode::ARCTAN2, CODE> {
   using T                     = legate::legate_type_of<CODE>;
   static constexpr bool valid = legate::is_floating_point<CODE>::value;
 
+  __CUDA_HD__ BinaryOp() {}
   BinaryOp(const std::vector<legate::Store>& args) {}
 
   constexpr decltype(auto) operator()(const T& a, const T& b) const
@@ -179,14 +188,12 @@ struct BinaryOp<BinaryOpCode::ARCTAN2, CODE> {
 
 template <>
 struct BinaryOp<BinaryOpCode::ARCTAN2, legate::LegateTypeCode::HALF_LT> {
-  using T                     = __half;
   static constexpr bool valid = true;
   BinaryOp(const std::vector<legate::Store>& args) {}
 
   __CUDA_HD__ __half operator()(const __half& a, const __half& b) const
   {
-    using std::atan2;
-    return __half{atan2(static_cast<float>(a), static_cast<float>(b))};
+    return lift(a, b, BinaryOp<BinaryOpCode::ARCTAN2, legate::LegateTypeCode::FLOAT_LT>{});
   }
 };
 
@@ -233,6 +240,7 @@ template <legate::LegateTypeCode CODE>
 struct BinaryOp<BinaryOpCode::COPYSIGN, CODE> {
   using T                     = legate::legate_type_of<CODE>;
   static constexpr bool valid = legate::is_floating_point<CODE>::value;
+  __CUDA_HD__ BinaryOp() {}
   BinaryOp(const std::vector<legate::Store>& args) {}
 
   constexpr T operator()(const T& a, const T& b) const
@@ -250,8 +258,7 @@ struct BinaryOp<BinaryOpCode::COPYSIGN, legate::LegateTypeCode::HALF_LT> {
 
   __CUDA_HD__ __half operator()(const __half& a, const __half& b) const
   {
-    using std::copysign;
-    return __half{copysign(static_cast<float>(a), static_cast<float>(b))};
+    return lift(a, b, BinaryOp<BinaryOpCode::COPYSIGN, legate::LegateTypeCode::FLOAT_LT>{});
   }
 };
 
@@ -312,6 +319,7 @@ struct BinaryOp<BinaryOpCode::FMOD, CODE> {
   using T = legate::legate_type_of<CODE>;
   static constexpr bool valid =
     not(CODE == legate::LegateTypeCode::BOOL_LT or legate::is_complex<CODE>::value);
+  __CUDA_HD__ BinaryOp() {}
   BinaryOp(const std::vector<legate::Store>& args) {}
 
   template <typename _T = T, std::enable_if_t<std::is_integral<_T>::value>* = nullptr>
@@ -334,8 +342,7 @@ struct BinaryOp<BinaryOpCode::FMOD, legate::LegateTypeCode::HALF_LT> {
   BinaryOp(const std::vector<legate::Store>& args) {}
   __CUDA_HD__ __half operator()(const __half& a, const __half& b) const
   {
-    using std::fmod;
-    return __half{fmod(static_cast<float>(a), static_cast<float>(b))};
+    return lift(a, b, BinaryOp<BinaryOpCode::FMOD, legate::LegateTypeCode::FLOAT_LT>{});
   }
 };
 
@@ -438,12 +445,25 @@ struct BinaryOp<BinaryOpCode::HYPOT, CODE> {
   using T                     = legate::legate_type_of<CODE>;
   static constexpr bool valid = legate::is_floating_point<CODE>::value;
 
+  __CUDA_HD__ BinaryOp() {}
   BinaryOp(const std::vector<legate::Store>& args) {}
 
   constexpr decltype(auto) operator()(const T& a, const T& b) const
   {
     using std::hypot;
     return hypot(a, b);
+  }
+};
+
+template <>
+struct BinaryOp<BinaryOpCode::HYPOT, legate::LegateTypeCode::HALF_LT> {
+  static constexpr bool valid = true;
+
+  BinaryOp(const std::vector<legate::Store>& args) {}
+
+  __CUDA_HD__ __half operator()(const __half& a, const __half& b) const
+  {
+    return lift(a, b, BinaryOp<BinaryOpCode::HYPOT, legate::LegateTypeCode::FLOAT_LT>{});
   }
 };
 
@@ -564,6 +584,7 @@ struct BinaryOp<BinaryOpCode::LOGADDEXP, CODE> {
   using T                     = legate::legate_type_of<CODE>;
   static constexpr bool valid = legate::is_floating_point<CODE>::value;
 
+  __CUDA_HD__ BinaryOp() {}
   BinaryOp(const std::vector<legate::Store>& args) {}
 
   constexpr decltype(auto) operator()(const T& a, const T& b) const
@@ -580,11 +601,24 @@ struct BinaryOp<BinaryOpCode::LOGADDEXP, CODE> {
   }
 };
 
+template <>
+struct BinaryOp<BinaryOpCode::LOGADDEXP, legate::LegateTypeCode::HALF_LT> {
+  static constexpr bool valid = true;
+
+  BinaryOp(const std::vector<legate::Store>& args) {}
+
+  __CUDA_HD__ __half operator()(const __half& a, const __half& b) const
+  {
+    return lift(a, b, BinaryOp<BinaryOpCode::LOGADDEXP, legate::LegateTypeCode::FLOAT_LT>{});
+  }
+};
+
 template <legate::LegateTypeCode CODE>
 struct BinaryOp<BinaryOpCode::LOGADDEXP2, CODE> {
   using T                     = legate::legate_type_of<CODE>;
   static constexpr bool valid = legate::is_floating_point<CODE>::value;
 
+  BinaryOp() {}
   BinaryOp(const std::vector<legate::Store>& args) {}
 
   constexpr decltype(auto) operator()(const T& a, const T& b) const
@@ -597,6 +631,18 @@ struct BinaryOp<BinaryOpCode::LOGADDEXP2, CODE> {
       return a + T{1.0};
     else
       return fmax(a, b) + log2(T{1} + exp2(-fabs(a - b)));
+  }
+};
+
+template <>
+struct BinaryOp<BinaryOpCode::LOGADDEXP2, legate::LegateTypeCode::HALF_LT> {
+  static constexpr bool valid = true;
+
+  BinaryOp(const std::vector<legate::Store>& args) {}
+
+  __CUDA_HD__ __half operator()(const __half& a, const __half& b) const
+  {
+    return lift(a, b, BinaryOp<BinaryOpCode::LOGADDEXP2, legate::LegateTypeCode::FLOAT_LT>{});
   }
 };
 
@@ -690,6 +736,7 @@ template <legate::LegateTypeCode CODE>
 struct BinaryOp<BinaryOpCode::MOD, CODE> {
   using T                     = legate::legate_type_of<CODE>;
   static constexpr bool valid = true;
+  __CUDA_HD__ BinaryOp() {}
   BinaryOp(const std::vector<legate::Store>& args) {}
 
   template <typename _T                                                                  = T,
@@ -720,7 +767,7 @@ struct BinaryOp<BinaryOpCode::MOD, legate::LegateTypeCode::HALF_LT> {
   BinaryOp(const std::vector<legate::Store>& args) {}
   __CUDA_HD__ __half operator()(const __half& a, const __half& b) const
   {
-    return static_cast<__half>(real_mod(static_cast<float>(a), static_cast<float>(b)));
+    return lift(a, b, BinaryOp<BinaryOpCode::MOD, legate::LegateTypeCode::FLOAT_LT>{});
   }
 };
 
@@ -746,6 +793,7 @@ template <legate::LegateTypeCode CODE>
 struct BinaryOp<BinaryOpCode::NEXTAFTER, CODE> {
   using T                     = legate::legate_type_of<CODE>;
   static constexpr bool valid = legate::is_floating_point<CODE>::value;
+  __CUDA_HD__ BinaryOp() {}
   BinaryOp(const std::vector<legate::Store>& args) {}
 
   constexpr T operator()(const T& a, const T& b) const
@@ -763,8 +811,7 @@ struct BinaryOp<BinaryOpCode::NEXTAFTER, legate::LegateTypeCode::HALF_LT> {
 
   __CUDA_HD__ __half operator()(const __half& a, const __half& b) const
   {
-    using std::nextafter;
-    return __half{nextafter(static_cast<float>(a), static_cast<float>(b))};
+    return lift(a, b, BinaryOp<BinaryOpCode::NEXTAFTER, legate::LegateTypeCode::FLOAT_LT>{});
   }
 };
 


### PR DESCRIPTION
Some binary operators on `float16` that go through `float32` to compute the results don't actually compile, and this PR fixes it. The issue is currently masked by an incorrect type trait `legate::is_floating_point` returning `false` for `LegateTypeCode::HALF_LT` (which will be fixed in a follow-on PR).