### PR TITLE
WAR for TBLIS compiler detection while upstream PR is pending

### DIFF
--- a/cmake/thirdparty/get_tblis.cmake
+++ b/cmake/thirdparty/get_tblis.cmake
@@ -171,11 +171,11 @@ function(find_or_configure_tblis)
 endfunction()
 
 if(NOT DEFINED cunumeric_TBLIS_BRANCH)
-  set(cunumeric_TBLIS_BRANCH master)
+  set(cunumeric_TBLIS_BRANCH cunumeric)
 endif()
 
 if(NOT DEFINED cunumeric_TBLIS_REPOSITORY)
-  set(cunumeric_TBLIS_REPOSITORY https://github.com/devinamatthews/tblis.git)
+  set(cunumeric_TBLIS_REPOSITORY https://github.com/manopapad/tblis.git)
 endif()
 
 find_or_configure_tblis(VERSION          1.2.0


### PR DESCRIPTION
It looks like the previous symlink-following behavior that https://github.com/nv-legate/cunumeric/pull/880 changed was necessary on some systems, because on those systems `/usr/bin/cc` was a symlink to `/usr/bin/gcc`, and TBLIS is using the output from `--version` to discover the compiler vendor, and for gcc the actual compiler name reported on the `--version` output is not the literal string "gcc", but rather the name of the program used to launch the compiler (i.e. `argv[0]`). I submitted https://github.com/devinamatthews/tblis/pull/56 to work around this issue. Switching to using the PR branch on my personal fork of TBLIS, until that PR gets merged upstream.