### PR TITLE
Adding logical_and.reduce() functionality

### DIFF
--- a/cunumeric/_ufunc/comparison.py
+++ b/cunumeric/_ufunc/comparison.py
@@ -73,6 +73,7 @@ logical_and = create_binary_ufunc(
     "logical_and",
     BinaryOpCode.LOGICAL_AND,
     relation_types_of(all_dtypes),
+    red_code=UnaryRedCode.PROD,
 )
 
 logical_or = create_binary_ufunc(

--- a/cunumeric/_ufunc/ufunc.py
+++ b/cunumeric/_ufunc/ufunc.py
@@ -748,6 +748,9 @@ class binary_ufunc(ufunc):
         --------
         numpy.ufunc.reduce
         """
+        if self._op_code in [BinaryOpCode.LOGICAL_AND, BinaryOpCode.LOGICAL_OR, BinaryOpCode.LOGICAL_XOR]:
+            array = array._astype(bool, temporary=True)
+
         if self._red_code is None:
             raise NotImplementedError(
                 f"reduction for {self} is not yet implemented"


### PR DESCRIPTION
By adding converting inputs to booleans, we can leverage existing reduction codes and Legion automatically uses an and for boolean product reductions.
Signed-off-by: Joseph Guman <joeytg@stanford.edu>