### PR TITLE
Don't cast histogram to int64 when density=True

### DIFF
--- a/cunumeric/module.py
+++ b/cunumeric/module.py
@@ -7910,7 +7910,7 @@ def histogram(
     --------
     Multiple GPUs, Multiple CPUs
     """
-    result_type = np.dtype(np.int64)
+    result_type: np.dtype[Any] = np.dtype(np.int64)
 
     if np.ndim(bins) > 1:
         raise ValueError("`bins` must be 1d, when an array")
@@ -7996,6 +7996,7 @@ def histogram(
     # handle (density = True):
     #
     if density:
+        result_type = np.dtype(np.float64)
         hist /= sum(hist)
         hist /= bins_array[1:] - bins_array[:-1]
 


### PR DESCRIPTION
In that case the histogram is expected to have floating-point values, and casting those to ints drops information. E.g. this example:

```
import cunumeric as cn
data = cn.arange(20)
hist, _ = cn.histogram(data, density=True)
print(hist)
```

would print out

```
[0 0 0 0 0 0 0 0 0 0]
```

rather than

```
[0.05263158 0.05263158 0.05263158 0.05263158 0.05263158 0.05263158 0.05263158 0.05263158 0.05263158 0.05263158]
```