### PR TITLE
Improve code coverage for cunumeric.bincount

### DIFF
--- a/cunumeric/module.py
+++ b/cunumeric/module.py
@@ -6361,7 +6361,7 @@ def bincount(
         else:
             out = zeros((minlength,), dtype=weights.dtype)
             index = x[0]
-            out[index] = weights[index]
+            out[index] = weights[0]
     else:
         # Normal case of bincount
         if weights is None:


### PR DESCRIPTION
For the three tests that are shown as removed, they're just moved into `TestBincountNegative`.