### PR TITLE
Fix for control replication violation in test 

### DIFF
--- a/scripts/hooks/enforce_boilerplate.py
+++ b/scripts/hooks/enforce_boilerplate.py
@@ -17,6 +17,8 @@ from pathlib import Path
 from typing import NoReturn
 
 BOILERPLATE = [
+    "import random",
+    "random.seed(12345)",
     "np.random.seed(12345)",
     "sys.exit(pytest.main(sys.argv))",
 ]

--- a/scripts/hooks/enforce_boilerplate.py
+++ b/scripts/hooks/enforce_boilerplate.py
@@ -17,8 +17,6 @@ from pathlib import Path
 from typing import NoReturn
 
 BOILERPLATE = [
-    "import random",
-    "random.seed(12345)",
     "np.random.seed(12345)",
     "sys.exit(pytest.main(sys.argv))",
 ]

--- a/tests/integration/test_advanced_indexing.py
+++ b/tests/integration/test_advanced_indexing.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 #
 
-import random
-
 import numpy as np
 import pytest
 from legate.core import LEGATE_MAX_DIM
@@ -920,7 +918,7 @@ def test():
     # we do less than LEGATE_MAX_DIM becasue the dimension will be increased by
     # 1 when passig 2d index array
     for ndim in range(2, LEGATE_MAX_DIM):
-        a_shape = tuple(random.randint(2, 5) for i in range(ndim))
+        a_shape = tuple(np.random.randint(2, 5) for i in range(ndim))
         np_array = mk_seq_array(np, a_shape)
         num_array = mk_seq_array(num, a_shape)
         # check when N of index arrays == N of dims

--- a/tests/integration/test_index_routines.py
+++ b/tests/integration/test_index_routines.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 #
 
-import random
 from itertools import permutations
 
 import numpy as np
@@ -279,7 +278,7 @@ def test_diagonal():
 
     # test diagonal
     for ndim in range(2, LEGATE_MAX_DIM + 1):
-        a_shape = tuple(random.randint(1, 9) for i in range(ndim))
+        a_shape = tuple(np.random.randint(1, 9) for i in range(ndim))
         np_array = mk_seq_array(np, a_shape)
         num_array = mk_seq_array(num, a_shape)
 
@@ -294,7 +293,7 @@ def test_diagonal():
 
     # test for diagonal_helper
     for ndim in range(3, LEGATE_MAX_DIM + 1):
-        a_shape = tuple(random.randint(1, 9) for i in range(ndim))
+        a_shape = tuple(np.random.randint(1, 9) for i in range(ndim))
         np_array = mk_seq_array(np, a_shape)
         num_array = mk_seq_array(num, a_shape)
         for num_axes in range(3, ndim + 1):

--- a/tests/integration/test_indices.py
+++ b/tests/integration/test_indices.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 #
 
-import random
-
 import numpy as np
 import pytest
 from legate.core import LEGATE_MAX_DIM
@@ -79,7 +77,7 @@ class TestIndices:
 
     @pytest.mark.parametrize("ndim", range(0, LEGATE_MAX_DIM))
     def test_indices_basic(self, ndim):
-        dimensions = tuple(random.randint(1, 5) for _ in range(ndim))
+        dimensions = tuple(np.random.randint(1, 5) for _ in range(ndim))
 
         np_res = np.indices(dimensions)
         num_res = num.indices(dimensions)
@@ -87,7 +85,7 @@ class TestIndices:
 
     @pytest.mark.parametrize("ndim", range(0, LEGATE_MAX_DIM))
     def test_indices_dtype_none(self, ndim):
-        dimensions = tuple(random.randint(1, 5) for _ in range(ndim))
+        dimensions = tuple(np.random.randint(1, 5) for _ in range(ndim))
 
         np_res = np.indices(dimensions, dtype=None)
         num_res = num.indices(dimensions, dtype=None)
@@ -95,14 +93,14 @@ class TestIndices:
 
     @pytest.mark.parametrize("ndim", range(0, LEGATE_MAX_DIM))
     def test_indices_dtype_float(self, ndim):
