### PR TITLE
Improve code coverage for array and trilu

### DIFF
--- a/tests/integration/test_array.py
+++ b/tests/integration/test_array.py
@@ -157,6 +157,21 @@ def test_asarray_dtype(obj, dtype):
     assert strict_type_equal(res_np, res_num)
 
 
+@pytest.mark.parametrize(
+    "src_dtype, tgt_dtype",
+    ((np.int32, np.complex128), (np.float64, np.int64)),
+    ids=str,
+)
+@pytest.mark.parametrize("func", ("array", "asarray"), ids=str)
+def test_ndarray_dtype(src_dtype, tgt_dtype, func):
+    shape = (1, 3, 1)
+    arr_np = np.ndarray(shape, dtype=src_dtype)
+    arr_num = num.array(arr_np)
+    res_np = getattr(np, func)(arr_np, dtype=tgt_dtype)
+    res_num = getattr(num, func)(arr_num, dtype=tgt_dtype)
+    assert strict_type_equal(res_np, res_num)
+
+
 class TestAsArrayErrors:
     @pytest.mark.parametrize(
         "dtype", (np.int32, np.float64), ids=lambda dtype: f"(dtype={dtype})"

--- a/tests/integration/test_array.py
+++ b/tests/integration/test_array.py
@@ -42,20 +42,20 @@ def strict_type_equal(a, b):
 
 
 @pytest.mark.parametrize(
-    "object",
+    "obj",
     (None,) + SCALARS + ARRAYS,
-    ids=lambda object: f"(object={object})",
+    ids=lambda obj: f"(object={obj})",
 )
-def test_array_basic(object):
-    res_np = np.array(object)
-    res_num = num.array(object)
+def test_array_basic(obj):
+    res_np = np.array(obj)
+    res_num = num.array(obj)
     assert strict_type_equal(res_np, res_num)
 
 
 def test_array_ndarray():
-    object = [[1, 2], [3, 4]]
-    res_np = np.array(np.array(object))
-    res_num = num.array(num.array(object))
+    obj = [[1, 2], [3, 4]]
+    res_np = np.array(np.array(obj))
+    res_num = num.array(num.array(obj))
     assert strict_type_equal(res_np, res_num)
 
 
@@ -68,13 +68,13 @@ DTYPES = (
 
 @pytest.mark.parametrize("dtype", DTYPES, ids=lambda dtype: f"(dtype={dtype})")
 @pytest.mark.parametrize(
-    "object",
+    "obj",
     (0, -10.5, [], [1, 2], [[1, 2], [3, 4.1]]),
-    ids=lambda object: f"(object={object})",
+    ids=lambda obj: f"(object={obj})",
 )
-def test_array_dtype(object, dtype):
-    res_np = np.array(object, dtype=dtype)
-    res_num = num.array(object, dtype=dtype)
+def test_array_dtype(obj, dtype):
+    res_np = np.array(obj, dtype=dtype)
+    res_num = num.array(obj, dtype=dtype)
     assert strict_type_equal(res_np, res_num)
 
 
@@ -84,13 +84,13 @@ def test_array_dtype(object, dtype):
     ids=lambda ndmin: f"(ndmin={ndmin})",
 )
 @pytest.mark.parametrize(
-    "object",
+    "obj",
     (0, [], [1, 2], [[1, 2], [3, 4.1]]),
-    ids=lambda object: f"(object={object})",
+    ids=lambda obj: f"(object={obj})",
 )
-def test_array_ndmin(object, ndmin):
-    res_np = np.array(object, ndmin=ndmin)
-    res_num = num.array(object, ndmin=ndmin)
+def test_array_ndmin(obj, ndmin):
+    res_np = np.array(obj, ndmin=ndmin)
+    res_num = num.array(obj, ndmin=ndmin)
     assert strict_type_equal(res_np, res_num)
 
 
@@ -115,45 +115,45 @@ class TestArrayErrors:
         "dtype", (np.int32, np.float64), ids=lambda dtype: f"(dtype={dtype})"
     )
     @pytest.mark.parametrize(
-        "object",
+        "obj",
         (1 + 1j, [1, 2, 3.0, 4 + 4j]),
-        ids=lambda object: f"(object={object})",
+        ids=lambda obj: f"(obj={obj})",
     )
-    def test_invalid_dtype(self, object, dtype):
+    def test_invalid_dtype(self, obj, dtype):
         expected_exc = TypeError
         with pytest.raises(expected_exc):
-            np.array(object, dtype=dtype)
+            np.array(obj, dtype=dtype)
         with pytest.raises(expected_exc):
-            num.array(object, dtype=dtype)
+            num.array(obj, dtype=dtype)
 
 
 @pytest.mark.parametrize(
-    "object",
+    "obj",
     (None,) + SCALARS + ARRAYS,
-    ids=lambda object: f"(object={object})",
+    ids=lambda obj: f"(object={obj})",
 )
-def test_asarray_basic(object):
-    res_np = np.asarray(object)
-    res_num = num.asarray(object)
+def test_asarray_basic(obj):
+    res_np = np.asarray(obj)
+    res_num = num.asarray(obj)
     assert strict_type_equal(res_np, res_num)
 
 
 def test_asarray_ndarray():
