### PR TITLE
Plumbing for np.ma

### DIFF
--- a/cunumeric/__init__.py
+++ b/cunumeric/__init__.py
@@ -28,7 +28,7 @@ import os
 
 import numpy as _np
 
-from cunumeric import linalg, random, fft
+from cunumeric import linalg, random, fft, ma
 from cunumeric.array import maybe_convert_to_np_ndarray, ndarray
 from cunumeric.bits import packbits, unpackbits
 from cunumeric.module import *

--- a/cunumeric/array.py
+++ b/cunumeric/array.py
@@ -178,7 +178,9 @@ def maybe_convert_to_np_ndarray(obj: Any) -> Any:
     """
     Converts cuNumeric arrays into NumPy arrays, otherwise has no effect.
     """
-    if isinstance(obj, ndarray):
+    from .ma import MaskedArray
+
+    if isinstance(obj, (ndarray, MaskedArray)):
         return obj.__array__()
     return obj
 

--- a/cunumeric/ma/__init__.py
+++ b/cunumeric/ma/__init__.py
@@ -1,0 +1,29 @@
+# Copyright 2023 NVIDIA Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from __future__ import annotations
+
+import numpy.ma as _ma
+
+from cunumeric.array import maybe_convert_to_np_ndarray
+from cunumeric.coverage import clone_module
+from cunumeric.ma._masked_array import MaskedArray
+
+masked_array = MaskedArray
+
+clone_module(_ma, globals(), maybe_convert_to_np_ndarray)
+
+del maybe_convert_to_np_ndarray
+del clone_module
+del _ma

--- a/cunumeric/ma/_masked_array.py
+++ b/cunumeric/ma/_masked_array.py
@@ -1,0 +1,79 @@
+# Copyright 2023 NVIDIA Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from __future__ import annotations
+
+import numpy as _np
+
+from ..array import maybe_convert_to_np_ndarray
+from ..coverage import clone_class
+
+NDARRAY_INTERNAL = {
+    "__array_finalize__",
+    "__array_function__",
+    "__array_interface__",
+    "__array_prepare__",
+    "__array_priority__",
+    "__array_struct__",
+    "__array_ufunc__",
+    "__array_wrap__",
+}
+
+MaskType = _np.bool_
+nomask = MaskType(0)
+
+
+@clone_class(_np.ma.MaskedArray, NDARRAY_INTERNAL, maybe_convert_to_np_ndarray)
+class MaskedArray:
+    def __new__(cls, *args, **kw):
+        return super().__new__(cls)
+
+    def __init__(
+        self,
+        data=None,
+        mask=nomask,
+        dtype=None,
+        copy=False,
+        subok=True,
+        ndmin=0,
+        fill_value=None,
+        keep_mask=True,
+        hard_mask=None,
+        shrink=True,
+        order=None,
+    ):
+        self._internal_ma = _np.ma.MaskedArray(
+            data=maybe_convert_to_np_ndarray(data),
+            mask=maybe_convert_to_np_ndarray(mask),
+            dtype=dtype,
+            copy=copy,
+            subok=subok,
+            ndmin=ndmin,
+            fill_value=fill_value,
+            keep_mask=keep_mask,
+            hard_mask=hard_mask,
+            shrink=shrink,
+            order=order,
+        )
+
+    def __array__(self, _dtype=None):
+        return self._internal_ma
+
+    @property
+    def size(self):
+        return self._internal_ma.size
+
+    @property
+    def shape(self):
+        return self._internal_ma.shape

--- a/cunumeric/ma/_masked_array.py
+++ b/cunumeric/ma/_masked_array.py
@@ -14,6 +14,13 @@
 #
 from __future__ import annotations
 
+from typing import TYPE_CHECKING, Any, Type, Union
+
+if TYPE_CHECKING:
+    import numpy.typing as npt
+    from ..types import NdShape
+
+
 import numpy as _np
 
 from ..array import maybe_convert_to_np_ndarray
@@ -36,24 +43,26 @@ nomask = MaskType(0)
 
 @clone_class(_np.ma.MaskedArray, NDARRAY_INTERNAL, maybe_convert_to_np_ndarray)
 class MaskedArray:
-    def __new__(cls, *args, **kw):
+    _internal_ma: _np.ma.MaskedArray[Any, Any]
+
+    def __new__(cls: Type[Any], *args: Any, **kw: Any) -> MaskedArray:
         return super().__new__(cls)
 
     def __init__(
         self,
-        data=None,
-        mask=nomask,
-        dtype=None,
-        copy=False,
-        subok=True,
-        ndmin=0,
-        fill_value=None,
-        keep_mask=True,
-        hard_mask=None,
-        shrink=True,
-        order=None,
-    ):
-        self._internal_ma = _np.ma.MaskedArray(
+        data: Any = None,
+        mask: _np.bool_ = nomask,
+        dtype: Union[npt.DTypeLike, None] = None,
+        copy: bool = False,
+        subok: bool = True,
+        ndmin: int = 0,
+        fill_value: Any = None,
+        keep_mask: Any = True,
+        hard_mask: Any = None,
+        shrink: bool = True,
+        order: Union[str, None] = None,
+    ) -> None:
+        self._internal_ma = _np.ma.MaskedArray(  # type: ignore
             data=maybe_convert_to_np_ndarray(data),
             mask=maybe_convert_to_np_ndarray(mask),
             dtype=dtype,
@@ -67,13 +76,13 @@ class MaskedArray:
             order=order,
         )
 
-    def __array__(self, _dtype=None):
+    def __array__(self, _dtype: Any = None) -> _np.ma.MaskedArray[Any, Any]:
         return self._internal_ma
 
     @property
-    def size(self):
+    def size(self) -> int:
         return self._internal_ma.size
 
     @property
-    def shape(self):
+    def shape(self) -> NdShape:
         return self._internal_ma.shape


### PR DESCRIPTION
This PR just adds minimal wrapping for the NumPy masked array module. Currently things will just fall back to numpy and emit the fallback warning:

```python
Welcome to Legion Python interactive console
>>> import cunumeric as np
>>> x = np.ma.array(np.matrix([[1, 2], [3, 4]]), mask=[[0, 1], [1, 0]])
/home/bryan/work/cunumeric/cunumeric/coverage.py:186: RuntimeWarning: cuNumeric has not implemented numpy.ma.array and is falling back to canonical NumPy. You may notice significantly decreased performance for this function call.
  warnings.warn(
>>> x
masked_matrix(
  data=[[1, --],
        [--, 4]],
  mask=[[False,  True],
        [ True, False]],
  fill_value=999999)
>>> x.sum()	
/home/bryan/work/cunumeric/cunumeric/coverage.py:186: RuntimeWarning: cuNumeric has not implemented numpy.ma.core.MaskedArray.sum and is falling back to canonical NumPy. You may notice significantly decreased performance for this function call.
  warnings.warn(
5

```
and now calls hows up in coverage reporting as well
```
old311 ❯ CUNUMERIC_REPORT_COVERAGE=1 CUNUMERIC_REPORT_DUMP_CSV="out.csv" legate ~/tmp/cov.py
cuNumeric API coverage: 0/1 (0.0%)

~/work/cunumeric bv/ma*

old311 ❯ cat out.csv 
function_name,location,implemented
numpy.ma.array,/home/bryan/work/legate.core/_skbuild/linux-x86_64-3.11/cmake-build/_deps/legion-src/bindings/python/build/lib/legion_top.py:295,False

```