### PR TITLE
Improve cunumeric.prod coverage and some test fixes

### DIFF
--- a/tests/integration/test_extract.py
+++ b/tests/integration/test_extract.py
@@ -205,8 +205,27 @@ def test_place_mask_reshape(shape, vals):
     arr_np = mk_seq_array(np, shape)
     arr_num = mk_seq_array(num, shape)
 
-    mask_np = np.arange(0, arr_np.size)
-    mask_num = num.arange(0, arr_num.size)
+    mask_np = np.arange(0, arr_np.size).astype(bool)
+    mask_num = num.arange(0, arr_num.size).astype(bool)
+
+    vals_np = np.array(vals).astype(arr_np.dtype)
+    vals_num = num.array(vals_np)
+
+    np.place(arr_np, mask_np, vals_np)
+    num.place(arr_num, mask_num, vals_num)
+
+    assert np.array_equal(arr_np, arr_num)
+
+
+@pytest.mark.parametrize("dtype", (np.float32, np.complex64), ids=str)
+def test_place_mask_dtype(dtype):
+    shape = (3, 2, 3)
+    vals = [42 + 3j]
+    arr_np = mk_seq_array(np, shape)
+    arr_num = mk_seq_array(num, shape)
+
+    mask_np = mk_seq_array(np, shape).astype(dtype)
+    mask_num = mk_seq_array(num, shape).astype(dtype)
 
     vals_np = np.array(vals).astype(arr_np.dtype)
     vals_num = num.array(vals_np)

--- a/tests/integration/test_extract.py
+++ b/tests/integration/test_extract.py
@@ -205,8 +205,8 @@ def test_place_mask_reshape(shape, vals):
     arr_np = mk_seq_array(np, shape)
     arr_num = mk_seq_array(num, shape)
 
-    mask_np = (arr_np % 2).astype(bool)
-    mask_num = (arr_np % 2).astype(bool)
+    mask_np = np.arange(0, arr_np.size)
+    mask_num = num.arange(0, arr_num.size)
 
     vals_np = np.array(vals).astype(arr_np.dtype)
     vals_num = num.array(vals_np)


### PR DESCRIPTION
- Improve `prod` coverage to 100%
- Rearrange some of the tests into the correct test class and changed the naming.
  - `test_dtype_negative` --> `test_dtype_integer_precision`, this is not a negative test.
  - `test_dtype_complex_negative` is removed, parameters are merged into `test_dtype_complex`
  - `test_axis_tuple` --> moved into positive tests
- Add more comments to some of the xfail tests to indicate the repro condition
  - These failures are mentioned in https://github.com/nv-legate/cunumeric/issues/736, but they're not reproducible if `LEGATE_TEST=1` or `CUNUMERIC_TEST=1` is not set.
- Compare exceptions in negative tests.
- Fix the coverage for `cunumeric.place`, some of the lines slipped through after the last change in https://github.com/nv-legate/cunumeric/pull/892