### PR TITLE
Fix docs breakage from np 1.25

### DIFF
--- a/cunumeric/_sphinxext/_comparison_config.py
+++ b/cunumeric/_sphinxext/_comparison_config.py
@@ -84,7 +84,12 @@ NUMPY_CONFIGS = [
     SectionConfig("Module-Level", None, types=FUNCTIONS),
     SectionConfig("Ufuncs", None, types=UFUNCS),
     SectionConfig("Multi-Dimensional Array", "ndarray", types=METHODS),
-    SectionConfig("Linear Algebra", "linalg", types=FUNCTIONS),
+    # numpy 1.25 introduced private _ArrayFunctionDispatcher for LA funcs
+    SectionConfig(
+        "Linear Algebra",
+        "linalg",
+        types=FUNCTIONS + (type(numpy.linalg.cholesky),),
+    ),
     SectionConfig("Discrete Fourier Transform", "fft", types=FUNCTIONS),
     SectionConfig("Random Sampling", "random", types=FUNCTIONS),
 ]

--- a/cunumeric/_sphinxext/_comparison_config.py
+++ b/cunumeric/_sphinxext/_comparison_config.py
@@ -76,7 +76,8 @@ class SectionConfig:
     names: tuple[str, ...] | None = None
 
 
-FUNCTIONS = (FunctionType, BuiltinFunctionType)
+# numpy 1.25 introduced private _ArrayFunctionDispatcher, handle gently
+FUNCTIONS = (FunctionType, BuiltinFunctionType, type(numpy.broadcast))
 METHODS = (MethodType, MethodDescriptorType)
 UFUNCS = (numpy.ufunc,)
 
@@ -84,12 +85,7 @@ NUMPY_CONFIGS = [
     SectionConfig("Module-Level", None, types=FUNCTIONS),
     SectionConfig("Ufuncs", None, types=UFUNCS),
     SectionConfig("Multi-Dimensional Array", "ndarray", types=METHODS),
-    # numpy 1.25 introduced private _ArrayFunctionDispatcher for LA funcs
-    SectionConfig(
-        "Linear Algebra",
-        "linalg",
-        types=FUNCTIONS + (type(numpy.linalg.cholesky),),
-    ),
+    SectionConfig("Linear Algebra", "linalg", types=FUNCTIONS),
     SectionConfig("Discrete Fourier Transform", "fft", types=FUNCTIONS),
     SectionConfig("Random Sampling", "random", types=FUNCTIONS),
 ]


### PR DESCRIPTION
This PR fixes docs breakage due to the introduction of `_ArrayFunctionDispatcher` in numpy 1.25 for functions in `np.linalg` . Specifically, the API comparison generation failed due to no longer being able to automatically collect any `np.linalg` functions. 

@manopapad I don't love this solution, but I am not sure what would be better. Not only is `_ArrayFunctionDispatcher` nominally private, but trying to access it normally raises an error:

```python
In [4]: type(np.linalg.cholesky)
Out[4]: numpy._ArrayFunctionDispatcher

In [5]: np._ArrayFunctionDispatcher
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
Cell In[5], line 1
----> 1 np.__ArrayFunctionDispatcher

File ~/anaconda3/envs/dev310/lib/python3.10/site-packages/numpy/__init__.py:322, in __getattr__(attr)
    319     "Removed in NumPy 1.25.0"
    320     raise RuntimeError("Tester was removed in NumPy 1.25.")
--> 322 raise AttributeError("module {!r} has no attribute "
    323                      "{!r}".format(__name__, attr))

AttributeError: module 'numpy' has no attribute '_ArrayFunctionDispatcher'
```
So I'm not really comfortable relying on it directly. 

We'll probably need to keep an eye out in case this new class will be rolled out to other modules. 

Alternatively, we could consider just manually and explicitly curating these lists since they don't change often. 

