### PR TITLE
fix build instructions link

### DIFF
--- a/docs/cunumeric/source/developer/building.rst
+++ b/docs/cunumeric/source/developer/building.rst
@@ -1,3 +1,5 @@
+.. _building cunumeric from source:
+
 Building from source
 ====================
 

--- a/docs/cunumeric/source/user/installation.rst
+++ b/docs/cunumeric/source/user/installation.rst
@@ -14,6 +14,6 @@ The default package contains GPU support, and is compatible with CUDA >= 11.4
 also CPU-only packages available, and will be automatically selected by
 ``conda`` when installing on a machine without GPUs.
 
-See :ref:`building-from-source` for instructions on building cuNumeric manually.
+See :ref:`building cunumeric from source` for instructions on building cuNumeric manually.
 
 .. _from conda: https://anaconda.org/legate/cunumeric


### PR DESCRIPTION
cc  @ipdemes @manopapad not sure if we want ot try and re-deploy existing docs or now. The "build" page does exist, just the link from the "install" page was wrong. 