### PR TITLE
specify min conda version

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ If you have questions, please contact us at legate(at)nvidia.com.
 ## Installation
 
 cuNumeric is available from [conda](https://docs.conda.io/projects/conda/en/latest/index.html)
-on the [legate channel](https://anaconda.org/legate/legate-core).
+on the [legate channel](https://anaconda.org/legate/cunumeric).
 Please make sure you have at least conda version 24.1 installed, then create
 a new environment containing cuNumeric:
 
@@ -52,8 +52,8 @@ or install it into an existing environment:
 conda install -c nvidia -c conda-forge -c legate cunumeric
 ```
 
-Once installed, you can verify intallation by running one of the examples
-from the cunumeric repository, for instance
+Once installed, you can verify the installation by running one of the examples
+from the cuNumeric repository, for instance:
 
 ```
 $ legate examples/black_scholes.py

--- a/README.md
+++ b/README.md
@@ -37,17 +37,28 @@ If you have questions, please contact us at legate(at)nvidia.com.
 
 ## Installation
 
-cuNumeric is available [on conda](https://anaconda.org/legate/cunumeric).
-Create a new environment containing cuNumeric:
+cuNumeric is available from [conda](https://docs.conda.io/projects/conda/en/latest/index.html)
+on the [legate channel](https://anaconda.org/legate/legate-core).
+Please make sure you have at least conda version 24.1 installed, then create
+a new environment containing cuNumeric:
 
 ```
-mamba create -n myenv -c nvidia -c conda-forge -c legate cunumeric
+conda create -n myenv -c nvidia -c conda-forge -c legate cunumeric
 ```
 
 or install it into an existing environment:
 
 ```
-mamba install -c nvidia -c conda-forge -c legate cunumeric
+conda install -c nvidia -c conda-forge -c legate cunumeric
+```
+
+Once installed, you can verify intallation by running one of the examples
+from the cunumeric repository, for instance
+
+```
+$ legate examples/black_scholes.py
+Running black scholes on 10K options...
+Elapsed Time: 129.017 ms
 ```
 
 Only linux-64 packages are available at the moment.
@@ -59,7 +70,7 @@ installing on a machine without GPUs. You can force installation of a CPU-only
 package by requesting it as follows:
 
 ```
-mamba ... cunumeric=*=*_cpu
+conda ... cunumeric=*=*_cpu
 ```
 
 See the build instructions at https://nv-legate.github.io/cunumeric for details

--- a/docs/cunumeric/source/user/installation.rst
+++ b/docs/cunumeric/source/user/installation.rst
@@ -3,7 +3,7 @@ Installation
 
 Linux-64 packages for cuNumeric are available from
 `conda <https://docs.conda.io/projects/conda/en/latest/index.html>`_
-on the `legate channel <https://anaconda.org/legate/legate-core>`_.
+on the `legate channel <https://anaconda.org/legate/cunumeric>`_.
 Please make sure you have at least conda version 24.1 installed, then create
 a new environment containing cuNumeric:
 
@@ -11,8 +11,8 @@ a new environment containing cuNumeric:
 
   conda install -c nvidia -c conda-forge -c legate cunumeric
 
-Once installed, you can verify intallation by running one of the examples
-from the cunumeric repository, for instance
+Once installed, you can verify the installation by running one of the examples
+from the cuNumeric repository, for instance:
 
 .. code-block:: sh
 

--- a/docs/cunumeric/source/user/installation.rst
+++ b/docs/cunumeric/source/user/installation.rst
@@ -1,11 +1,24 @@
 Installation
 ============
 
-cuNumeric is available `from conda`_:
+Linux-64 packages for cuNumeric are available from
+`conda <https://docs.conda.io/projects/conda/en/latest/index.html>`_
+on the `legate channel <https://anaconda.org/legate/legate-core>`_.
+Please make sure you have at least conda version 24.1 installed, then create
+a new environment containing cuNumeric:
 
 .. code-block:: sh
 
   conda install -c nvidia -c conda-forge -c legate cunumeric
+
+Once installed, you can verify intallation by running one of the examples
+from the cunumeric repository, for instance
+
+.. code-block:: sh
+
+    $ legate examples/black_scholes.py
+    Running black scholes on 10K options...
+    Elapsed Time: 129.017 ms
 
 Only linux-64 packages are available at the moment.
 
@@ -13,6 +26,12 @@ The default package contains GPU support, and is compatible with CUDA >= 11.4
 (CUDA driver version >= r470), and Volta or later GPU architectures. There are
 also CPU-only packages available, and will be automatically selected by
 ``conda`` when installing on a machine without GPUs.
+
+You can force installation of a CPU-only package by requesting it as follows:
+
+.. code-block:: sh
+
+    conda ... cunumeric=*=*_cpu
 
 See :ref:`building cunumeric from source` for instructions on building cuNumeric manually.
 


### PR DESCRIPTION
This PR adds a link to the conda docs and also specifies a min conda version to use to ensure that the latest legate versions are properly picked up, and also adds some example output from running an example to verify install.