### PR TITLE
Explicitly cast result of shift binary operators

### DIFF
--- a/src/cunumeric/binary/binary_op_util.h
+++ b/src/cunumeric/binary/binary_op_util.h
@@ -558,7 +558,7 @@ struct BinaryOp<BinaryOpCode::LEFT_SHIFT, CODE> {
 
   BinaryOp(const std::vector<legate::Store>& args) {}
 
-  constexpr decltype(auto) operator()(const T& a, const T& b) const
+  constexpr T operator()(const T& a, const T& b) const
   {
 #if defined(__NVCC__) || defined(__CUDACC__)
     return a << b;
@@ -867,7 +867,7 @@ struct BinaryOp<BinaryOpCode::RIGHT_SHIFT, CODE> {
 
   BinaryOp(const std::vector<legate::Store>& args) {}
 
-  constexpr decltype(auto) operator()(const T& a, const T& b) const { return a >> b; }
+  constexpr T operator()(const T& a, const T& b) const { return a >> b; }
 };
 
 template <legate::Type::Code CODE>


### PR DESCRIPTION
Fixes a bug reported by @syamajala.

The compile-time result of shifting an `unsigned short` by an `unsigned short` is `int`, so the task body was trying to create an `int` accessor, but the calling side was instantiating an `np.uint16` result array for a shift of a `np.uint16` array by a `np.uint16` value. This resulted in the following code:

```
x = cn.ones((4, 352, 384), dtype=np.uint16)
cn.right_shift(x, 1)
```

failing with an error message like:

```
terminate called after throwing an instance of 'std::invalid_argument'
  what():  Type mismatch: int32 accessor to a uint16 store. Disable type checking via accessor template parameter if this is intended.
Signal 6 received by node 0, process 26606 (thread 7f4308670700) - obtaining backtrace
Signal 6 received by process 26606 (thread 7f4308670700) at: stack trace: 17 frames
  [0] = raise at unknown file:0 [00007f43126c8387]
  [1] = abort at unknown file:0 [00007f43126c9a77]
  [2] = __gnu_cxx::__verbose_terminate_handler() at ../../../../libstdc++-v3/libsupc++/vterminate.cc:95 [00007f43158d7ecf]
  [3] = __cxxabiv1::__terminate(void (*)()) at ../../../../libstdc++-v3/libsupc++/eh_terminate.cc:48 [00007f43158d640b]
  [4] = std::terminate() at ../../../../libstdc++-v3/libsupc++/eh_terminate.cc:58 [00007f43158d645d]
  [5] = __cxa_throw at ../../../../libstdc++-v3/libsupc++/eh_throw.cc:98 [00007f43158d664f]
  [6] = void legate::Store::check_accessor_type<int>() const at unknown file:0 [00007f41e940b63a]
  [7] = Legion::FieldAccessor<(legion_privilege_mode_t)268435463, int, 3, long long, Realm::AffineAccessor<int, 3, long long>, false> legate::Store::write_accessor<int, 3, true>(Realm::Rect<3, long long> const&) const at unknown file:0 [00007f41ab22b3c1]
  [8] = void cunumeric::BinaryOpImpl<(cunumeric::VariantKind)0, (cunumeric::BinaryOpCode)34>::operator()<(legate::Type::Code)6, 3, (void*)0>(cunumeric::BinaryOpArgs&) const [clone .isra.0] at unknown file:0 [00007f41ab38b83b]
  [9] = cunumeric::BinaryOpTask::cpu_variant(legate::TaskContext&) at unknown file:0 [00007f41ab4d7176]
  [10] = legate::detail::task_wrapper(void (*)(legate::TaskContext&), std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, void const*, unsigned long, void const*, unsigned long, Realm::Processor) at unknown file:0 [00007f41e9406902]
  [11] = void legate::LegateTask<cunumeric::BinaryOpTask>::legate_task_wrapper<&cunumeric::BinaryOpTask::cpu_variant>(void const*, unsigned long, void const*, unsigned long, Realm::Processor) at unknown file:0 [00007f41ab2e683d]
  [12] = Realm::Task::execute_on_processor(Realm::Processor) at unknown file:0 [00007f4312fc4b11]
  [13] = Realm::UserThreadTaskScheduler::execute_task(Realm::Task*) at unknown file:0 [00007f4312fc4bc5]
  [14] = Realm::ThreadedTaskScheduler::scheduler_loop() at unknown file:0 [00007f4312fc2ef5]
  [15] = Realm::UserThread::uthread_entry() at unknown file:0 [00007f4312fc7d02]
  [16] = unknown symbol at unknown file:0 [00007f43126da18f]
```

Explicitly casting the result of the shift operations fixes this problem.