-        dimensions = tuple(random.randint(1, 5) for _ in range(ndim))
+        dimensions = tuple(np.random.randint(1, 5) for _ in range(ndim))
         np_res = np.indices(dimensions, dtype=float)
         num_res = num.indices(dimensions, dtype=float)
         assert np.array_equal(np_res, num_res)
 
     @pytest.mark.parametrize("ndim", range(0, LEGATE_MAX_DIM))
     def test_indices_sparse(self, ndim):
-        dimensions = tuple(random.randint(1, 5) for _ in range(ndim))
+        dimensions = tuple(np.random.randint(1, 5) for _ in range(ndim))
         np_res = np.indices(dimensions, sparse=True)
         num_res = num.indices(dimensions, sparse=True)
         for i in range(len(np_res)):

--- a/tests/integration/test_prod.py
+++ b/tests/integration/test_prod.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import random
-
 import numpy as np
 import pytest
 from utils.comparisons import allclose
@@ -144,7 +142,7 @@ class TestProdNegative(object):
         size = (1, 0)
         arr_np = np.random.random(size) * 10
         arr_num = num.array(arr_np)
-        initial_value = random.uniform(-20.0, 20.0)
+        initial_value = np.random.uniform(-20.0, 20.0)
         out_num = num.prod(arr_num, initial=initial_value)
         out_np = np.prod(arr_np, initial=initial_value)
         assert allclose(out_np, out_num)
@@ -330,7 +328,7 @@ class TestProdPositive(object):
     def test_initial(self, size):
         arr_np = np.random.random(size) * 10
         arr_num = num.array(arr_np)
-        initial_value = random.uniform(-20.0, 20.0)
+        initial_value = np.random.uniform(-20.0, 20.0)
         out_num = num.prod(arr_num, initial=initial_value)
         out_np = np.prod(arr_np, initial=initial_value)
 

--- a/tests/integration/test_reduction.py
+++ b/tests/integration/test_reduction.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import random
-
 import numpy as np
 import pytest
 from utils.comparisons import allclose
@@ -148,7 +146,7 @@ class TestSumNegative(object):
         size = (1, 0)
         arr_np = np.random.random(size) * 10
         arr_num = num.array(arr_np)
-        initial_value = random.uniform(-20.0, 20.0)
+        initial_value = np.random.uniform(-20.0, 20.0)
         out_num = num.sum(arr_num, initial=initial_value)  # return 0.0
         out_np = np.sum(arr_np, initial=initial_value)  # return initial_value
         assert allclose(out_np, out_num)
@@ -289,7 +287,7 @@ class TestSumPositive(object):
     def test_initial(self, size):
         arr_np = np.random.random(size) * 10
         arr_num = num.array(arr_np)
-        initial_value = random.uniform(-20.0, 20.0)
+        initial_value = np.random.uniform(-20.0, 20.0)
         out_num = num.sum(arr_num, initial=initial_value)
         out_np = np.sum(arr_np, initial=initial_value)
 

--- a/tests/integration/test_trace.py
+++ b/tests/integration/test_trace.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 #
 
-import random
 from itertools import permutations
 
 import numpy as np
@@ -72,7 +71,7 @@ def test_4d():
 
 @pytest.mark.parametrize("ndim", range(2, LEGATE_MAX_DIM + 1))
 def test_ndim(ndim):
-    a_shape = tuple(random.randint(1, 9) for i in range(ndim))
+    a_shape = tuple(np.random.randint(1, 9) for i in range(ndim))
     np_array = mk_seq_array(np, a_shape)
     num_array = mk_seq_array(num, a_shape)
 

--- a/tests/integration/utils/generators.py
+++ b/tests/integration/utils/generators.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 #
 
-import random
 from itertools import permutations, product
 
 import numpy as np
@@ -102,6 +101,6 @@ def generate_item(ndim):
     Generates item location for ndarray.item and ndarray.itemset
     """
     max_index = pow(4, ndim) - 1
-    random_index = random.randint(-1, max_index)
-    random_tuple = tuple(random.randint(0, 3) for i in range(0, ndim))
+    random_index = np.random.randint(-1, max_index)
+    random_tuple = tuple(np.random.randint(0, 3) for i in range(0, ndim))
     return [random_index, max_index, random_tuple]


### PR DESCRIPTION
Several tests used python's random which will generate different values on a different Legion shards. This violates control replication requirements. 