### PR TITLE
Revert "WAR for TBLIS compiler detection while upstream PR is pending (#890)"

### DIFF
--- a/cmake/thirdparty/get_tblis.cmake
+++ b/cmake/thirdparty/get_tblis.cmake
@@ -171,11 +171,11 @@ function(find_or_configure_tblis)
 endfunction()
 
 if(NOT DEFINED cunumeric_TBLIS_BRANCH)
-  set(cunumeric_TBLIS_BRANCH cunumeric)
+  set(cunumeric_TBLIS_BRANCH master)
 endif()
 
 if(NOT DEFINED cunumeric_TBLIS_REPOSITORY)
-  set(cunumeric_TBLIS_REPOSITORY https://github.com/manopapad/tblis.git)
+  set(cunumeric_TBLIS_REPOSITORY https://github.com/devinamatthews/tblis.git)
 endif()
 
 find_or_configure_tblis(VERSION          1.2.0


### PR DESCRIPTION
The upstream PR has now been merged.