### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Code Ownership
+/.github/                  @marcinz @m3vaz @sandeepd-nv @mag1cp1n
+/continuous_integration    @marcinz @m3vaz @sandeepd-nv @mag1cp1n 
+/conda                     @marcinz @m3vaz @sandeepd-nv @mag1cp1n
+

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Code Ownership
-/.github/                  @marcinz @m3vaz @sandeepd-nv @mag1cp1n
+/.github                   @marcinz @m3vaz @sandeepd-nv @mag1cp1n
 /continuous_integration    @marcinz @m3vaz @sandeepd-nv @mag1cp1n 
 /conda                     @marcinz @m3vaz @sandeepd-nv @mag1cp1n
 


### PR DESCRIPTION
Add CODEOWNERS file to include  .github/, conda/ and continuous_integration/ paths.