### PR TITLE
Update version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,7 @@ include(rapids-cuda)
 include(rapids-export)
 include(rapids-find)
 
-set(cunumeric_version 23.11.00)
+set(cunumeric_version 24.01.00)
 
 # For now we want the optimization flags to match on both normal make and cmake
 # builds so we override the cmake defaults here for release, this changes

--- a/cmake/versions.json
+++ b/cmake/versions.json
@@ -5,7 +5,7 @@
       "git_url" : "https://github.com/nv-legate/legate.core.git",
       "git_shallow": false,
       "always_download": false,
-      "git_tag" : "200e09c7ab85969c80d492ed94c0b7ea9f20f91a"
+      "git_tag" : "08da13fc544f3db26bf1ef7ce9bdb85e72a9d9fb"
     }
   }
 }

--- a/cmake/versions.json
+++ b/cmake/versions.json
@@ -1,11 +1,11 @@
 {
   "packages" : {
     "legate_core" : {
-      "version": "23.11.00",
+      "version": "24.01.00",
       "git_url" : "https://github.com/nv-legate/legate.core.git",
       "git_shallow": false,
       "always_download": false,
-      "git_tag" : "c05ebdab30dee6ac2d6e2808fb835fad0302822d"
+      "git_tag" : "d8d087580bba50710c1ac5c420bd6f07b5adcd22"
     }
   }
 }

--- a/cmake/versions.json
+++ b/cmake/versions.json
@@ -5,7 +5,7 @@
       "git_url" : "https://github.com/nv-legate/legate.core.git",
       "git_shallow": false,
       "always_download": false,
-      "git_tag" : "d8d087580bba50710c1ac5c420bd6f07b5adcd22"
+      "git_tag" : "200e09c7ab85969c80d492ed94c0b7ea9f20f91a"
     }
   }
 }


### PR DESCRIPTION
Tested alongside with nv-legate/legate.core/pull/901. After 901 is merged, the legate.core hash should be updated.