### PR TITLE
Don't instantiate template for low DIM counts, to fix a warning

### DIFF
--- a/src/cunumeric/matrix/batched_cholesky_template.inl
+++ b/src/cunumeric/matrix/batched_cholesky_template.inl
@@ -57,7 +57,7 @@ struct _cholesky_supported {
 
 template <VariantKind KIND>
 struct BatchedCholeskyImpl {
-  template <Type::Code CODE, int DIM>
+  template <Type::Code CODE, int32_t DIM, std::enable_if_t<2 < DIM>* = nullptr>
   void operator()(Array& input_array, Array& output_array) const
   {
     using VAL = legate_type_of<CODE>;
@@ -94,8 +94,8 @@ struct BatchedCholeskyImpl {
 
     if (shape.empty()) return;
 
-    int num_blocks = 1;
-    for (int i = 0; i < (DIM - 2); ++i) { num_blocks *= (shape.hi[i] - shape.lo[i] + 1); }
+    int32_t num_blocks = 1;
+    for (int32_t i = 0; i < (DIM - 2); ++i) { num_blocks *= (shape.hi[i] - shape.lo[i] + 1); }
 
     auto m = static_cast<int32_t>(shape.hi[DIM - 2] - shape.lo[DIM - 2] + 1);
     auto n = static_cast<int32_t>(shape.hi[DIM - 1] - shape.lo[DIM - 1] + 1);
@@ -103,7 +103,7 @@ struct BatchedCholeskyImpl {
 
     auto block_stride = m * n;
 
-    for (int i = 0; i < num_blocks; ++i) {
+    for (int32_t i = 0; i < num_blocks; ++i) {
       if constexpr (_cholesky_supported<CODE>::value) {
         CopyBlockImpl<KIND>()(output, input, sizeof(VAL) * block_stride);
         PotrfImplBody<KIND, CODE>()(output, m, n);
@@ -118,6 +118,12 @@ struct BatchedCholeskyImpl {
         output += block_stride;
       }
     }
+  }
+
+  template <Type::Code CODE, int32_t DIM, std::enable_if_t<DIM <= 2>* = nullptr>
+  void operator()(Array& input_array, Array& output_array) const
+  {
+    assert(false);
   }
 };
 

--- a/src/cunumeric/matrix/batched_cholesky_template.inl
+++ b/src/cunumeric/matrix/batched_cholesky_template.inl
@@ -57,7 +57,7 @@ struct _cholesky_supported {
 
 template <VariantKind KIND>
 struct BatchedCholeskyImpl {
-  template <Type::Code CODE, int32_t DIM, std::enable_if_t<2 < DIM>* = nullptr>
+  template <Type::Code CODE, int32_t DIM, std::enable_if_t<(DIM > 2)>* = nullptr>
   void operator()(Array& input_array, Array& output_array) const
   {
     using VAL = legate_type_of<CODE>;


### PR DESCRIPTION
The warning was

```
    In file included from /Users/mpapadakis/cunumeric/src/cunumeric/matrix/batched_cholesky.cc:19:
    /Users/mpapadakis/cunumeric/src/cunumeric/matrix/batched_cholesky_template.inl:82:9: warning: array index -1 is before the beginning of the array [-Warray-bounds]
        if (in_strides[DIM - 2] != ncols || in_strides[DIM - 1] != 1) {
            ^          ~~~~~~~
    /Users/mpapadakis/legate.core/src/core/utilities/dispatch.h:34:27: note: in instantiation of function template specialization 'cunumeric::BatchedCholeskyImpl<cunumeric::VariantKind::CPU>::operator()<legate::Type::Code::BOOL, 1>' requested here
            return f.template operator()<Type::Code::BOOL, DIM>(std::forward<Fnargs>(args)...);
                              ^
    /Users/mpapadakis/cunumeric/src/cunumeric/matrix/batched_cholesky.cc:74:3: note: in instantiation of function template specialization 'cunumeric::batched_cholesky_task_context_dispatch<cunumeric::VariantKind::CPU>' requested here
      batched_cholesky_task_context_dispatch<VariantKind::CPU>(context);
      ^
    /Users/mpapadakis/cunumeric/src/cunumeric/matrix/batched_cholesky_template.inl:78:5: note: array 'in_strides' declared here
        size_t in_strides[DIM];
        ^
    /Users/mpapadakis/cunumeric/src/cunumeric/matrix/batched_cholesky_template.inl:89:9: warning: array index -1 is before the beginning of the array [-Warray-bounds]
        if (out_strides[DIM - 2] != ncols || out_strides[DIM - 1] != 1) {
            ^           ~~~~~~~
    /Users/mpapadakis/cunumeric/src/cunumeric/matrix/batched_cholesky_template.inl:79:5: note: array 'out_strides' declared here
        size_t out_strides[DIM];
        ^
```