### PR TITLE
Bump legate core to pin host compilers to 11.*

### DIFF
--- a/cmake/versions.json
+++ b/cmake/versions.json
@@ -5,7 +5,7 @@
       "git_url" : "https://github.com/nv-legate/legate.core.git",
       "git_shallow": false,
       "always_download": false,
-      "git_tag" : "d943be62286cfe86360c7936667dbc6c5ebb2219"
+      "git_tag" : "ac75ac05a9056f49729797415ee489b45686a528"
     }
   }
 }


### PR DESCRIPTION
bump core to bring in [this](https://github.com/nv-legate/legate.core/commit/ac75ac05a9056f49729797415ee489b45686a528) change