### PR TITLE
src/cunumeric: add missing openmp variants to BitGenerator and UniqueReduce

### DIFF
--- a/cunumeric_cpp.cmake
+++ b/cunumeric_cpp.cmake
@@ -212,10 +212,11 @@ if(Legion_USE_OpenMP)
     src/cunumeric/search/argwhere_omp.cc
     src/cunumeric/search/nonzero_omp.cc
     src/cunumeric/set/unique_omp.cc
+    src/cunumeric/set/unique_reduce_omp.cc
     src/cunumeric/stat/bincount_omp.cc
     src/cunumeric/convolution/convolve_omp.cc
     src/cunumeric/transform/flip_omp.cc
-    src/cunumeric/stat/histogram_omp.cc    
+    src/cunumeric/stat/histogram_omp.cc
   )
 endif()
 

--- a/src/cunumeric/mapper.cc
+++ b/src/cunumeric/mapper.cc
@@ -108,7 +108,8 @@ std::vector<StoreMapping> CuNumericMapper::store_mappings(
         return {};
     }
     case CUNUMERIC_MATMUL:
-    case CUNUMERIC_MATVECMUL: {
+    case CUNUMERIC_MATVECMUL:
+    case CUNUMERIC_UNIQUE_REDUCE: {
       // TODO: Our actual requirements are a little less strict than this; we require each array or
       // vector to have a stride of 1 on at least one dimension.
       std::vector<StoreMapping> mappings;

--- a/src/cunumeric/random/bitgenerator.h
+++ b/src/cunumeric/random/bitgenerator.h
@@ -85,9 +85,7 @@ class BitGeneratorTask : public CuNumericTask<BitGeneratorTask> {
  public:
   static void cpu_variant(legate::TaskContext& context);
 #ifdef LEGATE_USE_OPENMP
-  static void omp_variant(legate::TaskContext& context) {
-    BitGeneratorTask::cpu_variant(context);
-  }
+  static void omp_variant(legate::TaskContext& context) { BitGeneratorTask::cpu_variant(context); }
 #endif
 #ifdef LEGATE_USE_CUDA
   static void gpu_variant(legate::TaskContext& context);

--- a/src/cunumeric/random/bitgenerator.h
+++ b/src/cunumeric/random/bitgenerator.h
@@ -84,6 +84,11 @@ class BitGeneratorTask : public CuNumericTask<BitGeneratorTask> {
 
  public:
   static void cpu_variant(legate::TaskContext& context);
+#ifdef LEGATE_USE_OPENMP
+  static void omp_variant(legate::TaskContext& context) {
+    BitGeneratorTask::cpu_variant(context);
+  }
+#endif
 #ifdef LEGATE_USE_CUDA
   static void gpu_variant(legate::TaskContext& context);
 #endif

--- a/src/cunumeric/random/bitgenerator.h
+++ b/src/cunumeric/random/bitgenerator.h
@@ -85,6 +85,8 @@ class BitGeneratorTask : public CuNumericTask<BitGeneratorTask> {
  public:
   static void cpu_variant(legate::TaskContext& context);
 #ifdef LEGATE_USE_OPENMP
+  // TODO: Fully parallelized OpenMP implementation for BitGenerator
+  // Doing it this way is safe, but only one thread is being used out of the OpenMP pool.
   static void omp_variant(legate::TaskContext& context) { BitGeneratorTask::cpu_variant(context); }
 #endif
 #ifdef LEGATE_USE_CUDA

--- a/src/cunumeric/set/unique_reduce.cc
+++ b/src/cunumeric/set/unique_reduce.cc
@@ -19,33 +19,9 @@
 
 namespace cunumeric {
 
-using namespace legate;
-
-template <Type::Code CODE>
-struct UniqueReduceImplBody<VariantKind::CPU, CODE> {
-  using VAL = legate_type_of<CODE>;
-
-  void operator()(Array& output, const std::vector<std::pair<AccessorRO<VAL, 1>, Rect<1>>>& inputs)
-  {
-    std::set<VAL> dedup_set;
-
-    for (auto& pair : inputs) {
-      auto& input = pair.first;
-      auto& shape = pair.second;
-      for (coord_t idx = shape.lo[0]; idx <= shape.hi[0]; ++idx) dedup_set.insert(input[idx]);
-    }
-
-    size_t size = dedup_set.size();
-    size_t pos  = 0;
-    auto result = output.create_output_buffer<VAL, 1>(Point<1>(size), true);
-
-    for (auto e : dedup_set) result[pos++] = e;
-  }
-};
-
 /*static*/ void UniqueReduceTask::cpu_variant(TaskContext& context)
 {
-  unique_reduce_template<VariantKind::CPU>(context);
+  unique_reduce_template(context, thrust::host);
 }
 
 namespace  // unnamed

--- a/src/cunumeric/set/unique_reduce.h
+++ b/src/cunumeric/set/unique_reduce.h
@@ -26,6 +26,11 @@ class UniqueReduceTask : public CuNumericTask<UniqueReduceTask> {
 
  public:
   static void cpu_variant(legate::TaskContext& context);
+#ifdef LEGATE_USE_OPENMP
+  static void omp_variant(legate::TaskContext& context) {
+    UniqueReduceTask::cpu_variant(context);
+  }
+#endif
 };
 
 }  // namespace cunumeric

--- a/src/cunumeric/set/unique_reduce.h
+++ b/src/cunumeric/set/unique_reduce.h
@@ -27,9 +27,7 @@ class UniqueReduceTask : public CuNumericTask<UniqueReduceTask> {
  public:
   static void cpu_variant(legate::TaskContext& context);
 #ifdef LEGATE_USE_OPENMP
-  static void omp_variant(legate::TaskContext& context) {
-    UniqueReduceTask::cpu_variant(context);
-  }
+  static void omp_variant(legate::TaskContext& context) { UniqueReduceTask::cpu_variant(context); }
 #endif
 };
 

--- a/src/cunumeric/set/unique_reduce_omp.cc
+++ b/src/cunumeric/set/unique_reduce_omp.cc
@@ -14,21 +14,16 @@
  *
  */
 
-#pragma once
+#include "cunumeric/set/unique_reduce.h"
+#include "cunumeric/set/unique_reduce_template.inl"
 
-#include "cunumeric/cunumeric.h"
+#include <thrust/system/omp/execution_policy.h>
 
 namespace cunumeric {
 
-class UniqueReduceTask : public CuNumericTask<UniqueReduceTask> {
- public:
-  static const int TASK_ID = CUNUMERIC_UNIQUE_REDUCE;
-
- public:
-  static void cpu_variant(legate::TaskContext& context);
-#ifdef LEGATE_USE_OPENMP
-  static void omp_variant(legate::TaskContext& context);
-#endif
-};
+/*static*/ void UniqueReduceTask::omp_variant(TaskContext& context)
+{
+  unique_reduce_template(context, thrust::omp::par);
+}
 
 }  // namespace cunumeric


### PR DESCRIPTION
This commit allows codes that use resource scoping and OpenMP processors to avoid crashes when using the corresponding numpy functions (random, unique) within a scope of only openmp processors.