### PR TITLE
Skip the docstrings for functions pulled from cloned modules

### DIFF
--- a/cunumeric/coverage.py
+++ b/cunumeric/coverage.py
@@ -192,6 +192,13 @@ def unimplemented(
                 kwargs = deep_apply(kwargs, fallback)
             return func(*args, **kwargs)
 
+    wrapper.__doc__ = f"""
+    cuNumeric has not implemented this function, and will fall back to NumPy.
+
+    See Also
+    --------
+    {name}
+    """
     wrapper._cunumeric = CuWrapperMetadata(implemented=False)
 
     return wrapper

--- a/cunumeric/coverage.py
+++ b/cunumeric/coverage.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import warnings
 from dataclasses import dataclass
-from functools import wraps
+from functools import WRAPPER_ASSIGNMENTS, wraps
 from types import (
     BuiltinFunctionType,
     FunctionType,
@@ -137,6 +137,11 @@ def implemented(
     return wrapper
 
 
+_UNIMPLEMENTED_COPIED_ATTRS = tuple(
+    attr for attr in WRAPPER_ASSIGNMENTS if attr != "__doc__"
+)
+
+
 def unimplemented(
     func: AnyCallable,
     prefix: str,
@@ -157,7 +162,7 @@ def unimplemented(
 
     if reporting:
 
-        @wraps(func)
+        @wraps(func, assigned=_UNIMPLEMENTED_COPIED_ATTRS)
         def wrapper(*args: Any, **kwargs: Any) -> Any:
             location = find_last_user_frames(
                 not settings.report_dump_callstack()
@@ -174,7 +179,7 @@ def unimplemented(
 
     else:
 
-        @wraps(func)
+        @wraps(func, assigned=_UNIMPLEMENTED_COPIED_ATTRS)
         def wrapper(*args: Any, **kwargs: Any) -> Any:
             stacklevel = find_last_user_stacklevel()
             warnings.warn(

--- a/tests/unit/cunumeric/test_coverage.py
+++ b/tests/unit/cunumeric/test_coverage.py
@@ -210,7 +210,8 @@ class Test_unimplemented:
 
         assert wrapped.__name__ == _test_func.__name__
         assert wrapped.__qualname__ == _test_func.__qualname__
-        assert wrapped.__doc__ == _test_func.__doc__
+        assert wrapped.__doc__ != _test_func.__doc__
+        assert "not implemented" in wrapped.__doc__
         assert wrapped.__wrapped__ is _test_func
 
         assert wrapped(10, 20) == 30
@@ -234,7 +235,8 @@ class Test_unimplemented:
 
         assert wrapped.__name__ == _test_func.__name__
         assert wrapped.__qualname__ == _test_func.__qualname__
-        assert wrapped.__doc__ == _test_func.__doc__
+        assert wrapped.__doc__ != _test_func.__doc__
+        assert "not implemented" in wrapped.__doc__
         assert wrapped.__wrapped__ is _test_func
 
         with pytest.warns(RuntimeWarning) as record:
@@ -253,7 +255,8 @@ class Test_unimplemented:
     ) -> None:
         wrapped = m.unimplemented(_test_ufunc, "foo", "_test_ufunc")
 
-        assert wrapped.__doc__ == _test_ufunc.__doc__
+        assert wrapped.__doc__ != _test_ufunc.__doc__
+        assert "not implemented" in wrapped.__doc__
         assert wrapped.__wrapped__ is _test_ufunc
 
         assert wrapped(10, 20) == 30
@@ -275,7 +278,8 @@ class Test_unimplemented:
             _test_ufunc, "foo", "_test_ufunc", reporting=False
         )
 
-        assert wrapped.__doc__ == _test_ufunc.__doc__
+        assert wrapped.__doc__ != _test_ufunc.__doc__
+        assert "not implemented" in wrapped.__doc__
         assert wrapped.__wrapped__ is _test_ufunc
 
         with pytest.warns(RuntimeWarning) as record:


### PR DESCRIPTION
The docstring for numpy.binomial has an unused reference, which causes our doc build to panic in cases where curand is not installed, and thus we end up falling back to numpy for binomial.