### PR TITLE
If a scalar ufunc arg is cn.ndarray use its type directly

### DIFF
--- a/cunumeric/_ufunc/ufunc.py
+++ b/cunumeric/_ufunc/ufunc.py
@@ -561,8 +561,9 @@ class binary_ufunc(ufunc):
         scalar_types = []
         array_types = []
         for arr, orig_arg in zip(arrs, orig_args):
-            if arr.ndim == 0 and not isinstance(orig_arg, ndarray):
-                scalar_types.append(orig_arg)
+            if arr.ndim == 0:
+                # Make sure all scalar arguments are NumPy arrays
+                scalar_types.append(np.asarray(orig_arg))
             else:
                 array_types.append(arr.dtype)
 

--- a/cunumeric/_ufunc/ufunc.py
+++ b/cunumeric/_ufunc/ufunc.py
@@ -561,7 +561,7 @@ class binary_ufunc(ufunc):
         scalar_types = []
         array_types = []
         for arr, orig_arg in zip(arrs, orig_args):
-            if arr.ndim == 0:
+            if arr.ndim == 0 and not isinstance(orig_arg, ndarray):
                 scalar_types.append(orig_arg)
             else:
                 array_types.append(arr.dtype)


### PR DESCRIPTION
This change avoids an extraneous warning message, as seen on https://github.com/nv-legate/cunumeric/issues/1009.

Alternatively we could convert explicitly to a NumPy array:
```
            if arr.ndim == 0:
                scalar_types.append(np.array(orig_arg))
```
but the change on this PR is in line with the `if len(unique_dtypes) == 1 and all_ndarray:` snippet above, which doesn't consider if `cunumeric.ndarray`s are scalars.

Or we could depart from NumPy's semantics altogether, and never consult the actual values of scalars when picking types.

CC @seberg, to advise whether this code could be changed according to recent updates in NumPy's type handling API.