### PR TITLE
Fix bugs in random integer functions

### DIFF
--- a/cunumeric/eager.py
+++ b/cunumeric/eager.py
@@ -743,9 +743,9 @@ class EagerArray(NumPyThunk):
             )
         else:
             if self.array.size == 1:
-                self.array.fill(np.random.random_integers(low, high))
+                self.array.fill(np.random.randint(low, high))
             else:
-                a = np.random.random_integers(low, high, size=self.array.shape)
+                a = np.random.randint(low, high, size=self.array.shape)
                 self.array[:] = a
 
     def bitgenerator_lognormal(

--- a/cunumeric/random/bitgenerator.py
+++ b/cunumeric/random/bitgenerator.py
@@ -96,7 +96,7 @@ class BitGenerator:
         endpoint: bool = False,
     ) -> ndarray:
         if shape is None:
-            shape = (1,)
+            shape = ()
         if not isinstance(shape, tuple):
             shape = (shape,)
         res = ndarray(shape, dtype=np.dtype(type))

--- a/cunumeric/random/random.py
+++ b/cunumeric/random/random.py
@@ -1045,7 +1045,7 @@ def randint(
     low: int,
     high: Union[int, None] = None,
     size: Union[NdShapeLike, None] = None,
-    dtype: Union[np.dtype[Any], type, None] = int,
+    dtype: Union[np.dtype[Any], type] = int,
 ) -> Union[int, ndarray, npt.NDArray[Any]]:
     """
     randint(low, high=None, size=None, dtype=int)
@@ -1086,6 +1086,20 @@ def randint(
     --------
     Multiple GPUs, Multiple CPUs
     """
+
+    if not isinstance(low, int):
+        raise NotImplementedError("'low' must be an integer")
+    if high is not None and not isinstance(high, int):
+        raise NotImplementedError("'high' must be an integer or None")
+
+    if high is None:
+        low = 0
+        high = low
+    if low >= high:
+        raise ValueError("low >= high")
+    if high <= 0:
+        raise ValueError("high <= 0")
+
     return generator.get_static_generator().integers(low, high, size, dtype)
 
 
@@ -1150,7 +1164,7 @@ def random_integers(
     low: int,
     high: Union[int, None] = None,
     size: Union[NdShapeLike, None] = None,
-    dtype: Union[np.dtype[Any], type, None] = int,
+    dtype: Union[np.dtype[Any], type] = int,
 ) -> Union[int, ndarray, npt.NDArray[Any]]:
     """
     random_integers(low, high=None, size=None)


### PR DESCRIPTION
Fix bugs reported on https://github.com/nv-legate/cunumeric/pull/955 and https://github.com/nv-legate/cunumeric/issues/965:

* `cunumeric.random.randint` high limit is inclusive when running in eager mode
* when size is `None` should be returning a scalar, not a singleton array 
* missing `low` and `high` type checks and limit checks