### PR TITLE
Skip codebase checks in CI

### DIFF
--- a/tests/unit/cunumeric/test_settings.py
+++ b/tests/unit/cunumeric/test_settings.py
@@ -92,6 +92,7 @@ class TestDefaults:
     def test_report_dump_csv(self) -> None:
         assert m.settings.report_dump_csv.default is None
 
+    @pytest.mark.skip(reason="Does not work in CI (path issue)")
     @pytest.mark.parametrize("name", _settings_with_test_defaults)
     def test_default(self, name: str) -> None:
         setting = getattr(m.settings, name)
@@ -99,6 +100,7 @@ class TestDefaults:
         expected = setting._convert(read_c_define(ENV_HEADER, define))
         assert setting.default == expected
 
+    @pytest.mark.skip(reason="Does not work in CI (path issue)")
     @pytest.mark.parametrize("name", _settings_with_test_defaults)
     def test_test_default(self, name: str) -> None:
         setting = getattr(m.settings, name)


### PR DESCRIPTION
This PR introduces a workaround for #907 by skipping the tests. A more long term solution should be researched and implemented as a fix for #907.