### PR TITLE
Adjust the iteration count for Black-Scholes example

### DIFF
--- a/examples/black_scholes_greeks.py
+++ b/examples/black_scholes_greeks.py
@@ -183,7 +183,7 @@ if __name__ == "__main__":
         "-i",
         "--iters",
         type=int,
-        default=3,
+        default=2,
         dest="iters",
         help="number of iterations",
     )
@@ -191,7 +191,7 @@ if __name__ == "__main__":
         "-w",
         "--warmup",
         type=int,
-        default=0,
+        default=1,
         dest="warmup",
         help="warm-up iterations",
     )

--- a/examples/black_scholes_greeks.py
+++ b/examples/black_scholes_greeks.py
@@ -183,7 +183,7 @@ if __name__ == "__main__":
         "-i",
         "--iters",
         type=int,
-        default=10,
+        default=3,
         dest="iters",
         help="number of iterations",
     )
@@ -191,7 +191,7 @@ if __name__ == "__main__":
         "-w",
         "--warmup",
         type=int,
-        default=5,
+        default=0,
         dest="warmup",
         help="warm-up iterations",
     )


### PR DESCRIPTION
[This new Black-Scholes example](https://github.com/nv-legate/cunumeric/blob/branch-23.07/examples/black_scholes_greeks.py) takes fairly long in its default configuration, which makes local testing really painful. This PR adjusts the default configuration so it finishes at least in a minute on 4 CPUs even in debug mode. (takes ~44s on my machine.)