### PR TITLE
Unify LEGATE_TEST and CUNUMERIC_TEST

### DIFF
--- a/cunumeric/linalg/cholesky.py
+++ b/cunumeric/linalg/cholesky.py
@@ -18,9 +18,9 @@ from typing import TYPE_CHECKING
 
 from legate.core import Rect, types as ty
 from legate.core.shape import Shape
+from legate.settings import settings
 
 from cunumeric.config import CuNumericOpCode
-from cunumeric.settings import settings
 
 from .exception import LinAlgError
 

--- a/cunumeric/runtime.py
+++ b/cunumeric/runtime.py
@@ -23,6 +23,7 @@ import legate.core.types as ty
 import numpy as np
 from legate.core import LEGATE_MAX_DIM, ProcessorKind, Rect, get_legate_runtime
 from legate.core.context import Context as LegateContext
+from legate.settings import settings as legate_settings
 from typing_extensions import TypeGuard
 
 from .config import (
@@ -74,7 +75,7 @@ class Runtime(object):
         self.cunumeric_lib = cunumeric_lib.shared_object
         self.has_curand = cunumeric_lib.shared_object.cunumeric_has_curand()
 
-        settings.warn = settings.warn() or settings.test()
+        settings.warn = settings.warn() or legate_settings.test()
 
         if self.num_gpus > 0 and settings.preload_cudalibs():
             self._load_cudalibs()
@@ -483,7 +484,7 @@ class Runtime(object):
         if volume == 0:
             return True
         # If we're testing then the answer is always no
-        if settings.test():
+        if legate_settings.test():
             return False
         if len(shape) > LEGATE_MAX_DIM:
             return True

--- a/cunumeric/settings.py
+++ b/cunumeric/settings.py
@@ -26,18 +26,6 @@ __all__ = ("settings",)
 
 
 class CunumericRuntimeSettings(Settings):
-    test: PrioritizedSetting[bool] = PrioritizedSetting(
-        "test",
-        "CUNUMERIC_TEST",
-        default=False,
-        convert=convert_bool,
-        help="""
-        Enable test mode. In test mode, all cuNumeric ndarrays are managed by
-        the distributed runtime and the NumPy fallback for small arrays is
-        turned off.
-        """,
-    )
-
     preload_cudalibs: PrioritizedSetting[bool] = PrioritizedSetting(
         "preload_cudalibs",
         "CUNUMERIC_PRELOAD_CUDALIBS",

--- a/cunumeric/settings.py
+++ b/cunumeric/settings.py
@@ -139,5 +139,16 @@ class CunumericRuntimeSettings(Settings):
         """,
     )
 
+    force_thunk: EnvOnlySetting[str | None] = EnvOnlySetting(
+        "force_thunk",
+        "CUNUMERIC_FORCE_THUNK",
+        default=None,
+        test_default="deferred",
+        help="""
+
+        This is a read-only environment variable setting used by the runtime.
+        """,
+    )
+
 
 settings = CunumericRuntimeSettings()

--- a/cunumeric/settings.py
+++ b/cunumeric/settings.py
@@ -145,6 +145,13 @@ class CunumericRuntimeSettings(Settings):
         default=None,
         test_default="deferred",
         help="""
+        Force cuNumeric to always use a specific strategy for backing
+        ndarrays: "deferred", i.e. managed by the Legate runtime, which
+        enables distribution and accelerated operations, but has some
+        up-front offloading overhead, or "eager", i.e. falling back to
+        using a vanilla NumPy array. By default cuNumeric will decide
+        this on a per-array basis, based on the size of the array and
+        the accelerator in use.
 
         This is a read-only environment variable setting used by the runtime.
         """,

--- a/tests/unit/cunumeric/test_settings.py
+++ b/tests/unit/cunumeric/test_settings.py
@@ -33,6 +33,7 @@ _expected_settings = (
     "min_gpu_chunk",
     "min_cpu_chunk",
     "min_omp_chunk",
+    "force_thunk",
 )
 
 _settings_with_test_defaults = (

--- a/tests/unit/cunumeric/test_settings.py
+++ b/tests/unit/cunumeric/test_settings.py
@@ -24,7 +24,6 @@ from legate.util.settings import EnvOnlySetting, PrioritizedSetting
 import cunumeric.settings as m
 
 _expected_settings = (
-    "test",
     "preload_cudalibs",
     "warn",
     "report_coverage",
@@ -62,7 +61,6 @@ class TestSettings:
         assert ps.env_var.startswith("CUNUMERIC_")
 
     def test_types(self) -> None:
-        assert m.settings.test.convert_type == 'bool ("0" or "1")'
         assert m.settings.preload_cudalibs.convert_type == 'bool ("0" or "1")'
         assert m.settings.warn.convert_type == 'bool ("0" or "1")'
         assert m.settings.report_coverage.convert_type == 'bool ("0" or "1")'
@@ -74,9 +72,6 @@ class TestSettings:
 
 
 class TestDefaults:
-    def test_test(self) -> None:
-        assert m.settings.test.default is False
-
     def test_preload_cudalibs(self) -> None:
         assert m.settings.preload_cudalibs.default is False
 


### PR DESCRIPTION
This PR removes usages of  `CUNUMERIC_TEST` in favor of single `LEGATE_TEST`. There is a corresponding `legate.core` PR to stop setting `CUNUMERIC_TEST` in the tester codepaths: https://github.com/nv-legate/legate.core/pull/715