### PR TITLE
Various test fixes

### DIFF
--- a/tests/integration/test_random_advanced.py
+++ b/tests/integration/test_random_advanced.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 #
 import os
-import sys
 
 import numpy as np
 import pytest
@@ -22,7 +21,7 @@ from utils.random import ModuleGenerator, assert_distribution
 import cunumeric as num
 
 LEGATE_TEST = os.environ.get("LEGATE_TEST", None) == "1"
-if sys.platform == "darwin":
+if not num.runtime.has_curand:
     pytestmark = pytest.mark.skip()
     BITGENERATOR_ARGS = []
 else:

--- a/tests/integration/test_random_beta.py
+++ b/tests/integration/test_random_beta.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import sys
 
 import numpy as np
 import pytest
@@ -20,7 +19,7 @@ from utils.random import ModuleGenerator, assert_distribution
 
 import cunumeric as num
 
-if sys.platform == "darwin":
+if not num.runtime.has_curand:
     pytestmark = pytest.mark.skip()
     BITGENERATOR_ARGS = []
 else:

--- a/tests/integration/test_random_bitgenerator.py
+++ b/tests/integration/test_random_bitgenerator.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import sys
 
 import numpy as np
 import pytest
@@ -20,7 +19,7 @@ from utils.random import ModuleGenerator, assert_distribution
 
 import cunumeric as num
 
-if sys.platform == "darwin":
+if not num.runtime.has_curand:
     pytestmark = pytest.mark.skip()
     BITGENERATOR_ARGS = []
 else:

--- a/tests/integration/test_random_gamma.py
+++ b/tests/integration/test_random_gamma.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import sys
 
 import numpy as np
 import pytest
@@ -20,7 +19,7 @@ from utils.random import ModuleGenerator, assert_distribution
 
 import cunumeric as num
 
-if sys.platform == "darwin":
+if not num.runtime.has_curand:
     pytestmark = pytest.mark.skip()
     BITGENERATOR_ARGS = []
 else:

--- a/tests/integration/test_random_straightforward.py
+++ b/tests/integration/test_random_straightforward.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 #
 import math
-import sys
 
 import numpy as np
 import pytest
@@ -21,7 +20,7 @@ from utils.random import ModuleGenerator, assert_distribution
 
 import cunumeric as num
 
-if sys.platform == "darwin":
+if not num.runtime.has_curand:
     pytestmark = pytest.mark.skip()
     BITGENERATOR_ARGS = []
 else:

--- a/tests/integration/test_reshape.py
+++ b/tests/integration/test_reshape.py
@@ -185,7 +185,7 @@ def test_reshape_empty_array(shape):
 
 def test_reshape_same_shape():
     shape = (1, 2, 3)
-    arr = np.empty(shape)
+    arr = np.random.rand(*shape)
     assert np.array_equal(np.reshape(arr, shape), num.reshape(arr, shape))
 
 


### PR DESCRIPTION
* Skip advanced RNG not only on MacOS, but any setup that's missing cuRand (e.g. also on CPU installations without the optional host-cuRand component).

* Don't compare arrays created with `np.empty`; they contain uninitialized data, that may be equivalent to `NaN` when
interpreted as a floating-point number, and `np.array_equal` considers that `NaN != NaN`. Fixes a non-deterministic CI failure, see https://github.com/nv-legate/cunumeric/actions/runs/5734924032/job/15544886016.