### PR TITLE
[WIP] Resolve numpy 1.25 deprecations and issues

### DIFF
--- a/cunumeric/_ufunc/ufunc.py
+++ b/cunumeric/_ufunc/ufunc.py
@@ -579,9 +579,7 @@ class binary_ufunc(ufunc):
         for arr, orig_arg in zip(arrs, orig_args):
             if arr.ndim == 0:
                 types.append(
-                    np.dtype(np.min_scalar_type(orig_arg)).type(0)
-                    if use_min_scalar
-                    else arr.dtype.type(0)
+                    np.dtype(orig_arg) if use_min_scalar else arr.dtype
                 )
             else:
                 types.append(arr.dtype)

--- a/cunumeric/linalg/linalg.py
+++ b/cunumeric/linalg/linalg.py
@@ -645,7 +645,7 @@ def _solve(
     if b.dtype.kind not in ("f", "c"):
         b = b.astype("float64")
     if a.dtype != b.dtype:
-        dtype = np.find_common_type([a.dtype, b.dtype], [])
+        dtype = np.result_type(a.dtype, b.dtype)
         a = a.astype(dtype)
         b = b.astype(dtype)
 

--- a/cunumeric/module.py
+++ b/cunumeric/module.py
@@ -663,7 +663,7 @@ def arange(
         step = 1
 
     if dtype is None:
-        dtype = np.find_common_type([], [type(start), type(stop), type(step)])
+        dtype = np.result_type(type(start), type(stop), type(step))
     else:
         dtype = np.dtype(dtype)
 
@@ -740,7 +740,7 @@ def linspace(
         raise ValueError("Number of samples, %s, must be non-negative." % num)
     div = (num - 1) if endpoint else num
 
-    common_kind = np.find_common_type((start.dtype, stop.dtype), ()).kind
+    common_kind = np.result_type(start.dtype, stop.dtype).kind
     dt = np.complex128 if common_kind == "c" else np.float64
     if dtype is None:
         dtype = dt
@@ -1516,7 +1516,7 @@ def check_shape_dtype_without_axis(
 
     # Cast arrays with the passed arguments (dtype, casting)
     if dtype is None:
-        dtype = np.find_common_type((inp.dtype for inp in inputs), [])
+        dtype = np.result_type(*[inp.dtype for inp in inputs])
     else:
         dtype = np.dtype(dtype)
 
@@ -4161,7 +4161,7 @@ def _contract(
     elif b is None:
         c_dtype = a.dtype
     else:
-        c_dtype = ndarray.find_common_type(a, b)
+        c_dtype = ndarray.result_type(a, b)
     a = _maybe_cast_input(a, c_dtype, casting)
     if b is not None:
         b = _maybe_cast_input(b, c_dtype, casting)
@@ -4855,7 +4855,7 @@ def isclose(
     out_shape = np.broadcast_shapes(a.shape, b.shape)
     out = empty(out_shape, dtype=bool)
 
-    common_type = ndarray.find_common_type(a, b)
+    common_type = ndarray.result_type(a, b)
     a = a.astype(common_type)
     b = b.astype(common_type)
 


### PR DESCRIPTION
This PR fixes two issues that cropped up with recent Numpy 1.25:

* A new class revealed an unprotected usage of `._cunumeric` that could file. For now, resolve by using safe `is_implemented`. 
* Mypy errors due to the deprecation of `find_common_type`

The latter changes have resulting in a few test failures. Still trying to apply the somewhat obscure advice for https://github.com/numpy/numpy/releases/tag/v1.25.0 

Alternatively we could simply ignore the new mypy errors and continue using `find_common_type` for now.