### PR TITLE
Add back None as an accepted value for axis on some type sigs

### DIFF
--- a/cunumeric/deferred.py
+++ b/cunumeric/deferred.py
@@ -3486,7 +3486,7 @@ class DeferredArray(NumPyThunk):
         self,
         rhs: Any,
         argsort: bool = False,
-        axis: int = -1,
+        axis: Union[int, None] = -1,
         kind: SortType = "quicksort",
         order: Union[None, str, list[str]] = None,
     ) -> None:
@@ -3511,7 +3511,7 @@ class DeferredArray(NumPyThunk):
         rhs: Any,
         kth: Union[int, Sequence[int]],
         argpartition: bool = False,
-        axis: int = -1,
+        axis: Union[int, None] = -1,
         kind: SelectKind = "introselect",
         order: Union[None, str, list[str]] = None,
     ) -> None:

--- a/cunumeric/eager.py
+++ b/cunumeric/eager.py
@@ -723,7 +723,7 @@ class EagerArray(NumPyThunk):
         self,
         rhs: Any,
         argsort: bool = False,
-        axis: int = -1,
+        axis: Union[int, None] = -1,
         kind: SortType = "quicksort",
         order: Union[None, str, list[str]] = None,
     ) -> None:
@@ -1383,7 +1383,7 @@ class EagerArray(NumPyThunk):
         rhs: Any,
         kth: Union[int, Sequence[int]],
         argpartition: bool = False,
-        axis: int = -1,
+        axis: Union[int, None] = -1,
         kind: SelectKind = "introselect",
         order: Union[None, str, list[str]] = None,
     ) -> None:

--- a/cunumeric/module.py
+++ b/cunumeric/module.py
@@ -6541,7 +6541,7 @@ def unique(
 @add_boilerplate("a")
 def argsort(
     a: ndarray,
-    axis: int = -1,
+    axis: Union[int, None] = -1,
     kind: SortType = "quicksort",
     order: Optional[Union[str, list[str]]] = None,
 ) -> ndarray:
@@ -6654,7 +6654,7 @@ def searchsorted(
 @add_boilerplate("a")
 def sort(
     a: ndarray,
-    axis: int = -1,
+    axis: Union[int, None] = -1,
     kind: SortType = "quicksort",
     order: Optional[Union[str, list[str]]] = None,
 ) -> ndarray:
@@ -6740,7 +6740,7 @@ def sort_complex(a: ndarray) -> ndarray:
 def argpartition(
     a: ndarray,
     kth: Union[int, Sequence[int]],
-    axis: int = -1,
+    axis: Union[int, None] = -1,
     kind: SelectKind = "introselect",
     order: Optional[Union[str, list[str]]] = None,
 ) -> ndarray:
@@ -6796,7 +6796,7 @@ def argpartition(
 def partition(
     a: ndarray,
     kth: Union[int, Sequence[int]],
-    axis: int = -1,
+    axis: Union[int, None] = -1,
     kind: SelectKind = "introselect",
     order: Optional[Union[str, list[str]]] = None,
 ) -> ndarray:

--- a/cunumeric/thunk.py
+++ b/cunumeric/thunk.py
@@ -601,7 +601,7 @@ class NumPyThunk(ABC):
         rhs: Any,
         kth: Union[int, Sequence[int]],
         argpartition: bool = False,
-        axis: int = -1,
+        axis: Union[int, None] = -1,
         kind: SelectKind = "introselect",
         order: Union[None, str, list[str]] = None,
     ) -> None:
@@ -628,7 +628,7 @@ class NumPyThunk(ABC):
         self,
         rhs: Any,
         argsort: bool = False,
-        axis: int = -1,
+        axis: Union[int, None] = -1,
         kind: SortType = "quicksort",
         order: Union[None, str, list[str]] = None,
     ) -> None:


### PR DESCRIPTION
I introduced this issue with https://github.com/nv-legate/cunumeric/pull/468, because I assumed that `axis : Optional[int] = -1` was just a case of someone misunderstanding `Optional[T]` to mean `T but with a default value`, where actually it means `Union[T, None]`. But actually the NumPy APIs (and the cuNumeric implementations) allow both `None` and `-1`, and just default to `-1`, so the original `Optional[int]` was correct.