### PR TITLE
Fix array API(#885).

### DIFF
--- a/cunumeric/module.py
+++ b/cunumeric/module.py
@@ -525,7 +525,7 @@ def array(
     elif copy and obj is result:
         result = result.copy()
     if result.ndim < ndmin:
-        shape = (np.newaxis,) * (ndmin - result.ndim) + result.shape
+        shape = (1,) * (ndmin - result.ndim) + result.shape
         result = result.reshape(shape)
     return result
 

--- a/tests/integration/test_array.py
+++ b/tests/integration/test_array.py
@@ -78,7 +78,6 @@ def test_array_dtype(object, dtype):
     assert strict_type_equal(res_np, res_num)
 
 
-@pytest.mark.xfail
 @pytest.mark.parametrize(
     "ndmin",
     range(-1, LEGATE_MAX_DIM + 1),
@@ -90,10 +89,6 @@ def test_array_dtype(object, dtype):
     ids=lambda object: f"(object={object})",
 )
 def test_array_ndmin(object, ndmin):
-    # if dim of object is smaller than ndmin,
-    # In Numpy, it pass
-    # In cuNumeric, it raises TypeError:
-    # 'NoneType' object cannot be interpreted as an integer
     res_np = np.array(object, ndmin=ndmin)
     res_num = num.array(object, ndmin=ndmin)
     assert strict_type_equal(res_np, res_num)


### PR DESCRIPTION
Root cause:
old code: `shape = (np.newaxis,) * (ndmin - result.ndim) + result.shape`
As np.newaxis is recognized as None, it would result in invalid shape, e.g. (None, None, 2，2).

Fix:
new code: `shape = (1,) * (ndmin - result.ndim) + result.shape`
