### PR TITLE
Update dependencies in meta.yaml

### DIFF
--- a/.github/actions/download-artifacts/action.yml
+++ b/.github/actions/download-artifacts/action.yml
@@ -25,7 +25,7 @@ runs:
         repo: nv-legate/legate.core
         commit: ${{ inputs.git_sha }}
         workflow_conclusion: success
-        workflow: "ci-gh-${{ inputs.device }}-build-and-test.yml"
+        workflow: "ci-gh.yml"
         name: "legate.core-${{ inputs.device }}-[0-9a-z]{40}"
         name_is_regexp: true
 

--- a/conda/conda-build/meta.yaml
+++ b/conda/conda-build/meta.yaml
@@ -116,11 +116,12 @@ requirements:
     - cuda-nvcc ={{ cuda_version }}
     - cuda-cccl ={{ cuda_version }}
     - cuda-cudart ={{ cuda_version }}
+    - cuda-cudart-static ={{ cuda_version }}
     - cuda-driver-dev ={{ cuda_version }}
     - cuda-cudart-dev ={{ cuda_version }}
     - cuda-nvtx ={{ cuda_version }}
     # - libcutensor-dev >=1.3
-    - cutensor >=1.3 =*_*
+    - cutensor >=1.3,<2.0 =*_*
     - libcublas-dev
     - libcusolver-dev
     - libcufft-dev
@@ -140,6 +141,8 @@ requirements:
     - libcublas
     - libcusolver >=11.4.1.48-0
     - libcufft
+    - libnvjitlink
+    - libcusparse
 {% endif %}
     - opt_einsum >=3.3
     - scipy


### PR DESCRIPTION
- Constrain cutensor to avoid the new version 2 of cutensor with a changed interface
- add depencies necessary for successful build in newer versions of conda