### PR TITLE
Bump up cunumeric version and legate.core version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,7 @@ include(rapids-cuda)
 include(rapids-export)
 include(rapids-find)
 
-set(cunumeric_version 23.07.00)
+set(cunumeric_version 23.09.00)
 
 # For now we want the optimization flags to match on both normal make and cmake
 # builds so we override the cmake defaults here for release, this changes

--- a/cmake/versions.json
+++ b/cmake/versions.json
@@ -5,7 +5,7 @@
       "git_url" : "https://github.com/nv-legate/legate.core.git",
       "git_shallow": false,
       "always_download": false,
-      "git_tag" : "82ba4afabbbfc894ab719f3bcb809f6b7cda637d"
+      "git_tag" : "fe621bafc86f0f54cc3541a46ebfb310a00cb87d"
     }
   }
 }

--- a/cmake/versions.json
+++ b/cmake/versions.json
@@ -5,7 +5,7 @@
       "git_url" : "https://github.com/nv-legate/legate.core.git",
       "git_shallow": false,
       "always_download": false,
-      "git_tag" : "3f7db4f0b04557873fcc01b79add873546ded27f"
+      "git_tag" : "35d0d4bd3c9d19946ccc641ec7074b44bbae8046"
     }
   }
 }

--- a/cmake/versions.json
+++ b/cmake/versions.json
@@ -5,7 +5,7 @@
       "git_url" : "https://github.com/nv-legate/legate.core.git",
       "git_shallow": false,
       "always_download": false,
-      "git_tag" : "fe621bafc86f0f54cc3541a46ebfb310a00cb87d"
+      "git_tag" : "b1bbff22f54e06ec29e10d1b4ada224144f281d3"
     }
   }
 }

--- a/cmake/versions.json
+++ b/cmake/versions.json
@@ -1,11 +1,11 @@
 {
   "packages" : {
     "legate_core" : {
-      "version": "23.07.00",
+      "version": "23.09.00",
       "git_url" : "https://github.com/nv-legate/legate.core.git",
       "git_shallow": false,
       "always_download": false,
-      "git_tag" : "ac75ac05a9056f49729797415ee489b45686a528"
+      "git_tag" : "82ba4afabbbfc894ab719f3bcb809f6b7cda637d"
     }
   }
 }

--- a/cmake/versions.json
+++ b/cmake/versions.json
@@ -5,7 +5,7 @@
       "git_url" : "https://github.com/nv-legate/legate.core.git",
       "git_shallow": false,
       "always_download": false,
-      "git_tag" : "f1a2e0191615309402b55d9269d73080a42d8957"
+      "git_tag" : "3f7db4f0b04557873fcc01b79add873546ded27f"
     }
   }
 }

--- a/cmake/versions.json
+++ b/cmake/versions.json
@@ -5,7 +5,7 @@
       "git_url" : "https://github.com/nv-legate/legate.core.git",
       "git_shallow": false,
       "always_download": false,
-      "git_tag" : "b1bbff22f54e06ec29e10d1b4ada224144f281d3"
+      "git_tag" : "f1a2e0191615309402b55d9269d73080a42d8957"
     }
   }
 }


### PR DESCRIPTION
Change version of cunumeric to `23.09.00` and change the version of legate.core to `23.09.00` (bump up the git tag accordingly).