-    object = [[1, 2], [3, 4]]
-    res_np = np.asarray(np.array(object))
-    res_num = num.asarray(num.array(object))
+    obj = [[1, 2], [3, 4]]
+    res_np = np.asarray(np.array(obj))
+    res_num = num.asarray(num.array(obj))
     assert strict_type_equal(res_np, res_num)
 
 
 @pytest.mark.parametrize("dtype", DTYPES, ids=lambda dtype: f"(dtype={dtype})")
 @pytest.mark.parametrize(
-    "object",
+    "obj",
     (0, -10.5, [], [1, 2], [[1, 2], [3, 4.1]]),
-    ids=lambda object: f"(object={object})",
+    ids=lambda obj: f"(object={obj})",
 )
-def test_asarray_dtype(object, dtype):
-    res_np = np.asarray(object, dtype=dtype)
-    res_num = num.asarray(object, dtype=dtype)
+def test_asarray_dtype(obj, dtype):
+    res_np = np.asarray(obj, dtype=dtype)
+    res_num = num.asarray(obj, dtype=dtype)
     assert strict_type_equal(res_np, res_num)
 
 
@@ -162,16 +162,16 @@ class TestAsArrayErrors:
         "dtype", (np.int32, np.float64), ids=lambda dtype: f"(dtype={dtype})"
     )
     @pytest.mark.parametrize(
-        "object",
+        "obj",
         (1 + 1j, [1, 2, 3.0, 4 + 4j]),
-        ids=lambda object: f"(object={object})",
+        ids=lambda obj: f"(object={obj})",
     )
-    def test_invalid_dtype(self, object, dtype):
+    def test_invalid_dtype(self, obj, dtype):
         expected_exc = TypeError
         with pytest.raises(expected_exc):
-            np.asarray(object, dtype=dtype)
+            np.asarray(obj, dtype=dtype)
         with pytest.raises(expected_exc):
-            num.asarray(object, dtype=dtype)
+            num.asarray(obj, dtype=dtype)
 
 
 if __name__ == "__main__":

--- a/tests/integration/test_trilu.py
+++ b/tests/integration/test_trilu.py
@@ -86,6 +86,13 @@ class TestTriluErrors:
         with pytest.raises(TypeError):
             num.tril(a, k=None)
 
+    def test_m_scalar(self):
+        expected_exc = TypeError
+        with pytest.raises(expected_exc):
+            np.tril(0)
+        with pytest.raises(expected_exc):
+            num.tril(0)
+
 
 if __name__ == "__main__":
     import sys

--- a/tests/integration/test_trilu_indices.py
+++ b/tests/integration/test_trilu_indices.py
@@ -192,23 +192,23 @@ class TestTriluIndicesFromErrors:
     @pytest.mark.parametrize(
         "dimension", (1, 3), ids=lambda dimension: f"(dim={dimension})"
     )
-    def test_arr_non_2d(self, dimension, size):
+    @pytest.mark.parametrize("func", FUNCTIONS_INDICES_FROM)
+    def test_arr_non_2d(self, func, dimension, size):
+        expected_exc = ValueError
         shape = size * dimension
         a = num.ones(shape, dtype=int)
-        msg = "input array must be 2-d"
-        with pytest.raises(ValueError, match=msg):
-            num.tril_indices_from(a)
+        with pytest.raises(expected_exc):
+            getattr(np, func)(a)
+        with pytest.raises(expected_exc):
+            getattr(num, func)(a)
 
-    def test_arr_0d(self):
-        a = num.array(3)
-        msg = "input array must be 2-d"
-        with pytest.raises(ValueError, match=msg):
-            num.tril_indices_from(a)
-
-    def test_arr_none(self):
-        msg = "'NoneType' object has no attribute 'ndim'"
-        with pytest.raises(AttributeError, match=msg):
-            num.tril_indices_from(None)
+    @pytest.mark.parametrize("func", FUNCTIONS_INDICES_FROM)
+    def test_arr_none(self, func):
+        expected_exc = AttributeError
+        with pytest.raises(expected_exc):
+            getattr(np, func)(None)
+        with pytest.raises(expected_exc):
+            getattr(num, func)(None)
 
     @pytest.mark.xfail
     def test_k_none(self):

--- a/tests/integration/test_trilu_indices.py
+++ b/tests/integration/test_trilu_indices.py
@@ -203,6 +203,15 @@ class TestTriluIndicesFromErrors:
             getattr(num, func)(a)
 
     @pytest.mark.parametrize("func", FUNCTIONS_INDICES_FROM)
+    def test_arr_0d(self, func):
+        expected_exc = ValueError
+        a = np.array(3)
+        with pytest.raises(expected_exc):
+            getattr(np, func)(a)
+        with pytest.raises(expected_exc):
+            getattr(num, func)(a)
+
+    @pytest.mark.parametrize("func", FUNCTIONS_INDICES_FROM)
     def test_arr_none(self, func):
         expected_exc = AttributeError
         with pytest.raises(expected_exc):


### PR DESCRIPTION
- Improve code coverage
- Change built-in name `object` to `obj`